### PR TITLE
fix: CTA bento eyebrow + responsive columns; cell borders + eyebrow style (1.9.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.3] - 2026-07-04
+### Added
+- **CTA (Bento) — cell borders.** New **Cell Border Width** + **Cell Border Colour** options (Style → Bento), global-colour connected. Blank/0 = no border, so existing instances are unchanged.
+- **CTA (Bento) — eyebrow style controls.** New **Eyebrow Colour** and **Eyebrow Typography** (responsive, live preview) in Style → Bento. Blank colour keeps the defaults (accent on text cells, white pill on image cells).
+
+### Fixed
+- **CTA (Bento) — the cell Eyebrow now actually renders.** The card form saved an Eyebrow for every bento cell but Style 3 never output it. Text cells now show it as a small accent label above the title; image cells show it as a rounded dark pill overlaid bottom-left.
+- **CTA (Bento) — responsive Columns / Gap / Row Height now work.** The tablet and mobile values of the Columns and Gap fields were ignored (tablet was hardcoded to 2 columns, mobile to 1), and the tablet Row Height was emitted before the hardcoded `grid-auto-rows: auto` so it never applied. All three now honour their tablet/mobile values; blank still falls back to the original 2-up / 1-up defaults.
+
 ## [1.9.2] - 2026-07-02
 ### Added
 - **LeagueApps Modules settings: per-module descriptions + an "Enable all" switch.** Each of the 14 module toggles now shows a short description of what the block does, and a top **Enable all modules** switch turns every block on or off at once (it checks/unchecks the individual toggles, which remain the source of truth and still save per-module).

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.2
+ * Version:           1.9.3
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.2' );
+define( 'DS_TOOLKIT_VERSION', '1.9.3' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-cta/css/frontend.css
+++ b/modules/ds-cta/css/frontend.css
@@ -73,6 +73,9 @@
 .ds-cta--style3 .ds-cta-bento-celldesc strong,.ds-cta--style3 .ds-cta-bento-celldesc b{color:var(--fl-global-white);}
 .ds-cta--style3 .ds-cta-bento-btn{align-self:flex-start;display:inline-block;background:var(--fl-global-accent);color:var(--fl-global-white);font-weight:700;font-size:.78rem;letter-spacing:.1em;text-transform:uppercase;padding:13px 22px;text-decoration:none;transition:filter .2s ease,transform .2s ease;}
 .ds-cta--style3 .ds-cta-bento-btn:hover{filter:brightness(1.08);transform:translateY(-1px);}
+/* Cell eyebrow: small accent label in text cells; overlay pill on image cells. */
+.ds-cta--style3 .ds-cta-bento-eyebrow{font-size:.75rem;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--fl-global-accent);margin:0 0 10px;}
+.ds-cta--style3 .ds-cta-bento-img .ds-cta-bento-eyebrow{position:absolute;left:14px;bottom:12px;z-index:1;margin:0;padding:7px 13px;border-radius:999px;background:color-mix(in srgb, var(--fl-global-dark-background) 78%, transparent);color:var(--fl-global-white);}
 
 /* ---- Style 4: Big Hero contact CTA (sub-heading, heading, partner contact + social, big button over a background image) ---- */
 .ds-cta--style4{position:relative;display:flex;align-items:center;min-height:520px;overflow:hidden;isolation:isolate;}

--- a/modules/ds-cta/ds-cta.php
+++ b/modules/ds-cta/ds-cta.php
@@ -217,6 +217,7 @@ class DS_CTA_Module extends FLBuilderModule {
 
 			if ( 'text' === $type ) {
 				echo '<div class="ds-cta-bento-cell ds-cta-bento-text"' . $span . '>';
+				if ( ! empty( $cell->eyebrow ) ) { echo '<div class="ds-cta-bento-eyebrow">' . esc_html( $cell->eyebrow ) . '</div>'; }
 				if ( ! empty( $cell->title ) ) { echo '<h3 class="ds-cta-bento-title">' . esc_html( $cell->title ) . '</h3>'; }
 				if ( ! empty( $cell->desc ) ) { echo '<div class="ds-cta-bento-celldesc">' . wpautop( wp_kses_post( $cell->desc ) ) . '</div>'; }
 				$lt = trim( (string) ( $cell->link_text ?? '' ) );
@@ -231,6 +232,7 @@ class DS_CTA_Module extends FLBuilderModule {
 				$attr = $has ? ' href="' . $url . '" target="' . esc_attr( $target ) . '"' . $rel : '';
 				echo '<' . $tag . ' class="ds-cta-bento-cell ds-cta-bento-img"' . $span . $attr . '>';
 				echo '<div class="ds-cta-bento-bg"' . ( $img ? ' style="background-image:url(' . esc_url( $img ) . ')"' : '' ) . '></div>';
+				if ( ! empty( $cell->eyebrow ) ) { echo '<div class="ds-cta-bento-eyebrow">' . esc_html( $cell->eyebrow ) . '</div>'; }
 				echo '</' . $tag . '>';
 			}
 		}
@@ -625,6 +627,10 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 				'fields' => array(
 					'row_height' => array( 'type' => 'unit', 'label' => __( 'Row Height', 'ds-toolkit' ), 'default' => '220', 'description' => 'px', 'responsive' => true, 'slider' => array( 'min' => 120, 'max' => 400, 'step' => 10 ) ),
 					'bento_radius' => array( 'type' => 'unit', 'label' => __( 'Cell Corner Radius', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 40, 'step' => 1 ), 'help' => __( 'Rounds every bento cell (image + text cells).', 'ds-toolkit' ) ),
+					'bento_border_width' => array( 'type' => 'unit', 'label' => __( 'Cell Border Width', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 10, 'step' => 1 ), 'help' => __( 'Border around every bento cell. Blank or 0 = no border.', 'ds-toolkit' ) ),
+					'bento_border_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Cell Border Colour', 'ds-toolkit' ), 'default' => 'var(--fl-global-line-color)', 'show_reset' => true, 'show_alpha' => true ),
+					'bento_eyebrow_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Eyebrow Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true, 'help' => __( 'Colour of the cell eyebrow label. Blank = accent on text cells, white on image cells.', 'ds-toolkit' ), 'preview' => array( 'type' => 'css', 'selector' => '.ds-cta-bento-eyebrow', 'property' => 'color' ) ),
+					'bento_eyebrow_typography' => array( 'type' => 'typography', 'label' => __( 'Eyebrow Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-cta-bento-eyebrow' ) ),
 					'cell_bg'    => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Text Cell Background', 'ds-toolkit' ), 'default' => 'var(--fl-global-dark-background)', 'show_reset' => true ),
 					'img_cell_bg' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Image Cell Background', 'ds-toolkit' ), 'default' => 'var(--fl-global-dark-background)', 'show_reset' => true, 'show_alpha' => true, 'help' => __( 'Shows behind image cells (visible with transparent logos or while the image loads).', 'ds-toolkit' ) ),
 					'btn_global' => array( 'type' => 'select', 'label' => __( 'Button Style', 'ds-toolkit' ), 'default' => 'yes', 'options' => array( 'yes' => __( 'Match site Button (Theme Setting)', 'ds-toolkit' ), 'no' => __( 'Accent colour', 'ds-toolkit' ) ), 'help' => __( 'Text-cell buttons inherit the global Button (background, hover, radius, typography) from Theme Setting by default.', 'ds-toolkit' ) ),

--- a/modules/ds-cta/includes/frontend.css.php
+++ b/modules/ds-cta/includes/frontend.css.php
@@ -72,11 +72,17 @@ if ( 'style3' === $style ) {
 	$gap3  = $u( $settings->gap ?? '', 16 );
 	$rh    = $u( $settings->row_height ?? '', 220 );
 	echo "$node .ds-cta-bento { grid-template-columns: repeat({$cols3}, 1fr); gap: {$gap3}px; grid-auto-rows: {$rh}px; }\n";
-	if ( '' !== ( $settings->row_height_medium ?? '' ) ) { echo "@media (max-width:{$bpm}px){ $node .ds-cta-bento { grid-auto-rows: " . (int) $settings->row_height_medium . "px; } }\n"; }
-	// Responsive: tablet -> 2 cols with auto-height rows (text cells can't be clipped),
-	// mobile -> single column. Span resets use !important to beat the per-cell inline spans.
-	echo "@media (max-width:{$bpm}px){ $node .ds-cta-bento { grid-template-columns: repeat(2,1fr); grid-auto-rows: auto; } $node .ds-cta-bento-cell { grid-column: span 1 !important; grid-row: span 1 !important; } $node .ds-cta-bento-img { min-height: {$rh}px; } }\n";
-	echo "@media (max-width:{$bpr}px){ $node .ds-cta-bento { grid-template-columns: 1fr; } }\n";
+	// Responsive: honour the Columns / Gap / Row Height tablet + mobile values; blank
+	// keeps the original defaults (tablet 2-up with auto rows, mobile 1-up). Span resets
+	// use !important to beat the per-cell inline spans.
+	$cols3m = ( '' !== ( $settings->columns_medium ?? '' ) ) ? max( 1, (int) $settings->columns_medium ) : 2;
+	$cols3r = ( '' !== ( $settings->columns_responsive ?? '' ) ) ? max( 1, (int) $settings->columns_responsive ) : 1;
+	$gap3m  = ( '' !== ( $settings->gap_medium ?? '' ) ) ? ' gap: ' . (int) $settings->gap_medium . 'px;' : '';
+	$gap3r  = ( '' !== ( $settings->gap_responsive ?? '' ) ) ? ' gap: ' . (int) $settings->gap_responsive . 'px;' : '';
+	$rhm    = ( '' !== ( $settings->row_height_medium ?? '' ) ) ? ( (int) $settings->row_height_medium ) . 'px' : 'auto';
+	$rhr    = ( '' !== ( $settings->row_height_responsive ?? '' ) ) ? ' grid-auto-rows: ' . (int) $settings->row_height_responsive . 'px;' : '';
+	echo "@media (max-width:{$bpm}px){ $node .ds-cta-bento { grid-template-columns: repeat({$cols3m},1fr); grid-auto-rows: {$rhm};{$gap3m} } $node .ds-cta-bento-cell { grid-column: span 1 !important; grid-row: span 1 !important; } $node .ds-cta-bento-img { min-height: {$rh}px; } }\n";
+	echo "@media (max-width:{$bpr}px){ $node .ds-cta-bento { grid-template-columns: repeat({$cols3r},1fr);{$gap3r}{$rhr} } }\n";
 	$cellbg = $col( $settings->cell_bg ?? '' );
 	if ( '' !== $cellbg ) { echo "$node .ds-cta-bento-text { background: {$cellbg}; }\n"; }
 	$imgbg = $col( $settings->img_cell_bg ?? '' );
@@ -86,6 +92,20 @@ if ( 'style3' === $style ) {
 	// Cell corner radius (image + text cells).
 	$brad = ( isset( $settings->bento_radius ) && '' !== $settings->bento_radius ) ? ( (int) $settings->bento_radius ) . 'px' : 'var(--ds-radius)';
 	echo "$node .ds-cta-bento-cell { border-radius: {$brad}; }\n";
+
+	// Cell border (blank/0 width = none).
+	$bbw = ( isset( $settings->bento_border_width ) && '' !== $settings->bento_border_width ) ? (int) $settings->bento_border_width : 0;
+	if ( $bbw > 0 ) {
+		$bbc = $col( $settings->bento_border_color ?? '' ) ?: 'var(--fl-global-line-color)';
+		echo "$node .ds-cta-bento-cell { border: {$bbw}px solid {$bbc}; }\n";
+	}
+
+	// Cell eyebrow colour (blank = static defaults: accent on text cells, white pill on image cells).
+	$beye = $col( $settings->bento_eyebrow_color ?? '' );
+	if ( '' !== $beye ) { echo "$node .ds-cta-bento-eyebrow { color: {$beye}; }\n"; }
+	if ( class_exists( 'FLBuilderCSS' ) ) {
+		FLBuilderCSS::typography_field_rule( array( 'settings' => $settings, 'setting_name' => 'bento_eyebrow_typography', 'selector' => "$node .ds-cta-bento-eyebrow" ) );
+	}
 
 	// Bento button: respect the Theme Setting global Button by default.
 	$btn_global = ( $settings->btn_global ?? 'yes' ) === 'yes';


### PR DESCRIPTION
Fixes two CTA (Bento/Style 3) bugs and adds requested options:
- **Eyebrow renders now** — cells saved an Eyebrow but Style 3 never output it (accent label on text cells, overlay pill on image cells).
- **Responsive Columns/Gap/Row Height honoured** — tablet was hardcoded 2-up, mobile 1-up; tablet row height never applied.
- **New Style → Bento options:** Cell Border Width/Colour, Eyebrow Colour + Typography (responsive, live preview).

Verified live on the DS6 home page bento: all 6 eyebrows render, 2px border applies, tablet measured 3 columns/160px rows with test values, then the page was restored.