### PR TITLE
1.2.5 — auto-re-enable UABB post-loop fix on affected installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.2.5] - 2026-05-05
+### Fixed
+- **UABB post-loop fix re-enabled on affected installs.** 1.2.4 restored the default for `uabb_post_loop_fix_enabled` to `1` and added a Features tab toggle, but `maybe_set_defaults()` only fills missing keys — so any site whose option was rebuilt by the 1.2.2 fatal-recovery path (or that fresh-installed 1.2.2/1.2.3) kept the value at `0` and had to enable the toggle by hand. Added a one-shot migration that flips the value to `1` once for affected installs and records `_dst_migrated_125_uabb_on` so the user can still toggle it off later without it bouncing back.
+
 ## [1.2.4] - 2026-05-05
 ### Added
 - **Features tab toggle for the UABB Advanced Posts featured-image loop fix.** The patch was registered as a feature in 1.2.0 but never had a UI row, so it couldn't be inspected or controlled. Now visible alongside the other feature toggles, with a description that explains it works on any post type (Posts, Staff, Events, Teams, etc.) and that the hooks only fire when UABB Advanced Posts is rendering — safe to leave on regardless of whether UABB is installed.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.2.4
+ * Version:           1.2.5
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.2.4' );
+define( 'DS_TOOLKIT_VERSION', '1.2.5' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -134,6 +134,21 @@ class DS_Toolkit {
             }
         }
 
+        // One-shot migration: 1.2.2 / 1.2.3 shipped uabb_post_loop_fix_enabled
+        // defaulting to 0, and any site that hit the v1.2.1 fatal got the option
+        // rebuilt with that value by the is_array() recovery guard. The patch is
+        // a UABB compat fix — its hooks only fire when UABB Advanced Posts is
+        // rendering, so leaving it on is safe regardless. Flip it back to 1 once
+        // for affected installs, then mark the migration done so the user can
+        // still toggle it off later without us re-enabling on the next load.
+        if ( empty( $settings['_dst_migrated_125_uabb_on'] ) ) {
+            if ( isset( $settings['uabb_post_loop_fix_enabled'] ) && empty( $settings['uabb_post_loop_fix_enabled'] ) ) {
+                $settings['uabb_post_loop_fix_enabled'] = 1;
+            }
+            $settings['_dst_migrated_125_uabb_on'] = 1;
+            $changed                               = true;
+        }
+
         if ( $changed ) {
             update_option( 'ds_toolkit_settings', $settings );
         }


### PR DESCRIPTION
## Summary
1.2.4 restored the default for `uabb_post_loop_fix_enabled` to `1` and added a Features tab toggle, but `maybe_set_defaults()` only fills missing keys. Sites whose `ds_toolkit_settings` option was rebuilt by the v1.2.2 fatal-recovery guard (or that fresh-installed 1.2.2 / 1.2.3) already have the key set to `0` — so 1.2.4 didn't auto-flip it.

This PR adds a one-shot migration that flips the value to `1` once for affected installs and records `_dst_migrated_125_uabb_on` in the option. After the flag is set, the migration is a no-op on subsequent loads, so the user can still toggle the fix off via the Features tab without it bouncing back.

### Why default-on is correct
The patch is a UABB Advanced Posts compat fix — its `uabb_blog_posts_before_post` / `_after_post` hooks only fire when that specific module is rendering, so sites without UABB are unaffected. Distinct from Global CSS / Global JS / MCP toggles which alter site output unconditionally.

## Test plan
- [ ] Install on a fresh site → `uabb_post_loop_fix_enabled = 1`, `_dst_migrated_125_uabb_on = 1`. Features tab toggle shown on.
- [ ] Upgrade a site that has `uabb_post_loop_fix_enabled = 0` (one of the fatal-recovered installs) → on next admin or frontend load, both keys flip to `1`. Features tab toggle now shown on. Staff CPT featured-image bug gone.
- [ ] After migration, toggle off via Features tab + save → reload → toggle stays off (migration flag prevents re-enabling).
- [ ] Existing site that already had `uabb_post_loop_fix_enabled = 1` → migration runs no-op, just records the flag.
