### PR TITLE
1.2.4 — Expose UABB post-loop fix as a toggle, restore default-on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.2.4] - 2026-05-05
+### Added
+- **Features tab toggle for the UABB Advanced Posts featured-image loop fix.** The patch was registered as a feature in 1.2.0 but never had a UI row, so it couldn't be inspected or controlled. Now visible alongside the other feature toggles, with a description that explains it works on any post type (Posts, Staff, Events, Teams, etc.) and that the hooks only fire when UABB Advanced Posts is rendering — safe to leave on regardless of whether UABB is installed.
+
+### Changed
+- **Default for `uabb_post_loop_fix_enabled` restored to `1`** (was `0` in 1.2.2/1.2.3). Unlike Global CSS / Global JS / MCP toggles, this is a compat patch — it only acts when UABB fires its per-post hooks, so defaulting on doesn't change behavior on sites that don't use UABB. Sites that hit the v1.2.1 fatal and got the option rebuilt from 1.2.2's defaults can now flip it back on from the Features tab without DB editing.
+
 ## [1.2.3] - 2026-05-05
 ### Performance
 - **`[child_pages]` shortcode** — capped `posts_per_page` at 50 (was unbounded `-1`) and added a new `limit` shortcode attribute (max 200). Each child renders a Beaver Builder saved layout, so on parent pages with many children the old query could exhaust memory.

--- a/admin/class-ds-toolkit-admin.php
+++ b/admin/class-ds-toolkit-admin.php
@@ -209,6 +209,7 @@ class DS_Toolkit_Admin {
                 $child_pages_columns         = ! empty( $opts['child_pages_columns'] )        ? (int) $opts['child_pages_columns']        : 3;
                 $child_pages_columns_tablet  = ! empty( $opts['child_pages_columns_tablet'] ) ? (int) $opts['child_pages_columns_tablet'] : 2;
                 $child_pages_columns_mobile  = ! empty( $opts['child_pages_columns_mobile'] ) ? (int) $opts['child_pages_columns_mobile'] : 1;
+                $uabb_post_loop_fix_enabled  = ! empty( $opts['uabb_post_loop_fix_enabled'] );
                 require DS_TOOLKIT_PATH . 'admin/views/page-settings.php';
             }
             ?>

--- a/admin/views/page-settings.php
+++ b/admin/views/page-settings.php
@@ -7,7 +7,8 @@
  *                      $current_year_enabled, $forminator_email_partner_enabled,
  *                      $forminator_email_partner_fallback, $child_pages_enabled,
  *                      $child_pages_template_id, $child_pages_columns,
- *                      $child_pages_columns_tablet, $child_pages_columns_mobile
+ *                      $child_pages_columns_tablet, $child_pages_columns_mobile,
+ *                      $uabb_post_loop_fix_enabled
  */
 if ( ! defined( 'ABSPATH' ) ) exit;
 ?>
@@ -61,6 +62,22 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <input type="hidden" name="ds_toolkit_settings[hide_fl_assistant]" value="0">
                 <input type="checkbox" id="hide_fl_assistant" name="ds_toolkit_settings[hide_fl_assistant]" value="1" <?php checked( $hide_fl_assistant ); ?>>
                 <label for="hide_fl_assistant"></label>
+            </div>
+        </div>
+    </div>
+
+    <!-- UABB Advanced Posts featured-image loop fix -->
+    <div class="dst-card">
+        <div class="dst-card-row">
+            <div class="dst-card-icon"><span class="dashicons dashicons-format-image"></span></div>
+            <div class="dst-card-info">
+                <strong>UABB Advanced Posts — Featured Image Loop Fix</strong>
+                <span>Patches the UABB Advanced Posts module bug where every post in a "Custom" layout shows the first post's featured image. Toggles Beaver Builder Theme Builder's <code>FLThemeBuilderFieldConnections::$in_post_grid_loop</code> flag around each post via UABB's <code>uabb_blog_posts_before_post</code> / <code>uabb_blog_posts_after_post</code> hooks. Works for any post type — Posts, Staff, Events, Teams, etc. Safe to leave on: the hooks only fire when UABB Advanced Posts is rendering, so sites without UABB are unaffected.</span>
+            </div>
+            <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[uabb_post_loop_fix_enabled]" value="0">
+                <input type="checkbox" id="uabb_post_loop_fix_enabled" name="ds_toolkit_settings[uabb_post_loop_fix_enabled]" value="1" <?php checked( $uabb_post_loop_fix_enabled ); ?>>
+                <label for="uabb_post_loop_fix_enabled"></label>
             </div>
         </div>
     </div>

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.2.3
+ * Version:           1.2.4
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.2.3' );
+define( 'DS_TOOLKIT_VERSION', '1.2.4' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -92,7 +92,9 @@ class DS_Toolkit {
             'child_pages_columns'                => 3,
             'child_pages_columns_tablet'         => 2,
             'child_pages_columns_mobile'         => 1,
-            'uabb_post_loop_fix_enabled'         => 0,
+            // Compat patch — only does anything when UABB Advanced Posts fires its
+            // hooks, so it's safe to default on. Sites without UABB are unaffected.
+            'uabb_post_loop_fix_enabled'         => 1,
             // MCP tool group access controls — off by default
             'mcp_posts_pages_enabled'            => 0,
             'mcp_cpt_enabled'                    => 0,


### PR DESCRIPTION
## Summary
The 1.2.0/1.2.1 UABB Advanced Posts featured-image loop fix had no UI control — registered as a feature but never rendered on the Features tab. In 1.2.2 we changed its default from `1` to `0`, and the new is_array fatal-recovery path rebuilds settings from defaults, so any site that hit the v1.2.1 fatal got the fix silently disabled with no way to turn it back on.

This adds the missing Features tab toggle and restores the default to `1`.

### Why default-on is correct here
Unlike Global CSS / Global JS / MCP toggles (which alter site output unconditionally), this is a compat patch — `uabb_blog_posts_before_post` / `uabb_blog_posts_after_post` only fire when UABB Advanced Posts is actually rendering, so sites that don't have UABB installed or active are unaffected.

### Why it already works for any CPT
After tracing UABB's [blog-posts/includes/frontend.php](https://github.com/Design-Shop-LeagueApps-Department/ds-toolkit/blob/main/features/class-ds-uabb-post-loop-fix.php) and BB Theme Builder's `FLThemeBuilderFieldConnections::connect_node_settings()`:
- UABB fires the per-post hooks for any post type its query returns.
- BB's connection cache key uses global `$post->ID`, which `setup_postdata()` updates per loop iteration regardless of `post_type`.
- With `in_post_grid_loop = true`, the cache key becomes `{node}_{loop_post_id}` — unique per card.

So the fix already covers Staff, Events, Teams, and any other CPT — the user's report of it "not working on Staff" was actually the toggle being silently disabled after the 1.2.2 recovery path.

## Test plan
- [ ] On a fresh install: Features tab shows "UABB Advanced Posts — Featured Image Loop Fix" row, on by default.
- [ ] On a site with UABB Advanced Posts + custom layout via `[fl_builder_insert_layout]` rendering Staff CPT: each card shows its own featured image (was: all the same).
- [ ] Same module pointed at default Posts: still works (regression check).
- [ ] Toggle off → save → reload page with the module → bug returns (proves the toggle controls the fix).
- [ ] Toggle on → save → bug gone.
- [ ] Site without UABB installed: no PHP notices/errors, plugin behaves identically with the toggle on or off.
- [ ] Sites already on 1.2.2/1.2.3 with `uabb_post_loop_fix_enabled => 0` from the recovery: option key already exists, so `maybe_set_defaults()` won't auto-flip it — they need to enable the new toggle manually. (This is the whole point of adding the UI.)
