### PR TITLE
feat: LeagueApps modules opt-in on any blueprint (1.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.1] - 2026-07-01
+### Added
+- **LeagueApps modules are now opt-in on any blueprint.** A new **LeagueApps Modules** section on Settings → DS Toolkit lists all 14 in-house Beaver Builder blocks (Hero, Menu, Post Loop, Page Cards, Image Carousel, Org Stats, Marquee, Info List, CTA, Heading, Divider, Team Detail, Content Router, Partner Social) with a per-module toggle, shown **regardless of blueprint**. Existing blueprint-5 sites can now enable individual blocks without a full blueprint bump; the toggles are **off by default** below blueprint 6, so auto-updates change nothing. The blueprint gate is bypassed for these module features only (they are additive builder blocks); the behavioral features (image optimization, disable comments, admin-menu tidy, theme setting) stay gated to blueprint 6. New builds (blueprint 6+) still get every module on by default.
+
 ## [1.9.0] - 2026-06-22
 ### Added
 - **Leagueapps Divider** Beaver Builder module (`ds_divider_module_enabled`, blueprint 6+, auto-on) — new in-house module in `modules/ds-divider/`, registered under the "LeagueApps" category. Horizontal or vertical, with five effects: **Solid**, **Gradient Fade** (fades to transparent at the ends), **Running Light** (a loading-style highlight that sweeps along — down for vertical, across for horizontal), **Glow Pulse**, and **Marching Dashes**. Two global-colour-connected colours, thickness, length/height + alignment, rounded ends, spacing, and animation controls (speed, reverse direction, glow size, dash length/gap). Every animation honours `prefers-reduced-motion`.

--- a/admin/class-ds-toolkit-admin.php
+++ b/admin/class-ds-toolkit-admin.php
@@ -228,6 +228,11 @@ class DS_Toolkit_Admin {
                 $admin_menu_tidy_enabled  = ! empty( $opts['admin_menu_tidy_enabled'] );
                 $ds_menu_module_enabled   = ! empty( $opts['ds_menu_module_enabled'] );
                 $image_optimization_enabled = ! empty( $opts['image_optimization_enabled'] );
+                // Per-module on/off states for the always-visible "LeagueApps Modules" section.
+                $ds_module_states = array();
+                foreach ( DS_Toolkit::module_features() as $mod_key => $mod_label ) {
+                    $ds_module_states[ $mod_key ] = ! empty( $opts[ $mod_key ] );
+                }
                 require DS_TOOLKIT_PATH . 'admin/views/page-settings.php';
             }
             ?>

--- a/admin/views/page-settings.php
+++ b/admin/views/page-settings.php
@@ -70,6 +70,25 @@ if ( ! defined( 'ABSPATH' ) ) exit;
         </div>
     </div>
 
+    <!-- LeagueApps modules (Beaver Builder blocks) — opt-in on ANY blueprint, off by default below gen 6 -->
+    <p class="dst-section-title">LeagueApps Modules (Beaver Builder blocks)</p>
+    <div class="dst-card">
+        <?php foreach ( DS_Toolkit::module_features() as $mod_key => $mod_label ) : ?>
+        <div class="dst-card-row">
+            <div class="dst-card-icon"><span class="dashicons dashicons-screenoptions"></span></div>
+            <div class="dst-card-info">
+                <strong><?php echo esc_html( $mod_label ); ?></strong>
+                <span>Adds the <strong><?php echo esc_html( $mod_label ); ?></strong> block to the Beaver Builder &ldquo;LeagueApps&rdquo; group.</span>
+            </div>
+            <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[<?php echo esc_attr( $mod_key ); ?>]" value="0">
+                <input type="checkbox" id="<?php echo esc_attr( $mod_key ); ?>" name="ds_toolkit_settings[<?php echo esc_attr( $mod_key ); ?>]" value="1" <?php checked( ! empty( $ds_module_states[ $mod_key ] ) ); ?>>
+                <label for="<?php echo esc_attr( $mod_key ); ?>"></label>
+            </div>
+        </div>
+        <?php endforeach; ?>
+    </div>
+
     <?php if ( $blueprint_version >= 6 ) : ?>
     <!-- Disable Comments (blueprint generation 6+) -->
     <div class="dst-card">
@@ -115,22 +134,6 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <input type="hidden" name="ds_toolkit_settings[admin_menu_tidy_enabled]" value="0">
                 <input type="checkbox" id="admin_menu_tidy_enabled" name="ds_toolkit_settings[admin_menu_tidy_enabled]" value="1" <?php checked( $admin_menu_tidy_enabled ); ?>>
                 <label for="admin_menu_tidy_enabled"></label>
-            </div>
-        </div>
-    </div>
-
-    <!-- LeagueApps Menu module (blueprint generation 6+) -->
-    <div class="dst-card">
-        <div class="dst-card-row">
-            <div class="dst-card-icon"><span class="dashicons dashicons-menu-alt3"></span></div>
-            <div class="dst-card-info">
-                <strong>LeagueApps Menu (Beaver Builder module)</strong>
-                <span>Registers an in-house <strong>LeagueApps Menu</strong> module in Beaver Builder: horizontal nav with dropdowns, per-item mega panels with a column count (add a <code>ds-cols-4</code> class to a menu item to override, <code>ds-no-mega</code> for a plain dropdown), and a full-screen hamburger overlay below a set breakpoint. Fully in-house (no UABB dependency). Auto-enabled on DSLP6 builds.</span>
-            </div>
-            <div class="dst-toggle">
-                <input type="hidden" name="ds_toolkit_settings[ds_menu_module_enabled]" value="0">
-                <input type="checkbox" id="ds_menu_module_enabled" name="ds_toolkit_settings[ds_menu_module_enabled]" value="1" <?php checked( $ds_menu_module_enabled ); ?>>
-                <label for="ds_menu_module_enabled"></label>
             </div>
         </div>
     </div>

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.0
+ * Version:           1.9.1
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.0' );
+define( 'DS_TOOLKIT_VERSION', '1.9.1' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -205,6 +205,33 @@ class DS_Toolkit {
         return (int) get_option( 'ds_blueprint_version', 0 );
     }
 
+    /**
+     * The in-house "LeagueApps" Beaver Builder module features (settings key => label).
+     * These are purely additive builder blocks, so they are opt-in on ANY blueprint:
+     * their toggles are shown on the Settings page regardless of blueprint, they load
+     * whenever their toggle is on (the blueprint gate is bypassed for modules in run()),
+     * and they still default ON for blueprint 6+ builds via get_defaults(). Existing
+     * blueprint-5 sites see them OFF until an admin turns one on.
+     */
+    public static function module_features() {
+        return array(
+            'ds_cta_module_enabled'            => 'CTA',
+            'ds_content_router_module_enabled' => 'Content Router',
+            'ds_divider_module_enabled'        => 'Divider',
+            'ds_heading_module_enabled'        => 'Heading',
+            'ds_hero_module_enabled'           => 'Hero Banner',
+            'ds_carousel_module_enabled'       => 'Image Carousel',
+            'ds_info_list_module_enabled'      => 'Info List',
+            'ds_marquee_module_enabled'        => 'Marquee',
+            'ds_menu_module_enabled'           => 'Menu',
+            'ds_orgstats_module_enabled'       => 'Org Stats',
+            'ds_page_cards_module_enabled'     => 'Page Cards',
+            'ds_social_module_enabled'         => 'Partner Social',
+            'ds_post_loop_module_enabled'      => 'Post Loop',
+            'ds_team_detail_module_enabled'    => 'Team Detail',
+        );
+    }
+
     public static function activate() {
         $settings = get_option( 'ds_toolkit_settings', array() );
 
@@ -373,12 +400,16 @@ class DS_Toolkit {
             $updater->init();
         }
 
-        $blueprint = self::blueprint_version();
+        $blueprint    = self::blueprint_version();
+        $module_keys  = self::module_features();
 
         foreach ( $this->features as $key => $feature ) {
-            // Blueprint-gated features never load below their required
-            // generation, even if the settings key was somehow set.
-            if ( ! empty( $feature['min_blueprint'] ) && $blueprint < (int) $feature['min_blueprint'] ) {
+            // Blueprint-gated features never load below their required generation,
+            // EXCEPT the LeagueApps modules: those are additive builder blocks that
+            // are opt-in on any blueprint (off by default below their generation),
+            // so an existing site can enable individual blocks without a blueprint bump.
+            $is_module = isset( $module_keys[ $key ] );
+            if ( ! empty( $feature['min_blueprint'] ) && ! $is_module && $blueprint < (int) $feature['min_blueprint'] ) {
                 continue;
             }
             if ( ! empty( $settings[ $key ] ) ) {


### PR DESCRIPTION
Lets existing (blueprint-5) fleet sites adopt the new modules. Adds a **LeagueApps Modules** section on Settings → DS Toolkit with a per-module toggle for all 14 blocks, shown on any blueprint, **off by default below gen 6** (so auto-updates change nothing). Module loading bypasses the blueprint gate; behavioral features stay gated. Verified on DS5 (blueprint 5): a toggled-on module loads, a toggled-off one doesn't, image-optimization stays gated, and DS5 was restored to 1.2.7 cleanly.