### PR TITLE
1.2.0 — patch UABB Advanced Posts featured image loop bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.2.0] - 2026-05-02
+### Fixed
+- UABB Advanced Posts module — all posts showing the same featured image when using a Custom Post Layout with `[fl_builder_insert_layout]`. Beaver Builder's field connection cache was using an identical key for every post in the loop because `FLThemeBuilderFieldConnections::$in_post_grid_loop` was never set. The patch toggles that flag around each post render via the existing `uabb_blog_posts_before_post` / `uabb_blog_posts_after_post` hooks.
+
 ## [1.1.0] - 2026-04-08
 ### Fixed
 - `.top-social > div` — added `float: right !important` to right-align the social icon container

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.1.0
+ * Version:           1.2.0
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.1.0' );
+define( 'DS_TOOLKIT_VERSION', '1.2.0' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-uabb-post-loop-fix.php
+++ b/features/class-ds-uabb-post-loop-fix.php
@@ -1,0 +1,37 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Fixes UABB Advanced Posts module showing the same featured image
+ * for all posts when using a Custom/Beaver Builder post layout.
+ *
+ * Root cause: Beaver Builder's field connection cache keys all resolve to
+ * `{node_id}_{page_post_id}` unless FLThemeBuilderFieldConnections::$in_post_grid_loop
+ * is true, which makes each key unique per loop post (`{node_id}_{loop_post_id}`).
+ * BB's own Post Grid module fires fl_builder_posts_module_before/after_posts to toggle
+ * this flag. UABB never fires those actions, so the cache hits on the first post's
+ * resolved featured image for every subsequent post.
+ *
+ * Fix: use UABB's own before/after hooks to toggle the flag around each post render.
+ */
+class DS_UABB_Post_Loop_Fix {
+
+    public function __construct( $settings = array() ) {}
+
+    public function init() {
+        add_action( 'uabb_blog_posts_before_post', array( $this, 'enter_post_loop' ), 1 );
+        add_action( 'uabb_blog_posts_after_post',  array( $this, 'leave_post_loop' ), 1 );
+    }
+
+    public function enter_post_loop() {
+        if ( class_exists( 'FLThemeBuilderFieldConnections' ) ) {
+            FLThemeBuilderFieldConnections::$in_post_grid_loop = true;
+        }
+    }
+
+    public function leave_post_loop() {
+        if ( class_exists( 'FLThemeBuilderFieldConnections' ) ) {
+            FLThemeBuilderFieldConnections::$in_post_grid_loop = false;
+        }
+    }
+}

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -47,6 +47,10 @@ class DS_Toolkit {
             'file'  => 'features/class-ds-child-pages.php',
             'class' => 'DS_Child_Pages',
         ),
+        'uabb_post_loop_fix_enabled' => array(
+            'file'  => 'features/class-ds-uabb-post-loop-fix.php',
+            'class' => 'DS_UABB_Post_Loop_Fix',
+        ),
     );
 
     public static function activate() {
@@ -85,6 +89,7 @@ class DS_Toolkit {
             'child_pages_columns'                => 3,
             'child_pages_columns_tablet'         => 2,
             'child_pages_columns_mobile'         => 1,
+            'uabb_post_loop_fix_enabled'         => 1,
             // MCP tool group access controls (all enabled by default)
             'mcp_posts_pages_enabled'            => 1,
             'mcp_cpt_enabled'                    => 1,


### PR DESCRIPTION
## Summary
- Fixes UABB Advanced Posts showing the same featured image for all posts with Custom Post Layout + `fl_builder_insert_layout`
- Root cause: `FLThemeBuilderFieldConnections::$in_post_grid_loop` never set during UABB loop — all posts share the same field connection cache key, returning the first post's image for every iteration
- Patch toggles the flag via `uabb_blog_posts_before_post` / `uabb_blog_posts_after_post` hooks — no UABB or Beaver Builder files modified

## Test plan
- [ ] 2+ posts with different featured images
- [ ] UABB Advanced Posts module with Post Layout → Custom, pointing to a BB template with a Featured Image field connection
- [ ] Each post should now show its own featured image
- [ ] Non-custom layouts unaffected
