### PR TITLE
feat: module descriptions + Enable-all switch (1.9.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.2] - 2026-07-02
+### Added
+- **LeagueApps Modules settings: per-module descriptions + an "Enable all" switch.** Each of the 14 module toggles now shows a short description of what the block does, and a top **Enable all modules** switch turns every block on or off at once (it checks/unchecks the individual toggles, which remain the source of truth and still save per-module).
+
 ## [1.9.1] - 2026-07-01
 ### Added
 - **LeagueApps modules are now opt-in on any blueprint.** A new **LeagueApps Modules** section on Settings → DS Toolkit lists all 14 in-house Beaver Builder blocks (Hero, Menu, Post Loop, Page Cards, Image Carousel, Org Stats, Marquee, Info List, CTA, Heading, Divider, Team Detail, Content Router, Partner Social) with a per-module toggle, shown **regardless of blueprint**. Existing blueprint-5 sites can now enable individual blocks without a full blueprint bump; the toggles are **off by default** below blueprint 6, so auto-updates change nothing. The blueprint gate is bypassed for these module features only (they are additive builder blocks); the behavioral features (image optimization, disable comments, admin-menu tidy, theme setting) stay gated to blueprint 6. New builds (blueprint 6+) still get every module on by default.

--- a/admin/class-ds-toolkit-admin.php
+++ b/admin/class-ds-toolkit-admin.php
@@ -230,7 +230,7 @@ class DS_Toolkit_Admin {
                 $image_optimization_enabled = ! empty( $opts['image_optimization_enabled'] );
                 // Per-module on/off states for the always-visible "LeagueApps Modules" section.
                 $ds_module_states = array();
-                foreach ( DS_Toolkit::module_features() as $mod_key => $mod_label ) {
+                foreach ( DS_Toolkit::module_features() as $mod_key => $mod_meta ) {
                     $ds_module_states[ $mod_key ] = ! empty( $opts[ $mod_key ] );
                 }
                 require DS_TOOLKIT_PATH . 'admin/views/page-settings.php';

--- a/admin/views/page-settings.php
+++ b/admin/views/page-settings.php
@@ -73,21 +73,50 @@ if ( ! defined( 'ABSPATH' ) ) exit;
     <!-- LeagueApps modules (Beaver Builder blocks) — opt-in on ANY blueprint, off by default below gen 6 -->
     <p class="dst-section-title">LeagueApps Modules (Beaver Builder blocks)</p>
     <div class="dst-card">
-        <?php foreach ( DS_Toolkit::module_features() as $mod_key => $mod_label ) : ?>
+        <div class="dst-card-row">
+            <div class="dst-card-icon"><span class="dashicons dashicons-grid-view"></span></div>
+            <div class="dst-card-info">
+                <strong>Enable all modules</strong>
+                <span>Quick switch to turn every LeagueApps block on (or off) at once. Each block can still be toggled individually below. Remember to Save.</span>
+            </div>
+            <div class="dst-toggle">
+                <input type="checkbox" id="dst-modules-all">
+                <label for="dst-modules-all"></label>
+            </div>
+        </div>
+        <?php foreach ( DS_Toolkit::module_features() as $mod_key => $mod ) : ?>
         <div class="dst-card-row">
             <div class="dst-card-icon"><span class="dashicons dashicons-screenoptions"></span></div>
             <div class="dst-card-info">
-                <strong><?php echo esc_html( $mod_label ); ?></strong>
-                <span>Adds the <strong><?php echo esc_html( $mod_label ); ?></strong> block to the Beaver Builder &ldquo;LeagueApps&rdquo; group.</span>
+                <strong><?php echo esc_html( $mod['label'] ); ?></strong>
+                <span><?php echo esc_html( $mod['desc'] ); ?></span>
             </div>
             <div class="dst-toggle">
                 <input type="hidden" name="ds_toolkit_settings[<?php echo esc_attr( $mod_key ); ?>]" value="0">
-                <input type="checkbox" id="<?php echo esc_attr( $mod_key ); ?>" name="ds_toolkit_settings[<?php echo esc_attr( $mod_key ); ?>]" value="1" <?php checked( ! empty( $ds_module_states[ $mod_key ] ) ); ?>>
+                <input type="checkbox" class="dst-module-toggle" id="<?php echo esc_attr( $mod_key ); ?>" name="ds_toolkit_settings[<?php echo esc_attr( $mod_key ); ?>]" value="1" <?php checked( ! empty( $ds_module_states[ $mod_key ] ) ); ?>>
                 <label for="<?php echo esc_attr( $mod_key ); ?>"></label>
             </div>
         </div>
         <?php endforeach; ?>
     </div>
+    <script>
+    ( function () {
+        var all  = document.getElementById( 'dst-modules-all' );
+        var mods = [].slice.call( document.querySelectorAll( '.dst-module-toggle' ) );
+        if ( ! all || ! mods.length ) { return; }
+        function sync() {
+            var on = mods.filter( function ( c ) { return c.checked; } ).length;
+            all.checked       = ( on === mods.length );
+            all.indeterminate = ( on > 0 && on < mods.length );
+        }
+        all.addEventListener( 'change', function () {
+            mods.forEach( function ( c ) { c.checked = all.checked; } );
+            all.indeterminate = false;
+        } );
+        mods.forEach( function ( c ) { c.addEventListener( 'change', sync ); } );
+        sync();
+    } )();
+    </script>
 
     <?php if ( $blueprint_version >= 6 ) : ?>
     <!-- Disable Comments (blueprint generation 6+) -->

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.1
+ * Version:           1.9.2
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.1' );
+define( 'DS_TOOLKIT_VERSION', '1.9.2' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -215,20 +215,20 @@ class DS_Toolkit {
      */
     public static function module_features() {
         return array(
-            'ds_cta_module_enabled'            => 'CTA',
-            'ds_content_router_module_enabled' => 'Content Router',
-            'ds_divider_module_enabled'        => 'Divider',
-            'ds_heading_module_enabled'        => 'Heading',
-            'ds_hero_module_enabled'           => 'Hero Banner',
-            'ds_carousel_module_enabled'       => 'Image Carousel',
-            'ds_info_list_module_enabled'      => 'Info List',
-            'ds_marquee_module_enabled'        => 'Marquee',
-            'ds_menu_module_enabled'           => 'Menu',
-            'ds_orgstats_module_enabled'       => 'Org Stats',
-            'ds_page_cards_module_enabled'     => 'Page Cards',
-            'ds_social_module_enabled'         => 'Partner Social',
-            'ds_post_loop_module_enabled'      => 'Post Loop',
-            'ds_team_detail_module_enabled'    => 'Team Detail',
+            'ds_hero_module_enabled'           => array( 'label' => 'Hero Banner',     'desc' => 'Full-width hero (image, video, or slideshow) with overlay, eyebrow, headline, and call-to-action buttons.' ),
+            'ds_menu_module_enabled'           => array( 'label' => 'Menu',            'desc' => 'Responsive navigation bar with dropdowns, mega-menus, and a full-screen mobile overlay.' ),
+            'ds_post_loop_module_enabled'      => array( 'label' => 'Post Loop',       'desc' => 'Lists of news, staff, teams, programs, sponsors, or tournaments in a range of card layouts.' ),
+            'ds_page_cards_module_enabled'     => array( 'label' => 'Page Cards',      'desc' => 'A grid of linked cards built from child pages or a manual list.' ),
+            'ds_carousel_module_enabled'       => array( 'label' => 'Image Carousel',  'desc' => 'A stacked-deck image slider with captions, arrows, and dots.' ),
+            'ds_orgstats_module_enabled'       => array( 'label' => 'Org Stats',       'desc' => 'Headline stat figures (the record) as plain figures or photo cards.' ),
+            'ds_marquee_module_enabled'        => array( 'label' => 'Marquee',         'desc' => 'A scrolling announcement ticker with a pinned label.' ),
+            'ds_info_list_module_enabled'      => array( 'label' => 'Info List',       'desc' => 'An icon-and-text list for hours, contact details, or quick facts.' ),
+            'ds_cta_module_enabled'            => array( 'label' => 'CTA',             'desc' => 'A call-to-action band with a heading, text, and buttons.' ),
+            'ds_heading_module_enabled'        => array( 'label' => 'Heading',         'desc' => 'A styled section heading with an eyebrow line and accent options.' ),
+            'ds_divider_module_enabled'        => array( 'label' => 'Divider',         'desc' => 'A horizontal or vertical divider with gradient-fade, running-light, glow, and dashed effects.' ),
+            'ds_team_detail_module_enabled'    => array( 'label' => 'Team Detail',     'desc' => 'A single-team layout: roster, schedule, and coaches.' ),
+            'ds_content_router_module_enabled' => array( 'label' => 'Content Router',  'desc' => 'Renders the right body layout for each page type (single vs. archive) from one Themer template.' ),
+            'ds_social_module_enabled'         => array( 'label' => 'Partner Social',  'desc' => "A row of the partner's social-media links." ),
         );
     }
 


### PR DESCRIPTION
Polish on the LeagueApps Modules settings section: a short description under each of the 14 module toggles, and a top **Enable all modules** switch that checks/unchecks them together (individual toggles remain the source of truth). Verified the settings page renders on DS6.