### PR TITLE
feat: inline HTML in titles, carousel Height option, bento Cell Shadow (1.9.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.4] - 2026-07-05
+### Added
+- **Inline HTML in module title fields.** Editor-authored title / eyebrow / label fields across the LeagueApps modules (Hero heading, Heading title + subheading, CTA heading + card/tile/bento titles and eyebrows, Team Detail section titles, Org Stats eyebrow + labels, Marquee items + label, Info List text) now accept safe inline HTML — `span` (class/style), `strong`, `em`, `b`, `i`, `u`, `small`, `mark`, `br`, `sup`, `sub` — via a shared `DS_Module_UI::inline()` kses whitelist, so e.g. `Lorem <span style="color:#069e33">Ipsum</span>` renders instead of printing literally. `style` attributes are sanitised by WP's safecss filter; everything else is still escaped. WP post titles remain fully escaped.
+- **Image Carousel — Height option.** New Sizing → **Height** select (Aspect ratio (default) / Small 300px / Medium 420px / Tall 560px / Custom with responsive per-breakpoint values): a fixed deck height that replaces the aspect ratio; slide images keep covering the card. The matching utility classes `height-small` / `height-medium` / `height-tall` (on the module, column, or row) now also work, emitted with enough specificity to beat the per-node aspect rule.
+- **CTA (Bento) — Cell Shadow.** New Style → Bento **Cell Shadow** option (None / Soft / Medium / Strong) alongside the 1.9.3 border controls.
+
 ## [1.9.3] - 2026-07-04
 ### Added
 - **CTA (Bento) — cell borders.** New **Cell Border Width** + **Cell Border Colour** options (Style → Bento), global-colour connected. Blank/0 = no border, so existing instances are unchanged.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.3
+ * Version:           1.9.4
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.3' );
+define( 'DS_TOOLKIT_VERSION', '1.9.4' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/class-ds-module-ui.php
+++ b/includes/class-ds-module-ui.php
@@ -36,6 +36,29 @@ class DS_Module_UI {
 		return '' === $c ? $fallback : $c;
 	}
 
+	/**
+	 * Editor-authored title/label text: allow safe INLINE HTML (span/strong/em/
+	 * b/i/u/small/mark/br, class + style attrs where sensible) and escape all
+	 * else. Lets an editor write e.g. Lorem <span style="color:#069e33">Ipsum</span>
+	 * in a Title field. style attributes are sanitised by WP's safecss filter.
+	 * Use for MODULE FIELDS only — keep esc_html() for WP post titles.
+	 */
+	public static function inline( $text ) {
+		return wp_kses( (string) $text, array(
+			'span'   => array( 'class' => true, 'style' => true ),
+			'strong' => array( 'class' => true, 'style' => true ),
+			'b'      => array(),
+			'em'     => array( 'class' => true, 'style' => true ),
+			'i'      => array( 'class' => true ),
+			'u'      => array(),
+			'small'  => array(),
+			'mark'   => array( 'class' => true, 'style' => true ),
+			'br'     => array(),
+			'sup'    => array(),
+			'sub'    => array(),
+		) );
+	}
+
 	/** color() wrapped in color-mix() at $opacity_pct toward transparent; '' if blank. Works on hex AND var(). */
 	public static function mix( $v, $opacity_pct ) {
 		$c = self::color( $v );

--- a/modules/ds-carousel/css/frontend.css
+++ b/modules/ds-carousel/css/frontend.css
@@ -83,3 +83,14 @@
 @media (prefers-reduced-motion:reduce){
   .ds-carousel--style2 .ds-logos-track{transition:none;}
 }
+
+/* Height utility classes: add `height-small` / `height-medium` / `height-tall` to the
+   module (Advanced → Class), or its column/row, to force a fixed deck height instead of
+   the aspect ratio. The .fl-builder-content prefix out-specifies the per-node aspect rule.
+   Prefer the Sizing → Height option; these classes are the shorthand equivalent. */
+.fl-builder-content .height-small  .ds-carousel-framewrap,
+.fl-builder-content .fl-module.height-small  .ds-carousel-framewrap { height: 300px; aspect-ratio: auto; }
+.fl-builder-content .height-medium .ds-carousel-framewrap,
+.fl-builder-content .fl-module.height-medium .ds-carousel-framewrap { height: 420px; aspect-ratio: auto; }
+.fl-builder-content .height-tall   .ds-carousel-framewrap,
+.fl-builder-content .fl-module.height-tall   .ds-carousel-framewrap { height: 560px; aspect-ratio: auto; }

--- a/modules/ds-carousel/ds-carousel.php
+++ b/modules/ds-carousel/ds-carousel.php
@@ -404,6 +404,24 @@ FLBuilder::register_module( 'DS_Carousel_Module', array(
 				'title'  => __( 'Sizing', 'ds-toolkit' ),
 				'fields' => array(
 					'max_width'   => array( 'type' => 'unit', 'label' => __( 'Card Width', 'ds-toolkit' ), 'default' => '540', 'description' => 'px', 'slider' => array( 'min' => 240, 'max' => 900, 'step' => 10 ) ),
+					'deck_height' => array(
+						'type'    => 'select',
+						'label'   => __( 'Height', 'ds-toolkit' ),
+						'default' => '',
+						'options' => array(
+							''       => __( 'Aspect ratio (below)', 'ds-toolkit' ),
+							'small'  => __( 'Small (300px)', 'ds-toolkit' ),
+							'medium' => __( 'Medium (420px)', 'ds-toolkit' ),
+							'tall'   => __( 'Tall (560px)', 'ds-toolkit' ),
+							'custom' => __( 'Custom', 'ds-toolkit' ),
+						),
+						'help'    => __( 'Fixed deck height instead of an aspect ratio. Images always cover the card (never stretched).', 'ds-toolkit' ),
+						'toggle'  => array(
+							''       => array( 'fields' => array( 'aspect' ) ),
+							'custom' => array( 'fields' => array( 'deck_height_custom' ) ),
+						),
+					),
+					'deck_height_custom' => array( 'type' => 'unit', 'label' => __( 'Custom Height', 'ds-toolkit' ), 'default' => '420', 'description' => 'px', 'responsive' => true, 'slider' => array( 'min' => 160, 'max' => 800, 'step' => 10 ) ),
 					'aspect'      => array(
 						'type'    => 'select',
 						'label'   => __( 'Aspect Ratio', 'ds-toolkit' ),

--- a/modules/ds-carousel/includes/frontend.css.php
+++ b/modules/ds-carousel/includes/frontend.css.php
@@ -75,8 +75,21 @@ if ( 'style2' === $style ) {
 $mw  = $u( $settings->max_width ?? '', 540 );
 echo "$node .ds-carousel-stage { max-width: {$mw}px; }\n";
 
-$ar = preg_replace( '/[^0-9 \/]/', '', (string) ( $settings->aspect ?? '4 / 5' ) ) ?: '4 / 5';
-echo "$node .ds-carousel-framewrap { aspect-ratio: {$ar}; }\n";
+/* Height: a preset / custom FIXED height beats the aspect ratio; blank = aspect (original). */
+$dh_preset = (string) ( $settings->deck_height ?? '' );
+$dh_map    = array( 'small' => 300, 'medium' => 420, 'tall' => 560 );
+$dh        = $dh_map[ $dh_preset ] ?? 0;
+if ( 'custom' === $dh_preset ) { $dh = $u( $settings->deck_height_custom ?? '', 420 ); }
+if ( $dh > 0 ) {
+	echo "$node .ds-carousel-framewrap { height: {$dh}px; aspect-ratio: auto; }\n";
+	if ( 'custom' === $dh_preset ) {
+		if ( '' !== ( $settings->deck_height_custom_medium ?? '' ) )     { echo "@media (max-width:{$bpm}px){ $node .ds-carousel-framewrap { height: " . (int) $settings->deck_height_custom_medium . "px; } }\n"; }
+		if ( '' !== ( $settings->deck_height_custom_responsive ?? '' ) ) { echo "@media (max-width:{$bpr}px){ $node .ds-carousel-framewrap { height: " . (int) $settings->deck_height_custom_responsive . "px; } }\n"; }
+	}
+} else {
+	$ar = preg_replace( '/[^0-9 \/]/', '', (string) ( $settings->aspect ?? '4 / 5' ) ) ?: '4 / 5';
+	echo "$node .ds-carousel-framewrap { aspect-ratio: {$ar}; }\n";
+}
 
 $crad = ( isset( $settings->card_radius ) && '' !== $settings->card_radius ) ? ( (int) $settings->card_radius ) . 'px' : 'var(--ds-radius)';
 echo "$node .ds-carousel-slide { border-radius: {$crad}; }\n";

--- a/modules/ds-cta/ds-cta.php
+++ b/modules/ds-cta/ds-cta.php
@@ -48,7 +48,7 @@ class DS_CTA_Module extends FLBuilderModule {
 
 	/** Heading markup: escape, {a}..{/a} -> accent span, newlines -> <br>. */
 	private function heading_html( $raw ) {
-		$h = esc_html( (string) $raw );
+		$h = DS_Module_UI::inline( (string) $raw ); // safe inline HTML (span/strong/em...) allowed
 		$h = str_replace( array( '{a}', '{/a}' ), array( '<span class="ds-cta-accent">', '</span>' ), $h );
 		return nl2br( $h );
 	}
@@ -122,9 +122,9 @@ class DS_CTA_Module extends FLBuilderModule {
 			echo '<div class="ds-cta-card-overlay" aria-hidden="true"></div>';
 			echo '<div class="ds-cta-card-body">';
 			if ( ! empty( $card->eyebrow ) ) {
-				echo '<div class="ds-cta-card-eyebrow">' . esc_html( $card->eyebrow ) . '</div>';
+				echo '<div class="ds-cta-card-eyebrow">' . DS_Module_UI::inline( $card->eyebrow ) . '</div>';
 			}
-			echo '<div class="ds-cta-card-row"><h3 class="ds-cta-card-title">' . esc_html( $card->title ?? '' ) . '</h3>';
+			echo '<div class="ds-cta-card-row"><h3 class="ds-cta-card-title">' . DS_Module_UI::inline( $card->title ?? '' ) . '</h3>';
 			echo '<span class="ds-cta-card-chevron" aria-hidden="true">&rsaquo;</span></div>';
 			echo '</div>';
 			echo '<span class="ds-cta-card-bar" aria-hidden="true"></span>';
@@ -172,8 +172,8 @@ class DS_CTA_Module extends FLBuilderModule {
 			echo '<div class="ds-cta-tile-bg"' . ( $img ? ' style="background-image:url(' . esc_url( $img ) . ')"' : '' ) . '></div>';
 			echo '<div class="ds-cta-tile-overlay" aria-hidden="true"></div>';
 			echo '<div class="ds-cta-tile-body">';
-			if ( ! empty( $card->eyebrow ) ) { echo '<div class="ds-cta-tile-num">' . esc_html( $card->eyebrow ) . '</div>'; }
-			echo '<h3 class="ds-cta-tile-title">' . esc_html( $card->title ?? '' ) . '</h3>';
+			if ( ! empty( $card->eyebrow ) ) { echo '<div class="ds-cta-tile-num">' . DS_Module_UI::inline( $card->eyebrow ) . '</div>'; }
+			echo '<h3 class="ds-cta-tile-title">' . DS_Module_UI::inline( $card->title ?? '' ) . '</h3>';
 			if ( '' !== $lt ) { echo '<span class="ds-cta-tile-go">' . esc_html( $lt ) . ' ' . $arrow . '</span>'; }
 			echo '</div>';
 			echo '</a>';
@@ -217,8 +217,8 @@ class DS_CTA_Module extends FLBuilderModule {
 
 			if ( 'text' === $type ) {
 				echo '<div class="ds-cta-bento-cell ds-cta-bento-text"' . $span . '>';
-				if ( ! empty( $cell->eyebrow ) ) { echo '<div class="ds-cta-bento-eyebrow">' . esc_html( $cell->eyebrow ) . '</div>'; }
-				if ( ! empty( $cell->title ) ) { echo '<h3 class="ds-cta-bento-title">' . esc_html( $cell->title ) . '</h3>'; }
+				if ( ! empty( $cell->eyebrow ) ) { echo '<div class="ds-cta-bento-eyebrow">' . DS_Module_UI::inline( $cell->eyebrow ) . '</div>'; }
+				if ( ! empty( $cell->title ) ) { echo '<h3 class="ds-cta-bento-title">' . DS_Module_UI::inline( $cell->title ) . '</h3>'; }
 				if ( ! empty( $cell->desc ) ) { echo '<div class="ds-cta-bento-celldesc">' . wpautop( wp_kses_post( $cell->desc ) ) . '</div>'; }
 				$lt = trim( (string) ( $cell->link_text ?? '' ) );
 				if ( '' !== $lt ) {
@@ -320,7 +320,7 @@ class DS_CTA_Module extends FLBuilderModule {
 		if ( ( $s->hero_show_eyebrow ?? 'yes' ) === 'yes' && ! empty( $s->hero_eyebrow ) ) {
 			echo '<div class="ds-cta-hero-eyebrow">';
 			if ( ( $s->hero_eyebrow_line ?? 'yes' ) === 'yes' ) { echo '<span class="ds-cta-hero-eyebrow-line" aria-hidden="true"></span>'; }
-			echo '<span>' . esc_html( $s->hero_eyebrow ) . '</span></div>';
+			echo '<span>' . DS_Module_UI::inline( $s->hero_eyebrow ) . '</span></div>';
 		}
 
 		// Heading.
@@ -629,6 +629,18 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 					'bento_radius' => array( 'type' => 'unit', 'label' => __( 'Cell Corner Radius', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 40, 'step' => 1 ), 'help' => __( 'Rounds every bento cell (image + text cells).', 'ds-toolkit' ) ),
 					'bento_border_width' => array( 'type' => 'unit', 'label' => __( 'Cell Border Width', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 10, 'step' => 1 ), 'help' => __( 'Border around every bento cell. Blank or 0 = no border.', 'ds-toolkit' ) ),
 					'bento_border_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Cell Border Colour', 'ds-toolkit' ), 'default' => 'var(--fl-global-line-color)', 'show_reset' => true, 'show_alpha' => true ),
+					'bento_shadow' => array(
+						'type'    => 'select',
+						'label'   => __( 'Cell Shadow', 'ds-toolkit' ),
+						'default' => '',
+						'options' => array(
+							''       => __( 'None', 'ds-toolkit' ),
+							'soft'   => __( 'Soft', 'ds-toolkit' ),
+							'medium' => __( 'Medium', 'ds-toolkit' ),
+							'strong' => __( 'Strong', 'ds-toolkit' ),
+						),
+						'help'    => __( 'Drop shadow on every bento cell.', 'ds-toolkit' ),
+					),
 					'bento_eyebrow_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Eyebrow Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true, 'help' => __( 'Colour of the cell eyebrow label. Blank = accent on text cells, white on image cells.', 'ds-toolkit' ), 'preview' => array( 'type' => 'css', 'selector' => '.ds-cta-bento-eyebrow', 'property' => 'color' ) ),
 					'bento_eyebrow_typography' => array( 'type' => 'typography', 'label' => __( 'Eyebrow Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-cta-bento-eyebrow' ) ),
 					'cell_bg'    => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Text Cell Background', 'ds-toolkit' ), 'default' => 'var(--fl-global-dark-background)', 'show_reset' => true ),

--- a/modules/ds-cta/includes/frontend.css.php
+++ b/modules/ds-cta/includes/frontend.css.php
@@ -94,6 +94,8 @@ if ( 'style3' === $style ) {
 	echo "$node .ds-cta-bento-cell { border-radius: {$brad}; }\n";
 
 	// Cell border (blank/0 width = none).
+	$bsh = array( 'soft' => '0 4px 14px rgba(0,0,0,.10)', 'medium' => '0 8px 24px rgba(0,0,0,.16)', 'strong' => '0 16px 40px rgba(0,0,0,.24)' )[ $settings->bento_shadow ?? '' ] ?? '';
+	if ( '' !== $bsh ) { echo "$node .ds-cta-bento-cell { box-shadow: {$bsh}; }\n"; }
 	$bbw = ( isset( $settings->bento_border_width ) && '' !== $settings->bento_border_width ) ? (int) $settings->bento_border_width : 0;
 	if ( $bbw > 0 ) {
 		$bbc = $col( $settings->bento_border_color ?? '' ) ?: 'var(--fl-global-line-color)';

--- a/modules/ds-heading/ds-heading.php
+++ b/modules/ds-heading/ds-heading.php
@@ -44,7 +44,7 @@ class DS_Heading_Module extends FLBuilderModule {
 
 	/** Heading markup: escape, {a}..{/a} -> accent span, newlines -> <br>. */
 	private function heading_html( $raw ) {
-		$h = esc_html( (string) $raw );
+		$h = DS_Module_UI::inline( (string) $raw ); // safe inline HTML (span/strong/em...) allowed
 		$h = str_replace( array( '{a}', '{/a}' ), array( '<span class="ds-heading-accent">', '</span>' ), $h );
 		return nl2br( $h );
 	}
@@ -56,7 +56,7 @@ class DS_Heading_Module extends FLBuilderModule {
 
 	/** Sub-heading element (always a <span>, optionally carrying an inline rule). */
 	private function subheading_html( $inline_rule ) {
-		$txt = '<span class="ds-heading-sub-text">' . esc_html( $this->settings->subheading ) . '</span>';
+		$txt = '<span class="ds-heading-sub-text">' . DS_Module_UI::inline( $this->settings->subheading ) . '</span>';
 		if ( $inline_rule ) {
 			return '<span class="ds-heading-sub ds-heading-sub--withrule">' . $this->rule_html() . $txt . '</span>';
 		}

--- a/modules/ds-hero/ds-hero.php
+++ b/modules/ds-hero/ds-hero.php
@@ -31,7 +31,7 @@ class DS_Hero_Module extends FLBuilderModule {
 
 	/** Heading markup: escape, turn {a}..{/a} into an accent span, newlines into <br>. */
 	private function heading_html( $raw ) {
-		$h = esc_html( (string) $raw );
+		$h = DS_Module_UI::inline( (string) $raw ); // safe inline HTML (span/strong/em...) allowed
 		$h = str_replace( array( '{a}', '{/a}' ), array( '<span class="ds-hero-accent">', '</span>' ), $h );
 		return nl2br( $h );
 	}

--- a/modules/ds-info-list/ds-info-list.php
+++ b/modules/ds-info-list/ds-info-list.php
@@ -109,7 +109,7 @@ class DS_Info_List_Module extends FLBuilderModule {
 			$icon  = trim( (string) ( $it->icon ?? '' ) );
 
 			$ic    = '' !== $icon ? '<span class="ds-info-ico"><i class="' . esc_attr( $icon ) . '" aria-hidden="true"></i></span>' : '';
-			$inner = $ic . '<span class="ds-info-text">' . esc_html( $text ) . '</span>';
+			$inner = $ic . '<span class="ds-info-text">' . DS_Module_UI::inline( $text ) . '</span>';
 
 			if ( '' !== $href ) {
 				$ext  = ( 0 === strpos( $href, 'http' ) ) ? ' target="_blank" rel="noopener noreferrer"' : '';

--- a/modules/ds-marquee/ds-marquee.php
+++ b/modules/ds-marquee/ds-marquee.php
@@ -70,7 +70,7 @@ class DS_Marquee_Module extends FLBuilderModule {
 				esc_html( $text )
 			);
 		}
-		return '<span class="ds-marquee-item">' . esc_html( $text ) . '</span>';
+		return '<span class="ds-marquee-item">' . DS_Module_UI::inline( $text ) . '</span>';
 	}
 
 	/** Build one full group: every item followed by a separator glyph. */
@@ -120,7 +120,7 @@ class DS_Marquee_Module extends FLBuilderModule {
 			if ( ( $s->show_dot ?? 'yes' ) === 'yes' ) {
 				echo '<span class="ds-marquee-dot" aria-hidden="true"></span>';
 			}
-			echo '<span class="ds-marquee-label-text">' . esc_html( $s->label_text ) . '</span>';
+			echo '<span class="ds-marquee-label-text">' . DS_Module_UI::inline( $s->label_text ) . '</span>';
 			echo '</div>';
 		}
 

--- a/modules/ds-orgstats/ds-orgstats.php
+++ b/modules/ds-orgstats/ds-orgstats.php
@@ -92,7 +92,7 @@ class DS_OrgStats_Module extends FLBuilderModule {
 			echo '<div class="ds-orgstats-head">';
 			if ( ! empty( $s->eyebrow ) ) {
 				$erule = in_array( $s->eyebrow_rule ?? 'before', array( 'none', 'before', 'both' ), true ) ? ( $s->eyebrow_rule ?? 'before' ) : 'before';
-				echo '<span class="ds-orgstats-eyebrow ds-orgstats-eyebrow--rule-' . esc_attr( $erule ) . '">' . esc_html( $s->eyebrow ) . '</span>';
+				echo '<span class="ds-orgstats-eyebrow ds-orgstats-eyebrow--rule-' . esc_attr( $erule ) . '">' . DS_Module_UI::inline( $s->eyebrow ) . '</span>';
 			}
 			if ( ! empty( $s->heading ) ) {
 				echo '<h2 class="ds-orgstats-heading">' . $this->heading_html( $s->heading ) . '</h2>';
@@ -142,7 +142,7 @@ class DS_OrgStats_Module extends FLBuilderModule {
 			echo '<span class="ds-orgstats-value">' . esc_html( $number ) . '</span>';
 			if ( '' !== $suffix ) { echo '<span class="ds-orgstats-affix ds-orgstats-suffix">' . esc_html( $suffix ) . '</span>'; }
 			echo '</div>';
-			if ( '' !== $label ) { echo '<div class="ds-orgstats-label">' . esc_html( $label ) . '</div>'; }
+			if ( '' !== $label ) { echo '<div class="ds-orgstats-label">' . DS_Module_UI::inline( $label ) . '</div>'; }
 			if ( $cards ) { echo '</div>'; }
 			echo '</div>';
 		}

--- a/modules/ds-team-detail/ds-team-detail.php
+++ b/modules/ds-team-detail/ds-team-detail.php
@@ -42,7 +42,7 @@ class DS_Team_Detail_Module extends FLBuilderModule {
 	private function section_html( $title, $tag, $body, $extra_class = '' ) {
 		$head = '';
 		if ( '' !== trim( (string) $title ) ) {
-			$head  = '<' . $tag . ' class="ds-teamdetail-title">' . esc_html( $title ) . '</' . $tag . '>';
+			$head  = '<' . $tag . ' class="ds-teamdetail-title">' . DS_Module_UI::inline( $title ) . '</' . $tag . '>';
 			if ( ( $this->settings->divider_show ?? 'yes' ) === 'yes' ) {
 				$head .= '<span class="ds-teamdetail-divider" aria-hidden="true"></span>';
 			}


### PR DESCRIPTION
Three additive fixes from user reports:
- **Inline HTML in title fields** — `<span>` (and strong/em/b/i/u/small/mark/br) now renders in module title/eyebrow/label fields via a shared kses whitelist (`DS_Module_UI::inline()`); previously `esc_html` printed it literally. Swept across Hero, Heading, CTA, Team Detail, Org Stats, Marquee, Info List. Post titles stay escaped.
- **Image Carousel Height** — Sizing → Height (Small 300 / Medium 420 / Tall 560 / Custom responsive px) replaces the aspect ratio with a fixed deck height; the `height-small/medium/tall` utility classes also work now.
- **CTA Bento Cell Shadow** — None/Soft/Medium/Strong, joining the 1.9.3 border controls.

All files lint clean (PHP 8.2). Shipped per user call without live verification (DS6 local env was down); typography-inheritance report still under investigation separately.