### PR TITLE
Fix: load updater in cron/CLI so auto-updates don't break the plugin folder (1.2.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.2.7] - 2026-05-15
+### Fixed
+- **Auto-updates no longer deactivate the plugin into a long folder name.** The updater (and its `upgrader_source_selection` → `fix_source_dir` filter) was only instantiated under `is_admin()`. WP Engine Smart Plugin Manager, wp-cron auto-updates, and `wp plugin update` all run in CLI/cron context where `is_admin()` is false, so when the updater fell back to GitHub's raw zipball (release JSON cached during the ~10s window before CI attaches `ds-toolkit.zip`) the extracted `owner-repo-hash` folder was never renamed back to `ds-toolkit/`. WordPress then couldn't resolve the `active_plugins` path and silently deactivated the plugin. The updater now also loads under `wp_doing_cron()` and `WP_CLI`, and `fix_source_dir` no longer bails when an upgrader omits `hook_extra['type']`.
+
+### Changed
+- **Updater repo pointer updated to `Design-Shop-LeagueApps-Department/ds-toolkit`.** The hardcoded `agabriel1590/ds-toolkit` only worked via GitHub's redirect; the release `zipball_url` already pointed at the new org, lengthening the fallback folder name. Pointing directly at the current org removes that fragility.
+
 ## [1.2.6] - 2026-05-15
 ### Added
 - **`[ds_overlay_nav]` and `[ds_overlay_subs]` shortcodes** (contributed by @LouiePacheco, #7). Render a WordPress nav menu as a full-screen overlay: `[ds_overlay_nav menu="..."]` outputs auto-numbered top-level items, and `[ds_overlay_subs]` (same page, after the nav) outputs child-link blocks for items that have a submenu. Off by default; toggle on the Features tab. Markup is intentionally unstyled to pair with theme-side overlay CSS/JS. Maintainer note: the PR added the feature class only, so the registry entry, default key, and Features-tab toggle were wired up on merge.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.2.6
+ * Version:           1.2.7
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.2.6' );
+define( 'DS_TOOLKIT_VERSION', '1.2.7' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/class-ds-toolkit-updater.php
+++ b/includes/class-ds-toolkit-updater.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class DS_Toolkit_Updater {
 
     private $slug = 'ds-toolkit';
-    private $repo = 'agabriel1590/ds-toolkit';
+    private $repo = 'Design-Shop-LeagueApps-Department/ds-toolkit';
 
     /**
      * Returns true if the site is a local/development environment.
@@ -178,8 +178,12 @@ class DS_Toolkit_Updater {
     public function fix_source_dir( $source, $remote_source, $upgrader, $hook_extra = array() ) {
         global $wp_filesystem;
 
-        // Only act on plugin installs or updates, not themes or core
-        if ( ! isset( $hook_extra['type'] ) || $hook_extra['type'] !== 'plugin' ) {
+        // Skip only when the upgrader explicitly says this is a theme/core
+        // job. Some cron/CLI auto-update paths (incl. WP Engine Smart Plugin
+        // Manager) omit hook_extra['type'] entirely — bailing on a missing
+        // type would skip the rename in exactly the context this fixes. The
+        // ds-toolkit.php existence check below is the real safety gate.
+        if ( isset( $hook_extra['type'] ) && $hook_extra['type'] !== 'plugin' ) {
             return $source;
         }
 

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -176,7 +176,17 @@ class DS_Toolkit {
             require_once DS_TOOLKIT_PATH . 'admin/class-ds-toolkit-admin.php';
             $admin = new DS_Toolkit_Admin();
             $admin->init();
+        }
 
+        // The updater must also load outside wp-admin: WP Engine Smart Plugin
+        // Manager, wp-cron auto-updates, and `wp plugin update` all run in
+        // CLI/cron context where is_admin() is false. Without it the
+        // upgrader_source_selection filter never registers, so a GitHub
+        // zipball fallback installs into a long owner-repo-hash folder and
+        // WordPress deactivates the plugin (active_plugins path no longer
+        // resolves). Loading it here keeps fix_source_dir on the hook in
+        // every update path.
+        if ( is_admin() || wp_doing_cron() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
             require_once DS_TOOLKIT_PATH . 'includes/class-ds-toolkit-updater.php';
             $updater = new DS_Toolkit_Updater();
             $updater->init();


### PR DESCRIPTION
## Problem

After SPM auto-updated **dslaunchpad5** to 1.2.6, the plugin deactivated and reinstalled into a long `owner-repo-hash` folder instead of `ds-toolkit/`.

Root cause, confirmed on the live install:

- `autoupdater/autoupdater.php` = **WP Engine Smart Plugin Manager** v6.1.4 is active. SPM updates plugins daily in a **WP-CLI/cron context** where `is_admin()` is `false`.
- The updater (and its `upgrader_source_selection` → `fix_source_dir` filter, whose only job is renaming the extracted folder back to `ds-toolkit/`) was instantiated **only inside `if ( is_admin() )`** in `class-ds-toolkit.php`.
- v1.2.6's release JSON was cached during the ~10s window between release publish (`09:19:14`) and CI attaching `ds-toolkit.zip` (`09:19:24`), so the updater fell back to GitHub's raw zipball.
- The zipball folder is `Design-Shop-LeagueApps-Department-ds-toolkit-<sha>/` (repo moved orgs; updater still hardcoded `agabriel1590/ds-toolkit`). `fix_source_dir` never ran → folder not renamed → `active_plugins` path `ds-toolkit/ds-toolkit.php` no longer resolved → WordPress deactivated the plugin.

Manual admin "update now" was unaffected (that path *is* `is_admin()`), which is why 1.2.2–1.2.5 were fine. Every SPM-managed install would hit this on the next release.

## Fix

- Load the updater under `is_admin() || wp_doing_cron() || ( defined('WP_CLI') && WP_CLI )` so `fix_source_dir` is registered in every update path. Admin UI class stays admin-only.
- `fix_source_dir` no longer bails when an upgrader omits `hook_extra['type']` (the `ds-toolkit.php` existence check remains the real safety gate).
- Point `$repo` at `Design-Shop-LeagueApps-Department/ds-toolkit` so the fallback no longer relies on GitHub's redirect.
- Version bump to 1.2.7 + CHANGELOG.

## Live site

dslaunchpad5 already self-healed (correct `ds-toolkit/` folder, 1.2.6, active, no fatals). No site remediation needed; this prevents recurrence on the next release across all SPM-managed installs.

## Test notes

`php -l` clean on all three changed files. Behavior is hook-registration only — admin update path unchanged; cron/CLI path now also registers the rename filter.
