### PR TITLE
Add ds_overlay_nav / ds_overlay_subs shortcodes + contributor docs (#7)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!--
+Read CONTRIBUTING.md before opening this PR.
+If an AI assistant (Claude Code, etc.) is preparing this PR, it MUST read
+CONTRIBUTING.md first — the feature-wiring checklist below is the most common
+reason PRs are sent back.
+-->
+
+## What this changes
+
+<!-- One or two sentences. Link any related issue or PR. -->
+
+## Type
+
+- [ ] New feature
+- [ ] Bug fix
+- [ ] Performance / refactor
+- [ ] Docs / chore
+
+## If this adds a feature, it is NOT complete without all of these
+
+<!-- Delete this section only if this PR adds no new feature class. -->
+
+- [ ] New class file in `features/` follows the `__construct($settings)` + `init()` shape
+- [ ] Registered in `$features[]` in `includes/class-ds-toolkit.php`
+- [ ] Default key added to `get_defaults()` in the same file
+- [ ] Toggle card added to `admin/views/page-settings.php` + `$<key>` var initialized in `DS_Toolkit_Admin::render_page()`
+- [ ] If it creates DB rows / cron: `uninstall.php` and `DS_Toolkit::activate()` updated
+
+## Always
+
+- [ ] All output escaped; every PHP file has the `ABSPATH` guard
+- [ ] `CHANGELOG.md` entry added under a new version heading
+- [ ] `DS_TOOLKIT_VERSION` bumped in both spots in `ds-toolkit.php` (final commit)
+- [ ] Branched off `main` with a `feat/` `fix/` `perf/` `refactor/` `docs/` `chore/` prefix (not from fork `main`)
+- [ ] `php -l` passes on all changed PHP files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.2.6] - 2026-05-15
+### Added
+- **`[ds_overlay_nav]` and `[ds_overlay_subs]` shortcodes** (contributed by @LouiePacheco, #7). Render a WordPress nav menu as a full-screen overlay: `[ds_overlay_nav menu="..."]` outputs auto-numbered top-level items, and `[ds_overlay_subs]` (same page, after the nav) outputs child-link blocks for items that have a submenu. Off by default; toggle on the Features tab. Markup is intentionally unstyled to pair with theme-side overlay CSS/JS. Maintainer note: the PR added the feature class only, so the registry entry, default key, and Features-tab toggle were wired up on merge.
+- **`CONTRIBUTING.md` and a GitHub PR template.** Spell out the full feature-wiring checklist (registry entry + default + toggle) that the #7 PR missed, with an explicit instruction for AI assistants to read it before opening a PR. `main` had no contributor-facing guidance previously.
+
 ## [1.2.5] - 2026-05-05
 ### Fixed
 - **UABB post-loop fix re-enabled on affected installs.** 1.2.4 restored the default for `uabb_post_loop_fix_enabled` to `1` and added a Features tab toggle, but `maybe_set_defaults()` only fills missing keys — so any site whose option was rebuilt by the 1.2.2 fatal-recovery path (or that fresh-installed 1.2.2/1.2.3) kept the value at `0` and had to enable the toggle by hand. Added a one-shot migration that flips the value to `1` once for affected installs and records `_dst_migrated_125_uabb_on` so the user can still toggle it off later without it bouncing back.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to DS Toolkit
+
+Thanks for contributing. Please read this before opening a PR. **If you are using
+Claude Code or another AI assistant to make changes, point it at this file first** —
+most rejected PRs fail the feature-wiring checklist below, not code review.
+
+## The one rule that trips people up
+
+Dropping a class file in `features/` does **not** make a feature work. The class is
+never instantiated unless it is registered. A PR that adds only the feature file is
+incomplete and will not be merged as-is.
+
+## Adding a feature (complete checklist)
+
+A feature is a class in `features/class-ds-<name>.php` with this exact shape:
+
+```php
+class DS_<Name> {
+    private $settings;
+    public function __construct( $settings = array() ) { $this->settings = $settings; }
+    public function init() {
+        // add_action / add_shortcode / etc.
+    }
+}
+```
+
+To make it actually load, **all** of these are required in the same PR:
+
+1. **Register it.** Add one entry to `$features[]` in
+   `includes/class-ds-toolkit.php` (key = settings flag, value = file + class).
+2. **Give it a default.** Add the settings key to `get_defaults()` in the same
+   file. New optional features default to `0` (off) unless they are a no-op
+   compat patch.
+3. **Make it toggleable.** Add a toggle card to
+   `admin/views/page-settings.php` and initialize the matching `$<key>` variable
+   in `DS_Toolkit_Admin::render_page()` (`admin/class-ds-toolkit-admin.php`).
+   Without this the feature can never be turned on.
+4. **If it creates DB rows or cron events:** extend `uninstall.php` to remove
+   them, and add schema install to `DS_Toolkit::activate()`.
+
+A feature missing steps 1-3 is dead code. The PR checklist enforces this.
+
+## Code conventions
+
+- Guard every PHP file with `if ( ! defined( 'ABSPATH' ) ) exit;`.
+- Escape all output (`esc_html`, `esc_url`, `esc_attr`, `wp_kses_*`).
+- All settings live in the single `ds_toolkit_settings` option array. Do not add
+  new `wp_options` rows.
+- End files with a single trailing newline, no trailing whitespace.
+
+## Branch, version, and release workflow
+
+- Branch off `main` with a prefix: `feat/`, `fix/`, `perf/`, `refactor/`,
+  `docs/`, or `chore/`. Do not push from your fork's `main`.
+- Add a `CHANGELOG.md` entry under a new version heading.
+- Bump `DS_TOOLKIT_VERSION` in **both** places in `ds-toolkit.php` (the header
+  comment and the `define()`), as the **final commit** on your branch.
+- Open the PR into `main`. Maintainers squash-merge; publishing a GitHub Release
+  builds and ships the update to live sites via the auto-updater.
+
+## Architecture in one paragraph
+
+`ds-toolkit.php` boots `DS_Toolkit` (`includes/class-ds-toolkit.php`), which holds
+the feature registry, the defaults, and conditional instantiation: each feature
+class is loaded and `init()`-ed only if its settings key is truthy. The admin
+settings page and MCP endpoint are always loaded but restricted by email domain.
+That is the whole model — features are opt-in, registry-driven, and single-option.

--- a/admin/class-ds-toolkit-admin.php
+++ b/admin/class-ds-toolkit-admin.php
@@ -200,6 +200,7 @@ class DS_Toolkit_Admin {
                 $acf_css_vars_mappings              = ! empty( $opts['acf_css_vars_mappings'] ) ? $opts['acf_css_vars_mappings'] : array();
                 $getsubmenu_enabled                 = ! empty( $opts['getsubmenu_enabled'] );
                 $current_year_enabled               = ! empty( $opts['current_year_enabled'] );
+                $overlay_nav_enabled                = ! empty( $opts['overlay_nav_enabled'] );
                 $forminator_email_partner_enabled   = ! empty( $opts['forminator_email_partner_enabled'] );
                 $forminator_email_partner_fallback  = ! empty( $opts['forminator_email_partner_fallback'] )
                     ? $opts['forminator_email_partner_fallback']

--- a/admin/views/page-settings.php
+++ b/admin/views/page-settings.php
@@ -4,7 +4,8 @@
  * Rendered inside the shared wrap + header + tabs in DS_Toolkit_Admin::render_page().
  * Variables available: $enabled, $logo_id, $logo_url, $default_url, $hide_fl_assistant,
  *                      $acf_css_vars_enabled, $acf_css_vars_mappings, $getsubmenu_enabled,
- *                      $current_year_enabled, $forminator_email_partner_enabled,
+ *                      $current_year_enabled, $overlay_nav_enabled,
+ *                      $forminator_email_partner_enabled,
  *                      $forminator_email_partner_fallback, $child_pages_enabled,
  *                      $child_pages_template_id, $child_pages_columns,
  *                      $child_pages_columns_tablet, $child_pages_columns_mobile,
@@ -175,6 +176,33 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <p>Place this shortcode anywhere you want the year to appear and update itself automatically each year — no manual edits needed.</p>
                 <code>[current_year]</code>
                 <p>Example: &copy; <?php echo date( 'Y' ); ?> LeagueApps Design Shop — type it as: <code>&amp;copy; [current_year] LeagueApps Design Shop</code></p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Overlay Nav Shortcodes -->
+    <div class="dst-card">
+        <div class="dst-card-row">
+            <div class="dst-card-icon"><span class="dashicons dashicons-menu"></span></div>
+            <div class="dst-card-info">
+                <strong>[ds_overlay_nav] / [ds_overlay_subs] Shortcodes</strong>
+                <span>Renders a WordPress nav menu as a full-screen overlay: a numbered left panel and a matching sub-link right panel.</span>
+            </div>
+            <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[overlay_nav_enabled]" value="0">
+                <input type="checkbox" id="overlay_nav_enabled" name="ds_toolkit_settings[overlay_nav_enabled]" value="1" <?php checked( $overlay_nav_enabled ); ?>>
+                <label for="overlay_nav_enabled"></label>
+            </div>
+        </div>
+
+        <div class="dst-card-row dst-shortcode-docs">
+            <div class="dst-card-icon"><span class="dashicons dashicons-info-outline"></span></div>
+            <div class="dst-card-info">
+                <strong>How to use it</strong>
+                <p>Place <code>[ds_overlay_nav]</code> in the left panel to output top-level menu items, numbered automatically. Place <code>[ds_overlay_subs]</code> in the right panel, on the same page and after <code>[ds_overlay_nav]</code>, to output the child-link blocks for any items that have a submenu.</p>
+                <code>[ds_overlay_nav menu="primary"]</code>
+                <code>[ds_overlay_subs]</code>
+                <p>The <code>menu</code> attribute accepts a menu name or slug (defaults to <code>primary</code>). Markup is unstyled by design — pair it with your theme's overlay-nav CSS/JS.</p>
             </div>
         </div>
     </div>

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.2.5
+ * Version:           1.2.6
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.2.5' );
+define( 'DS_TOOLKIT_VERSION', '1.2.6' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-overlay-nav.php
+++ b/features/class-ds-overlay-nav.php
@@ -1,0 +1,142 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * [ds_overlay_nav] and [ds_overlay_subs] Shortcodes
+ *
+ * Outputs a WordPress nav menu as a full-screen overlay navigation.
+ * Designed to work with the DS Overlay Nav CSS/JS pattern.
+ *
+ * Usage:
+ *   Left panel (numbered nav items):
+ *     [ds_overlay_nav menu="primary"]
+ *
+ *   Right panel (sub-link blocks, must follow ds_overlay_nav on same page):
+ *     [ds_overlay_subs]
+ *
+ * The menu attribute accepts a menu name, slug, or location slug.
+ * Only top-level items are rendered as nav items.
+ * Items with children get a sub-panel in [ds_overlay_subs].
+ * Items with no children are skipped in [ds_overlay_subs].
+ */
+class DS_Overlay_Nav {
+
+    private $settings;
+
+    /**
+     * Holds sub-panel data built by [ds_overlay_nav] for use by [ds_overlay_subs].
+     * Keyed by sanitized item slug.
+     *
+     * @var array
+     */
+    private static $subs = array();
+
+    public function __construct( $settings = array() ) {
+        $this->settings = $settings;
+    }
+
+    public function init() {
+        add_shortcode( 'ds_overlay_nav',  array( $this, 'render_nav'  ) );
+        add_shortcode( 'ds_overlay_subs', array( $this, 'render_subs' ) );
+    }
+
+    /**
+     * [ds_overlay_nav] — renders the numbered left-panel items.
+     */
+    public function render_nav( $atts ) {
+        $atts = shortcode_atts(
+            array(
+                'menu' => 'primary',
+            ),
+            $atts,
+            'ds_overlay_nav'
+        );
+
+        $menu_items = wp_get_nav_menu_items( $atts['menu'] );
+
+        if ( ! $menu_items ) {
+            return '';
+        }
+
+        // Reset subs for this render pass
+        self::$subs = array();
+
+        $output = '';
+        $num    = 1;
+
+        foreach ( $menu_items as $item ) {
+
+            // Top-level items only
+            if ( $item->menu_item_parent != 0 ) {
+                continue;
+            }
+
+            $padded = str_pad( $num, 2, '0', STR_PAD_LEFT );
+            $sub_id = 'sub-' . sanitize_title( $item->title );
+
+            // Collect direct children for the right panel
+            $children_html = '';
+            foreach ( $menu_items as $child ) {
+                if ( $child->menu_item_parent != $item->ID ) {
+                    continue;
+                }
+                $children_html .= sprintf(
+                    '<a href="%s">%s</a>',
+                    esc_url( $child->url ),
+                    esc_html( $child->title )
+                );
+            }
+
+            // Store for [ds_overlay_subs] — only if there are children
+            if ( $children_html ) {
+                self::$subs[ $sub_id ] = array(
+                    'label'    => $item->title,
+                    'children' => $children_html,
+                );
+            }
+
+            $output .= sprintf(
+                '<div class="titans-nav-item" data-sub="%s" data-num="%s">
+                    <span class="tni-num">%s</span>
+                    <a class="tni-text" href="%s">%s</a>
+                </div>',
+                esc_attr( $sub_id ),
+                esc_attr( $padded ),
+                esc_html( $padded ),
+                esc_url( $item->url ),
+                esc_html( $item->title )
+            );
+
+            $num++;
+        }
+
+        return $output;
+    }
+
+    /**
+     * [ds_overlay_subs] — renders the right-panel sub-link blocks.
+     * Must appear after [ds_overlay_nav] on the same page.
+     */
+    public function render_subs( $atts ) {
+
+        if ( empty( self::$subs ) ) {
+            return '';
+        }
+
+        $output = '';
+
+        foreach ( self::$subs as $id => $sub ) {
+            $output .= sprintf(
+                '<div class="titans-sub" id="%s">
+                    <h4>%s</h4>
+                    %s
+                </div>',
+                esc_attr( $id ),
+                esc_html( $sub['label'] ),
+                $sub['children']
+            );
+        }
+
+        return $output;
+    }
+}

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -51,6 +51,10 @@ class DS_Toolkit {
             'file'  => 'features/class-ds-uabb-post-loop-fix.php',
             'class' => 'DS_UABB_Post_Loop_Fix',
         ),
+        'overlay_nav_enabled' => array(
+            'file'  => 'features/class-ds-overlay-nav.php',
+            'class' => 'DS_Overlay_Nav',
+        ),
     );
 
     public static function activate() {
@@ -82,6 +86,7 @@ class DS_Toolkit {
             ),
             'getsubmenu_enabled'                  => 0,
             'current_year_enabled'               => 0,
+            'overlay_nav_enabled'                => 0,
             'forminator_email_partner_enabled'   => 0,
             'forminator_email_partner_fallback'  => 'designshop' . DS_TOOLKIT_ADMIN_DOMAIN,
             'global_css_enabled'                 => 0,


### PR DESCRIPTION
Incorporates @LouiePacheco's overlay-nav shortcodes from #7 and finishes the wiring the original PR was missing.

## Feature
`[ds_overlay_nav menu="..."]` renders top-level WP menu items as auto-numbered overlay entries; `[ds_overlay_subs]` (same page, after the nav) renders child-link blocks for items with a submenu. Off by default, toggle on the Features tab. Markup is intentionally unstyled to pair with theme-side overlay CSS/JS.

## What was added on merge
PR #7 added only `features/class-ds-overlay-nav.php`, so the class was never instantiated. This PR adds:
- Registry entry in `includes/class-ds-toolkit.php`
- `overlay_nav_enabled => 0` default
- Features-tab toggle card + admin var

@LouiePacheco's commit is credited; PR #7 is superseded by this and can be closed once this merges.

## Contributor guidance
`main` had no `CLAUDE.md` or contributor docs, which is the root cause of #7 shipping incomplete. Added:
- `CONTRIBUTING.md` with the full feature-wiring checklist and an explicit instruction for AI assistants to read it before opening a PR
- `.github/pull_request_template.md` enforcing the checklist as checkboxes

## Verification
`php -l` passes on all changed PHP files.
