### PR TITLE
Bump to 1.2.3 — performance review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.2.3] - 2026-05-05
+### Performance
+- **`[child_pages]` shortcode** — capped `posts_per_page` at 50 (was unbounded `-1`) and added a new `limit` shortcode attribute (max 200). Each child renders a Beaver Builder saved layout, so on parent pages with many children the old query could exhaust memory.
+- **`[getsubmenu]` shortcode** — capped `posts_per_page` at 100 (was unbounded `-1`); replaced deprecated `get_page_by_title()` (removed-in-WP-6.2 noise) with a `WP_Query` title lookup; switched the children loop to read titles off the post objects instead of re-fetching each via `get_the_title($id)`.
+- **Global CSS / Global JS** — static-cache the contents of `includes/defaults/global-css.css` and `global-js.js` per-request so multiple `wp_head`/`wp_footer` calls don't re-read from disk.
+- **ACF CSS Vars** — cache the rendered `<style>` block in object cache (group `ds_toolkit`, 1 hour TTL); auto-busts on `acf/save_post` so options-page edits flush immediately.
+- **MCP `bb_list_layout_templates`** — capped `posts_per_page` at 200 (was unbounded `-1`); skip post meta/term cache priming since only `ID` and `post_title` are read.
+- **MCP `delete_transients`** — also flushes the persistent object cache when one is in use, so transients held in Redis/Memcached actually get cleared (the SQL `DELETE` only ever touched `wp_options`). Response now includes `object_cache_flushed`.
+- **University Logo Finder import** — replaced the `meta_query LIKE '%filename%'` lookup with a direct `$wpdb->get_var` query using an anchored trailing match (`%/<filename>`). Avoids the WP_Query → wp_posts JOIN on every "is this logo already imported?" check (one per logo per import batch).
+- **Plugin bootstrap** — `DS_MCP_Server` is now loaded lazily on `rest_api_init` instead of being `require_once`'d on every request. Frontend and wp-admin page loads no longer parse the 2.8k-line MCP file. Also deduplicated a redundant `get_option('ds_toolkit_settings')` in `run()`.
+
+### Fixed
+- **`[current_year]` shortcode** — uses `wp_date('Y')` instead of `date('Y')` so the year reflects the site's configured timezone instead of the server's.
+
 ## [1.2.2] - 2026-05-05
 ### Fixed
 - **Fatal error** "Cannot access offset of type string on string" in `class-ds-toolkit.php` when saving the MCP tab with every checkbox unchecked. The empty POST caused WP to write the option as an empty string; `maybe_set_defaults()` then tried to index into a string and white-screened the site. Now both `maybe_set_defaults()` and `run()` coerce a non-array option back to `array()`, so a corrupted value self-heals on the next request.

--- a/admin/class-ds-logo-finder.php
+++ b/admin/class-ds-logo-finder.php
@@ -79,21 +79,19 @@ class DS_Logo_Finder {
             wp_send_json_error( array( 'message' => 'File not found: ' . $filename ) );
         }
 
-        // Check if already imported
-        $existing = get_posts( array(
-            'post_type'      => 'attachment',
-            'post_status'    => 'inherit',
-            'posts_per_page' => 1,
-            'meta_query'     => array(
-                array(
-                    'key'     => '_wp_attached_file',
-                    'value'   => $filename,
-                    'compare' => 'LIKE',
-                ),
-            ),
+        // Check if already imported. Direct $wpdb query with an anchored trailing match
+        // (`%/<filename>`) is more selective than WP_Query's auto-wrapped `%<filename>%`
+        // and avoids the JOIN against wp_posts that meta_query would build.
+        global $wpdb;
+        $existing_id = (int) $wpdb->get_var( $wpdb->prepare(
+            "SELECT post_id FROM {$wpdb->postmeta}
+             WHERE meta_key = '_wp_attached_file'
+               AND meta_value LIKE %s
+             LIMIT 1",
+            '%' . $wpdb->esc_like( '/' . $filename )
         ) );
 
-        if ( ! empty( $existing ) ) {
+        if ( $existing_id ) {
             wp_send_json_success( array(
                 'status'  => 'exists',
                 'message' => $name . ' — already in Media Library',

--- a/admin/class-ds-mcp-server.php
+++ b/admin/class-ds-mcp-server.php
@@ -1055,11 +1055,13 @@ class DS_MCP_Server {
         $filter_type = ! empty( $args['type'] ) ? sanitize_key( $args['type'] ) : '';
 
         $templates = get_posts( array(
-            'post_type'      => 'fl-builder-template',
-            'posts_per_page' => -1,
-            'post_status'    => 'publish',
-            'orderby'        => 'title',
-            'order'          => 'ASC',
+            'post_type'              => 'fl-builder-template',
+            'posts_per_page'         => 200,
+            'post_status'            => 'publish',
+            'orderby'                => 'title',
+            'order'                  => 'ASC',
+            'update_post_meta_cache' => false,
+            'update_post_term_cache' => false,
         ) );
 
         $patterns = array(
@@ -2500,7 +2502,14 @@ class DS_MCP_Server {
         }
         global $wpdb;
         $deleted = $wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_%' OR option_name LIKE '_site_transient_%'" );
-        return $this->tool_result( $id, array( 'success' => true, 'deleted_rows' => (int) $deleted ) );
+        // Persistent object caches (Redis/Memcached) hold transients in memory, not in wp_options.
+        // Flush them too so the tool actually clears transients on those hosts.
+        $object_cache_flushed = wp_using_ext_object_cache() ? wp_cache_flush() : false;
+        return $this->tool_result( $id, array(
+            'success'              => true,
+            'deleted_rows'         => (int) $deleted,
+            'object_cache_flushed' => (bool) $object_cache_flushed,
+        ) );
     }
 
     private function tool_search_replace( $id, $args ) {

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.2.2
+ * Version:           1.2.3
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.2.2' );
+define( 'DS_TOOLKIT_VERSION', '1.2.3' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-acf-css-vars.php
+++ b/features/class-ds-acf-css-vars.php
@@ -9,12 +9,29 @@ class DS_ACF_CSS_Vars {
         $this->settings = $settings;
     }
 
+    const CACHE_KEY   = 'acf_css_vars_style';
+    const CACHE_GROUP = 'ds_toolkit';
+
     public function init() {
         add_action( 'wp_head', array( $this, 'output_css_vars' ), 1 );
+        // Bust the cached <style> block whenever the ACF options page is saved.
+        add_action( 'acf/save_post', array( __CLASS__, 'flush_cache' ), 20 );
+    }
+
+    public static function flush_cache() {
+        wp_cache_delete( self::CACHE_KEY, self::CACHE_GROUP );
     }
 
     public function output_css_vars() {
         if ( ! function_exists( 'get_field' ) ) {
+            return;
+        }
+
+        $cached = wp_cache_get( self::CACHE_KEY, self::CACHE_GROUP );
+        if ( false !== $cached ) {
+            if ( $cached !== '' ) {
+                echo $cached;
+            }
             return;
         }
 
@@ -23,6 +40,7 @@ class DS_ACF_CSS_Vars {
             : array();
 
         if ( empty( $mappings ) ) {
+            wp_cache_set( self::CACHE_KEY, '', self::CACHE_GROUP, HOUR_IN_SECONDS );
             return;
         }
 
@@ -50,8 +68,11 @@ class DS_ACF_CSS_Vars {
             $css .= esc_attr( $css_var ) . ':' . esc_attr( $value ) . ';';
         }
 
-        if ( $css ) {
-            echo '<style id="dst-acf-css-vars">:root{' . $css . '}</style>' . "\n";
+        $output = $css ? '<style id="dst-acf-css-vars">:root{' . $css . '}</style>' . "\n" : '';
+        wp_cache_set( self::CACHE_KEY, $output, self::CACHE_GROUP, HOUR_IN_SECONDS );
+
+        if ( $output !== '' ) {
+            echo $output;
         }
     }
 }

--- a/features/class-ds-child-pages.php
+++ b/features/class-ds-child-pages.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  *
  * Usage:
  *   [child_pages]
- *   [child_pages template="56369" columns="3" columns_tablet="2" columns_mobile="1"]
+ *   [child_pages template="56369" columns="3" columns_tablet="2" columns_mobile="1" limit="50"]
  *
  * Also registers:
  *   [get_parent_page_title] — outputs the title of the page where [child_pages] is placed.
@@ -59,6 +59,7 @@ class DS_Child_Pages {
                 'columns'        => $default_cols,
                 'columns_tablet' => $default_cols_tablet,
                 'columns_mobile' => $default_cols_mobile,
+                'limit'          => 50,
             ),
             $atts,
             'child_pages'
@@ -68,6 +69,8 @@ class DS_Child_Pages {
         $cols        = max( 1, absint( $atts['columns'] ) );
         $cols_tablet = max( 1, absint( $atts['columns_tablet'] ) );
         $cols_mobile = max( 1, absint( $atts['columns_mobile'] ) );
+        // Hard cap to keep an unbounded query + per-child BB render loop from blowing memory
+        $limit       = max( 1, min( 200, absint( $atts['limit'] ) ?: 50 ) );
 
         if ( ! $template_id ) {
             return '<!-- [child_pages] error: no template ID set -->';
@@ -87,7 +90,7 @@ class DS_Child_Pages {
             'post_parent'    => $parent_id,
             'orderby'        => 'menu_order title',
             'order'          => 'ASC',
-            'posts_per_page' => -1,
+            'posts_per_page' => $limit,
         ) );
 
         if ( empty( $children ) ) {

--- a/features/class-ds-current-year.php
+++ b/features/class-ds-current-year.php
@@ -22,6 +22,7 @@ class DS_Current_Year {
     }
 
     public function render() {
-        return date( 'Y' );
+        // wp_date honours the site's configured timezone instead of the server's.
+        return function_exists( 'wp_date' ) ? wp_date( 'Y' ) : date( 'Y' );
     }
 }

--- a/features/class-ds-getsubmenu.php
+++ b/features/class-ds-getsubmenu.php
@@ -67,9 +67,20 @@ class DS_Getsubmenu {
                 }
             }
 
-            // Fall back to page title
+            // Fall back to page title (get_page_by_title was deprecated in WP 6.2)
             if ( ! $parent ) {
-                $parent = get_page_by_title( $label, OBJECT, 'page' );
+                $title_query = new WP_Query( array(
+                    'post_type'              => 'page',
+                    'post_status'            => 'publish',
+                    'title'                  => $label,
+                    'posts_per_page'         => 1,
+                    'no_found_rows'          => true,
+                    'update_post_meta_cache' => false,
+                    'update_post_term_cache' => false,
+                ) );
+                if ( ! empty( $title_query->posts ) ) {
+                    $parent = $title_query->posts[0];
+                }
             }
 
             if ( ! $parent || 'page' !== $parent->post_type ) {
@@ -77,18 +88,19 @@ class DS_Getsubmenu {
             }
 
             $children = get_posts( array(
-                'post_type'      => 'page',
-                'post_status'    => 'publish',
-                'post_parent'    => (int) $parent->ID,
-                'orderby'        => 'menu_order title',
-                'order'          => 'ASC',
-                'posts_per_page' => -1,
-                'fields'         => 'ids',
+                'post_type'              => 'page',
+                'post_status'            => 'publish',
+                'post_parent'            => (int) $parent->ID,
+                'orderby'                => 'menu_order title',
+                'order'                  => 'ASC',
+                'posts_per_page'         => 100,
+                'update_post_meta_cache' => false,
+                'update_post_term_cache' => false,
             ) );
 
-            foreach ( $children as $child_id ) {
-                $title = get_the_title( $child_id );
-                $url   = get_permalink( $child_id );
+            foreach ( $children as $child ) {
+                $title = $child->post_title;
+                $url   = get_permalink( $child );
                 if ( $title && $url ) {
                     $links[] = sprintf(
                         '<a href="%s">%s</a>',

--- a/features/class-ds-global-css.php
+++ b/features/class-ds-global-css.php
@@ -8,8 +8,11 @@ class DS_Global_CSS {
     }
 
     public function output_css() {
-        // Always output the plugin-managed CSS file (survives updates).
-        $plugin_css = file_get_contents( DS_TOOLKIT_PATH . 'includes/defaults/global-css.css' );
+        // Static-cache so multiple wp_head calls in the same request don't re-read from disk.
+        static $plugin_css = null;
+        if ( $plugin_css === null ) {
+            $plugin_css = (string) file_get_contents( DS_TOOLKIT_PATH . 'includes/defaults/global-css.css' );
+        }
         echo '<style id="ds-toolkit-global-css">' . "\n" . $plugin_css . "\n" . '</style>' . "\n";
 
         // Inject site-specific CSS variable overrides stored in wp_options (survives updates).

--- a/features/class-ds-global-js.php
+++ b/features/class-ds-global-js.php
@@ -8,8 +8,11 @@ class DS_Global_JS {
     }
 
     public function output_js() {
-        // Always output the plugin-managed JS file (survives updates).
-        $js = file_get_contents( DS_TOOLKIT_PATH . 'includes/defaults/global-js.js' );
+        // Static-cache so multiple wp_footer calls in the same request don't re-read from disk.
+        static $js = null;
+        if ( $js === null ) {
+            $js = (string) file_get_contents( DS_TOOLKIT_PATH . 'includes/defaults/global-js.js' );
+        }
         echo '<script id="ds-toolkit-global-js">' . "\n" . $js . "\n" . '</script>' . "\n";
     }
 }

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -111,6 +111,7 @@ class DS_Toolkit {
     /**
      * Fills in any missing settings keys with their defaults.
      * Runs on every load so existing installs pick up new feature defaults automatically.
+     * Returns the (possibly updated) settings array so run() can reuse it without a second get_option().
      */
     private function maybe_set_defaults() {
         $settings = get_option( 'ds_toolkit_settings', array() );
@@ -134,15 +135,20 @@ class DS_Toolkit {
         if ( $changed ) {
             update_option( 'ds_toolkit_settings', $settings );
         }
+
+        return $settings;
     }
 
     public function run() {
-        $this->maybe_set_defaults();
+        $settings = $this->maybe_set_defaults();
 
-        // MCP server must be loaded on every request (registers REST routes)
-        require_once DS_TOOLKIT_PATH . 'admin/class-ds-mcp-server.php';
-        $mcp_server = new DS_MCP_Server();
-        $mcp_server->init();
+        // The MCP server only needs to be alive for REST requests. Defer loading the
+        // 2.8k-line class file until rest_api_init fires so non-REST page loads
+        // (frontend, wp-admin) skip parsing it entirely.
+        add_action( 'rest_api_init', static function() {
+            require_once DS_TOOLKIT_PATH . 'admin/class-ds-mcp-server.php';
+            ( new DS_MCP_Server() )->register_routes();
+        } );
 
         if ( is_admin() ) {
             require_once DS_TOOLKIT_PATH . 'admin/class-ds-toolkit-admin.php';
@@ -152,11 +158,6 @@ class DS_Toolkit {
             require_once DS_TOOLKIT_PATH . 'includes/class-ds-toolkit-updater.php';
             $updater = new DS_Toolkit_Updater();
             $updater->init();
-        }
-
-        $settings = get_option( 'ds_toolkit_settings', array() );
-        if ( ! is_array( $settings ) ) {
-            $settings = array();
         }
 
         foreach ( $this->features as $key => $feature ) {


### PR DESCRIPTION
## Summary
- Applies every recommendation from the v1.2.2 `/wp-performance-review` pass — 1 critical, 8 warnings, 5 info — and bumps the plugin to **1.2.3**.
- Front-end hot path: `[child_pages]` is no longer an unbounded query + per-child Beaver Builder render loop, `[getsubmenu]` no longer triggers WP 6.2's `_deprecated_function` notice on every render, and Global CSS/JS no longer re-read from disk on every `wp_head`/`wp_footer` call.
- Bootstrap: `DS_MCP_Server` (2.8k lines) is now lazy-loaded on `rest_api_init` so frontend and wp-admin page loads stop parsing it.

### Changes by file
| File | Change |
| --- | --- |
| `features/class-ds-child-pages.php` | Cap `posts_per_page` at 50 (was `-1`); new `limit` attr capped at 200 |
| `features/class-ds-getsubmenu.php` | Cap at 100 (was `-1`); replace deprecated `get_page_by_title()` with `WP_Query`; read titles off post objects |
| `features/class-ds-global-css.php` / `class-ds-global-js.php` | Static-cache `file_get_contents` per request |
| `features/class-ds-acf-css-vars.php` | Cache rendered `<style>` block in object cache (`ds_toolkit` group, 1h TTL); bust on `acf/save_post` |
| `features/class-ds-current-year.php` | `wp_date('Y')` instead of `date('Y')` |
| `admin/class-ds-mcp-server.php` (`bb_list_layout_templates`) | Cap at 200 (was `-1`); skip meta/term cache priming |
| `admin/class-ds-mcp-server.php` (`delete_transients`) | Also `wp_cache_flush()` so persistent object caches actually clear |
| `admin/class-ds-logo-finder.php` | Replace `meta_query LIKE '%filename%'` with anchored `$wpdb` query |
| `includes/class-ds-toolkit.php` | Lazy-load MCP server on `rest_api_init`; dedupe redundant `get_option` |
| `ds-toolkit.php` + `CHANGELOG.md` | 1.2.2 → 1.2.3 |

## Test plan
- [ ] Activate plugin on a site running 1.2.2 — confirm no fatals on activation, frontend, or wp-admin
- [ ] Frontend: place `[child_pages]` on a page with 5+ children; confirm same render as 1.2.2
- [ ] Frontend: place `[child_pages limit="2"]` and `[child_pages limit="500"]`; confirm 2 and 200 children render (200 cap)
- [ ] Frontend: `[getsubmenu listfrom="<page title>" mode="pages"]` returns the same list as before; check error log — no `get_page_by_title is deprecated` notice
- [ ] Frontend: `[getsubmenu listfrom="<menu item>" mode="menus"]` still works
- [ ] Frontend: `[current_year]` outputs the year as expected
- [ ] Enable Global CSS + Global JS; view source — both `<style id="ds-toolkit-global-css">` and `<script id="ds-toolkit-global-js">` still render
- [ ] Enable ACF CSS Vars with a mapped option; view source for `<style id="dst-acf-css-vars">`; edit the mapped ACF options page and re-load — value updates (cache busts)
- [ ] MCP: `bb_list_layout_templates` returns templates; `delete_transients` returns `object_cache_flushed: true` on a site with Redis/Memcached, `false` otherwise
- [ ] University Logo Finder: importing a new logo creates a Media Library entry; running the same logo a second time returns "already in Media Library"
- [ ] WP-CLI / network tab: REST endpoint `/wp-json/ds-toolkit/v1/mcp` still returns the GET probe and accepts JSON-RPC POSTs (lazy-load smoke test)
