### PR TITLE
1.2.1 — UABB loop fix guards flag ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.2.1] - 2026-05-02
+### Fixed
+- UABB post loop fix — patch now tracks flag ownership so it only resets `$in_post_grid_loop` if it was the one that set it. Prevents conflict if UABB ships their own fix that sets the flag at the loop level.
+
 ## [1.2.0] - 2026-05-02
 ### Fixed
 - UABB Advanced Posts module — all posts showing the same featured image when using a Custom Post Layout with `[fl_builder_insert_layout]`. Beaver Builder's field connection cache was using an identical key for every post in the loop because `FLThemeBuilderFieldConnections::$in_post_grid_loop` was never set. The patch toggles that flag around each post render via the existing `uabb_blog_posts_before_post` / `uabb_blog_posts_after_post` hooks.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.2.0
+ * Version:           1.2.1
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.2.0' );
+define( 'DS_TOOLKIT_VERSION', '1.2.1' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-uabb-post-loop-fix.php
+++ b/features/class-ds-uabb-post-loop-fix.php
@@ -13,8 +13,12 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  * resolved featured image for every subsequent post.
  *
  * Fix: use UABB's own before/after hooks to toggle the flag around each post render.
+ * We only reset the flag if we were the ones who set it, so a future UABB fix that
+ * sets the flag at the loop level won't conflict with our per-post reset.
  */
 class DS_UABB_Post_Loop_Fix {
+
+    private $flag_owner = false;
 
     public function __construct( $settings = array() ) {}
 
@@ -24,14 +28,17 @@ class DS_UABB_Post_Loop_Fix {
     }
 
     public function enter_post_loop() {
-        if ( class_exists( 'FLThemeBuilderFieldConnections' ) ) {
+        if ( class_exists( 'FLThemeBuilderFieldConnections' )
+            && ! FLThemeBuilderFieldConnections::$in_post_grid_loop ) {
             FLThemeBuilderFieldConnections::$in_post_grid_loop = true;
+            $this->flag_owner = true;
         }
     }
 
     public function leave_post_loop() {
-        if ( class_exists( 'FLThemeBuilderFieldConnections' ) ) {
+        if ( $this->flag_owner ) {
             FLThemeBuilderFieldConnections::$in_post_grid_loop = false;
+            $this->flag_owner = false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Refines the 1.2.0 UABB featured image patch to track flag ownership
- We now only reset `FLThemeBuilderFieldConnections::$in_post_grid_loop` if **we** were the ones who set it
- Prevents a conflict if UABB ships their own fix that sets the flag at the loop level — without this, our per-post reset would turn it off too early and re-introduce the bug

## Test plan
- [ ] Same as 1.2.0 — each post shows its own featured image in the UABB Advanced Posts carousel with Custom layout
- [ ] No regression on non-custom layouts
