### PR TITLE
1.2.2 — fatal-error hotfix + saving + defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.2.2] - 2026-05-05
+### Fixed
+- **Fatal error** "Cannot access offset of type string on string" in `class-ds-toolkit.php` when saving the MCP tab with every checkbox unchecked. The empty POST caused WP to write the option as an empty string; `maybe_set_defaults()` then tried to index into a string and white-screened the site. Now both `maybe_set_defaults()` and `run()` coerce a non-array option back to `array()`, so a corrupted value self-heals on the next request.
+- **Toggles wouldn't turn off** on the Features and MCP tabs. Unchecked checkboxes don't POST anything, so the missing key was refilled from defaults on the next load and the toggle silently re-enabled itself. Each toggle now has a hidden `value="0"` input so the off state is explicitly submitted (mirrors the trick already used on Global CSS / Global JS).
+- **Saving one tab wiped the others.** `register_setting()` had no sanitize callback, so each form's POST replaced the entire option array. Backported the merge sanitize callback (LA branch `c087a19`) so each tab only updates the keys it owns.
+
+### Changed
+- **Fresh-install defaults**: only **LeagueApps Custom Login** and **Hide Beaver Builder Cloud Icon for Non-LeagueApps Users** are on by default. Global CSS, Global JS, ACF CSS Vars, `[getsubmenu]`, `[current_year]`, Forminator `{email_partner}`, `[child_pages]`, the UABB post-loop fix, and every MCP tool group now default to **off**. Existing installs keep their current settings — only newly seeded keys pick up the new defaults.
+
 ## [1.2.1] - 2026-05-02
 ### Fixed
 - UABB post loop fix — patch now tracks flag ownership so it only resets `$in_post_grid_loop` if it was the one that set it. Prevents conflict if UABB ships their own fix that sets the flag at the loop level.

--- a/admin/class-ds-toolkit-admin.php
+++ b/admin/class-ds-toolkit-admin.php
@@ -40,7 +40,32 @@ class DS_Toolkit_Admin {
     }
 
     public function register_settings() {
-        register_setting( 'ds_toolkit_options', 'ds_toolkit_settings' );
+        register_setting( 'ds_toolkit_options', 'ds_toolkit_settings', array(
+            'sanitize_callback' => array( $this, 'merge_with_existing_settings' ),
+        ) );
+    }
+
+    /**
+     * WP's Settings API replaces the entire option on save. Each tab's form
+     * only POSTs ITS fields, so without merging, saving one tab wipes every
+     * other tab's keys (Features wipes MCP toggles, MCP wipes Features, etc.).
+     * Always merge incoming form values on top of the existing option so
+     * unrelated keys survive.
+     *
+     * Also defends against the fatal-error case: when every checkbox in a
+     * form is unchecked, $_POST['ds_toolkit_settings'] can come through as
+     * a non-array (null/empty string), which would otherwise be saved as ''
+     * and crash maybe_set_defaults() on the next page load.
+     */
+    public function merge_with_existing_settings( $new ) {
+        $existing = get_option( 'ds_toolkit_settings', array() );
+        if ( ! is_array( $existing ) ) {
+            $existing = array();
+        }
+        if ( ! is_array( $new ) ) {
+            return $existing;
+        }
+        return array_merge( $existing, $new );
     }
 
     public function enqueue_scripts( $hook ) {

--- a/admin/views/page-mcp.php
+++ b/admin/views/page-mcp.php
@@ -44,6 +44,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Allow Claude to list, read, create, edit, and delete standard WordPress posts and pages.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[mcp_posts_pages_enabled]" value="0">
                 <input type="checkbox" id="mcp_posts_pages_enabled" name="ds_toolkit_settings[mcp_posts_pages_enabled]" value="1" <?php checked( $mcp_posts_pages_enabled ); ?>>
                 <label for="mcp_posts_pages_enabled"></label>
             </div>
@@ -56,6 +57,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Allow Claude to access CPTs — Events, Athletes, Staff, Teams, and any future custom post types registered on this site.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[mcp_cpt_enabled]" value="0">
                 <input type="checkbox" id="mcp_cpt_enabled" name="ds_toolkit_settings[mcp_cpt_enabled]" value="1" <?php checked( $mcp_cpt_enabled ); ?>>
                 <label for="mcp_cpt_enabled"></label>
             </div>
@@ -68,6 +70,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Allow Claude to list, create, edit, and delete taxonomy terms — Athlete Categories, Staff Categories, Team Categories, and any other taxonomies.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[mcp_taxonomies_enabled]" value="0">
                 <input type="checkbox" id="mcp_taxonomies_enabled" name="ds_toolkit_settings[mcp_taxonomies_enabled]" value="1" <?php checked( $mcp_taxonomies_enabled ); ?>>
                 <label for="mcp_taxonomies_enabled"></label>
             </div>
@@ -80,6 +83,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Allow Claude to read and update ACF field values on posts and CPT entries. Uses ACF's <code>get_fields()</code> / <code>update_field()</code> if ACF is active.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[mcp_acf_enabled]" value="0">
                 <input type="checkbox" id="mcp_acf_enabled" name="ds_toolkit_settings[mcp_acf_enabled]" value="1" <?php checked( $mcp_acf_enabled ); ?>>
                 <label for="mcp_acf_enabled"></label>
             </div>
@@ -92,6 +96,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Allow Claude to read and update DS Toolkit feature settings — toggles, column counts, Global CSS/JS, template IDs, etc.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[mcp_toolkit_settings_enabled]" value="0">
                 <input type="checkbox" id="mcp_toolkit_settings_enabled" name="ds_toolkit_settings[mcp_toolkit_settings_enabled]" value="1" <?php checked( $mcp_toolkit_settings_enabled ); ?>>
                 <label for="mcp_toolkit_settings_enabled"></label>
             </div>
@@ -104,6 +109,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Allow Claude to read and update Beaver Builder Global Style colors — Primary, Accent, Headings, Body, and all other named colors.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[mcp_bb_enabled]" value="0">
                 <input type="checkbox" id="mcp_bb_enabled" name="ds_toolkit_settings[mcp_bb_enabled]" value="1" <?php checked( $mcp_bb_enabled ); ?>>
                 <label for="mcp_bb_enabled"></label>
             </div>
@@ -116,6 +122,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Allow Claude to create, update, and delete ACF Post Types and Taxonomies. <strong>Restricted to @leagueapps.com accounts only</strong> — even if enabled, non-LeagueApps users cannot use these tools.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[mcp_acf_schema_enabled]" value="0">
                 <input type="checkbox" id="mcp_acf_schema_enabled" name="ds_toolkit_settings[mcp_acf_schema_enabled]" value="1" <?php checked( $mcp_acf_schema_enabled ); ?>>
                 <label for="mcp_acf_schema_enabled"></label>
             </div>
@@ -128,6 +135,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Allow Claude to list menus, read menu structure, replace all menu items, and assign menus to theme locations.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[mcp_menus_enabled]" value="0">
                 <input type="checkbox" id="mcp_menus_enabled" name="ds_toolkit_settings[mcp_menus_enabled]" value="1" <?php checked( $mcp_menus_enabled ); ?>>
                 <label for="mcp_menus_enabled"></label>
             </div>
@@ -140,6 +148,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Allow Claude to flush rewrite rules, flush object cache, delete transients, and run search &amp; replace on the database. <strong>search_replace restricted to @leagueapps.com accounts.</strong></span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[mcp_maintenance_enabled]" value="0">
                 <input type="checkbox" id="mcp_maintenance_enabled" name="ds_toolkit_settings[mcp_maintenance_enabled]" value="1" <?php checked( $mcp_maintenance_enabled ); ?>>
                 <label for="mcp_maintenance_enabled"></label>
             </div>
@@ -152,6 +161,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Allow Claude to read and write WordPress options (wp_options). <strong>Restricted to @leagueapps.com accounts only.</strong></span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[mcp_options_enabled]" value="0">
                 <input type="checkbox" id="mcp_options_enabled" name="ds_toolkit_settings[mcp_options_enabled]" value="1" <?php checked( $mcp_options_enabled ); ?>>
                 <label for="mcp_options_enabled"></label>
             </div>
@@ -164,6 +174,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Allow Claude to list and read WordPress users and regenerate image thumbnails.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[mcp_users_enabled]" value="0">
                 <input type="checkbox" id="mcp_users_enabled" name="ds_toolkit_settings[mcp_users_enabled]" value="1" <?php checked( $mcp_users_enabled ); ?>>
                 <label for="mcp_users_enabled"></label>
             </div>

--- a/admin/views/page-settings.php
+++ b/admin/views/page-settings.php
@@ -24,6 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Custom logo, "Powered by LeagueApps Design Shop" branding, and support link on the WP login page.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[enable_login_branding]" value="0">
                 <input type="checkbox" id="enable_login_branding" name="ds_toolkit_settings[enable_login_branding]" value="1" <?php checked( $enabled ); ?>>
                 <label for="enable_login_branding"></label>
             </div>
@@ -57,6 +58,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Hides the FL Assistant cloud button in the Beaver Builder toolbar for all users except @leagueapps.com accounts.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[hide_fl_assistant]" value="0">
                 <input type="checkbox" id="hide_fl_assistant" name="ds_toolkit_settings[hide_fl_assistant]" value="1" <?php checked( $hide_fl_assistant ); ?>>
                 <label for="hide_fl_assistant"></label>
             </div>
@@ -72,6 +74,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Map ACF option fields to CSS custom properties output in <code>:root</code> on every page.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[acf_css_vars_enabled]" value="0">
                 <input type="checkbox" id="acf_css_vars_enabled" name="ds_toolkit_settings[acf_css_vars_enabled]" value="1" <?php checked( $acf_css_vars_enabled ); ?>>
                 <label for="acf_css_vars_enabled"></label>
             </div>
@@ -113,6 +116,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Adds a shortcode that displays the child pages of any page as a navigation list.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[getsubmenu_enabled]" value="0">
                 <input type="checkbox" id="getsubmenu_enabled" name="ds_toolkit_settings[getsubmenu_enabled]" value="1" <?php checked( $getsubmenu_enabled ); ?>>
                 <label for="getsubmenu_enabled"></label>
             </div>
@@ -141,6 +145,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Outputs the current year automatically. Great for copyright notices in footers.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[current_year_enabled]" value="0">
                 <input type="checkbox" id="current_year_enabled" name="ds_toolkit_settings[current_year_enabled]" value="1" <?php checked( $current_year_enabled ); ?>>
                 <label for="current_year_enabled"></label>
             </div>
@@ -166,6 +171,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Adds a custom <code>{email_partner}</code> variable to Forminator forms, pulled from the ACF options field <code>partner_email</code>.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[forminator_email_partner_enabled]" value="0">
                 <input type="checkbox" id="forminator_email_partner_enabled" name="ds_toolkit_settings[forminator_email_partner_enabled]" value="1" <?php checked( $forminator_email_partner_enabled ); ?>>
                 <label for="forminator_email_partner_enabled"></label>
             </div>
@@ -193,6 +199,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <span>Outputs a responsive grid of child page cards using a Beaver Builder template. Also registers <code>[get_parent_page_title]</code> for use inside the card template.</span>
             </div>
             <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[child_pages_enabled]" value="0">
                 <input type="checkbox" id="child_pages_enabled" name="ds_toolkit_settings[child_pages_enabled]" value="1" <?php checked( $child_pages_enabled ); ?>>
                 <label for="child_pages_enabled"></label>
             </div>

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.2.1
+ * Version:           1.2.2
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.2.1' );
+define( 'DS_TOOLKIT_VERSION', '1.2.2' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -66,10 +66,13 @@ class DS_Toolkit {
     }
 
     private static function get_defaults() {
+        // On fresh install only the core LeagueApps-branding features are on.
+        // Everything else is opt-in so a new site doesn't get unexpected CSS/JS,
+        // shortcodes, or MCP tools the moment the plugin is activated.
         return array(
             'enable_login_branding' => 1,
             'hide_fl_assistant'     => 1,
-            'acf_css_vars_enabled'  => 1,
+            'acf_css_vars_enabled'  => 0,
             'acf_css_vars_mappings' => array(
                 array(
                     'acf_field' => 'header_scrolled_bar_color',
@@ -77,31 +80,31 @@ class DS_Toolkit {
                     'fallback'  => 'var(--fl-global-accent)',
                 ),
             ),
-            'getsubmenu_enabled'                  => 1,
-            'current_year_enabled'               => 1,
-            'forminator_email_partner_enabled'   => 1,
+            'getsubmenu_enabled'                  => 0,
+            'current_year_enabled'               => 0,
+            'forminator_email_partner_enabled'   => 0,
             'forminator_email_partner_fallback'  => 'designshop' . DS_TOOLKIT_ADMIN_DOMAIN,
-            'global_css_enabled'                 => 1,
+            'global_css_enabled'                 => 0,
             'global_css_overrides'               => '',
-            'global_js_enabled'                  => 1,
-            'child_pages_enabled'                => 1,
+            'global_js_enabled'                  => 0,
+            'child_pages_enabled'                => 0,
             'child_pages_template_id'            => '56369',
             'child_pages_columns'                => 3,
             'child_pages_columns_tablet'         => 2,
             'child_pages_columns_mobile'         => 1,
-            'uabb_post_loop_fix_enabled'         => 1,
-            // MCP tool group access controls (all enabled by default)
-            'mcp_posts_pages_enabled'            => 1,
-            'mcp_cpt_enabled'                    => 1,
-            'mcp_taxonomies_enabled'             => 1,
-            'mcp_acf_enabled'                    => 1,
-            'mcp_toolkit_settings_enabled'       => 1,
-            'mcp_bb_enabled'                     => 1,
-            'mcp_acf_schema_enabled'             => 1,
-            'mcp_menus_enabled'                  => 1,
-            'mcp_maintenance_enabled'            => 1,
-            'mcp_options_enabled'                => 1,
-            'mcp_users_enabled'                  => 1,
+            'uabb_post_loop_fix_enabled'         => 0,
+            // MCP tool group access controls — off by default
+            'mcp_posts_pages_enabled'            => 0,
+            'mcp_cpt_enabled'                    => 0,
+            'mcp_taxonomies_enabled'             => 0,
+            'mcp_acf_enabled'                    => 0,
+            'mcp_toolkit_settings_enabled'       => 0,
+            'mcp_bb_enabled'                     => 0,
+            'mcp_acf_schema_enabled'             => 0,
+            'mcp_menus_enabled'                  => 0,
+            'mcp_maintenance_enabled'            => 0,
+            'mcp_options_enabled'                => 0,
+            'mcp_users_enabled'                  => 0,
         );
     }
 
@@ -111,8 +114,16 @@ class DS_Toolkit {
      */
     private function maybe_set_defaults() {
         $settings = get_option( 'ds_toolkit_settings', array() );
-        $changed  = false;
 
+        // Recover from a corrupted option value (e.g. a save that wrote an
+        // empty string instead of an array). Without this guard, the foreach
+        // below throws "Cannot access offset of type string on string" and
+        // takes the whole site down.
+        if ( ! is_array( $settings ) ) {
+            $settings = array();
+        }
+
+        $changed = false;
         foreach ( self::get_defaults() as $key => $value ) {
             if ( ! isset( $settings[ $key ] ) ) {
                 $settings[ $key ] = $value;
@@ -144,6 +155,9 @@ class DS_Toolkit {
         }
 
         $settings = get_option( 'ds_toolkit_settings', array() );
+        if ( ! is_array( $settings ) ) {
+            $settings = array();
+        }
 
         foreach ( $this->features as $key => $feature ) {
             if ( ! empty( $settings[ $key ] ) ) {


### PR DESCRIPTION
## Summary
Three related bugs surfaced together; ships as a single hotfix on top of 1.2.1.

- **Fatal error** "Cannot access offset of type string on string" in `class-ds-toolkit.php` when saving the MCP tab with every checkbox unchecked — empty POST → option saved as `''` → `maybe_set_defaults()` indexes a string → white screen. Both `maybe_set_defaults()` and `run()` now coerce a non-array option back to `array()`, so a corrupted value self-heals on the next request.
- **Toggles wouldn't turn off** on the Features and MCP tabs. Unchecked checkboxes don't POST anything, so the missing key was refilled from defaults on the next load and the toggle silently re-enabled itself. Added a hidden `value="0"` input before every toggle (mirrors the trick already used on Global CSS / Global JS).
- **Saving one tab wiped the others.** `register_setting()` had no sanitize callback, so each form's POST replaced the entire option. Backported the `merge_with_existing_settings` callback from the LA branch (commit c087a19) so each tab only updates the keys it owns.

Also changed `get_defaults()` so a fresh install only enables **LeagueApps Custom Login** and **Hide Beaver Builder Cloud Icon for Non-LeagueApps Users**. Global CSS, Global JS, ACF CSS Vars, `[getsubmenu]`, `[current_year]`, Forminator `{email_partner}`, `[child_pages]`, the UABB post-loop fix, and every MCP tool group now default to off — partners opt in per-site. Existing installs are unchanged (defaults only fill missing keys).

## Test plan
- [ ] On a site already broken by the fatal: update to 1.2.2 → admin loads without WSOD; `ds_toolkit_settings` is restored to a valid array.
- [ ] On the MCP tab: uncheck every toggle → Save → no fatal, page reloads cleanly, toggles stay unchecked.
- [ ] On the Features tab: turn off any toggle → Save → toggle stays off after reload (regression: previously re-enabled itself).
- [ ] Save the Features tab → MCP toggles + Global CSS/JS values + LA settings are unchanged (cross-tab wipe gone).
- [ ] Activate the plugin on a brand-new site → only Login Branding + Hide BB Cloud Icon are on; Global CSS/JS and everything else are off.
- [ ] Existing 1.2.1 site upgrades → all current toggles preserved; no settings flip back to defaults.
