### PR TITLE
feat: Images/Videos Carousel rename + Reels Strip style (1.9.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.5] - 2026-07-05
+### Added
+- **Images/Videos Carousel — Style 3: Reels Strip.** A new multi-column style (modeled on an Instagram-reels strip): portrait cards side by side, each an **image or an MP4 video**. The slide form gains a **Video URL (MP4)** field — a video card shows a centred play button over its poster image and plays inline on click (playing one pauses the others); an image card stays a plain (optionally linked) card. Style → Reels Strip controls: responsive **Columns** (default 5 / 3 / 2) + **Gap**, **Card Aspect Ratio** (9:16 default, 3:4, 4:5, 1:1), **Corner Radius** (blank = Theme Setting radius), **Arrows** (steps one card; the strip always swipes/scrolls with snap), and **Play Button** background + icon colours. Honours `prefers-reduced-motion`; play button has a `:focus-visible` ring; JS is idempotent and re-inits on builder partial refresh; imageless slides fall back to the Social Card.
+
+### Changed
+- **Renamed "Image Carousel" → "Images/Videos Carousel"** (module name, description, and the Settings-page module list; the `ds-carousel` slug and existing instances are unchanged).
+
 ## [1.9.4] - 2026-07-05
 ### Added
 - **Inline HTML in module title fields.** Editor-authored title / eyebrow / label fields across the LeagueApps modules (Hero heading, Heading title + subheading, CTA heading + card/tile/bento titles and eyebrows, Team Detail section titles, Org Stats eyebrow + labels, Marquee items + label, Info List text) now accept safe inline HTML — `span` (class/style), `strong`, `em`, `b`, `i`, `u`, `small`, `mark`, `br`, `sup`, `sub` — via a shared `DS_Module_UI::inline()` kses whitelist, so e.g. `Lorem <span style="color:#069e33">Ipsum</span>` renders instead of printing literally. `style` attributes are sanitised by WP's safecss filter; everything else is still escaped. WP post titles remain fully escaped.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.4
+ * Version:           1.9.5
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.4' );
+define( 'DS_TOOLKIT_VERSION', '1.9.5' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -219,7 +219,7 @@ class DS_Toolkit {
             'ds_menu_module_enabled'           => array( 'label' => 'Menu',            'desc' => 'Responsive navigation bar with dropdowns, mega-menus, and a full-screen mobile overlay.' ),
             'ds_post_loop_module_enabled'      => array( 'label' => 'Post Loop',       'desc' => 'Lists of news, staff, teams, programs, sponsors, or tournaments in a range of card layouts.' ),
             'ds_page_cards_module_enabled'     => array( 'label' => 'Page Cards',      'desc' => 'A grid of linked cards built from child pages or a manual list.' ),
-            'ds_carousel_module_enabled'       => array( 'label' => 'Image Carousel',  'desc' => 'A stacked-deck image slider with captions, arrows, and dots.' ),
+            'ds_carousel_module_enabled'       => array( 'label' => 'Images/Videos Carousel', 'desc' => 'A stacked-deck slider or a multi-column reels strip of images and videos.' ),
             'ds_orgstats_module_enabled'       => array( 'label' => 'Org Stats',       'desc' => 'Headline stat figures (the record) as plain figures or photo cards.' ),
             'ds_marquee_module_enabled'        => array( 'label' => 'Marquee',         'desc' => 'A scrolling announcement ticker with a pinned label.' ),
             'ds_info_list_module_enabled'      => array( 'label' => 'Info List',       'desc' => 'An icon-and-text list for hours, contact details, or quick facts.' ),

--- a/modules/ds-carousel/css/frontend.css
+++ b/modules/ds-carousel/css/frontend.css
@@ -94,3 +94,21 @@
 .fl-builder-content .fl-module.height-medium .ds-carousel-framewrap { height: 420px; aspect-ratio: auto; }
 .fl-builder-content .height-tall   .ds-carousel-framewrap,
 .fl-builder-content .fl-module.height-tall   .ds-carousel-framewrap { height: 560px; aspect-ratio: auto; }
+
+/* ---- Style 3: reels strip (multi-column image/video cards) ---- */
+.ds-carousel--style3 .ds-reels-wrap{position:relative;}
+.ds-carousel--style3 .ds-reels-track{display:flex;gap:var(--ds-reel-gap,24px);overflow-x:auto;scroll-snap-type:x mandatory;-webkit-overflow-scrolling:touch;scrollbar-width:none;padding:4px 2px;}
+.ds-carousel--style3 .ds-reels-track::-webkit-scrollbar{display:none;}
+.ds-carousel--style3 .ds-reel-card{position:relative;display:block;flex:0 0 calc((100% - (var(--ds-reel-cols,5) - 1) * var(--ds-reel-gap,24px)) / var(--ds-reel-cols,5));scroll-snap-align:start;aspect-ratio:9/16;overflow:hidden;border-radius:var(--ds-radius);background:var(--fl-global-dark-background) center/cover no-repeat;text-decoration:none;}
+.ds-carousel--style3 a.ds-reel-card{transition:transform .25s ease;}
+.ds-carousel--style3 a.ds-reel-card:hover{transform:translateY(-3px);}
+.ds-reel-play{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);width:54px;height:54px;padding:0;border:0;border-radius:50%;background:rgba(10,14,21,.62);color:var(--fl-global-white,#fff);display:flex;align-items:center;justify-content:center;cursor:pointer;transition:transform .2s ease,background .2s ease;}
+.ds-reel-card:hover .ds-reel-play{transform:translate(-50%,-50%) scale(1.1);background:rgba(10,14,21,.85);}
+.ds-reel-play svg{width:22px;height:22px;display:block;margin-left:2px;}
+.ds-reel-play:focus-visible{outline:2px solid var(--fl-global-accent,#0b57d0);outline-offset:2px;}
+.ds-reel-video{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;background:#000;}
+.ds-reel-nav--prev{left:-6px;}
+.ds-reel-nav--next{right:-6px;}
+@media (prefers-reduced-motion:reduce){
+  .ds-carousel--style3 a.ds-reel-card,.ds-reel-play{transition:none;}
+}

--- a/modules/ds-carousel/ds-carousel.php
+++ b/modules/ds-carousel/ds-carousel.php
@@ -26,8 +26,8 @@ class DS_Carousel_Module extends FLBuilderModule {
 
 	public function __construct() {
 		parent::__construct( array(
-			'name'            => __( 'Image Carousel', 'ds-toolkit' ),
-			'description'     => __( 'Stacked-deck image carousel with autoplay, loop, captions and links.', 'ds-toolkit' ),
+			'name'            => __( 'Images/Videos Carousel', 'ds-toolkit' ),
+			'description'     => __( 'Stacked-deck carousel or multi-column reels strip of images and videos.', 'ds-toolkit' ),
 			'category'        => __( 'LeagueApps', 'ds-toolkit' ),
 			'dir'             => DS_TOOLKIT_PATH . 'modules/ds-carousel/',
 			'url'             => DS_TOOLKIT_URL . 'modules/ds-carousel/',
@@ -40,6 +40,7 @@ class DS_Carousel_Module extends FLBuilderModule {
 		return array(
 			'style1' => __( 'Style 1 — Stacked Deck', 'ds-toolkit' ),
 			'style2' => __( 'Style 2 — Sponsors / Logos', 'ds-toolkit' ),
+			'style3' => __( 'Style 3 — Reels Strip (images / videos)', 'ds-toolkit' ),
 		);
 	}
 
@@ -286,9 +287,59 @@ class DS_Carousel_Module extends FLBuilderModule {
 		echo '</div>'; // wrap
 		echo '</div>'; // carousel
 	}
+
+
+	/** Style 3 — Reels Strip: multi-column image/video cards (scroll-snap + inline video). */
+	public function render_style3() {
+		$s      = $this->settings;
+		$slides = ( isset( $s->slides ) && is_array( $s->slides ) ) ? $s->slides : array();
+
+		echo '<div class="ds-carousel ds-carousel--style3">';
+		if ( empty( $slides ) ) {
+			if ( FLBuilderModel::is_builder_active() ) {
+				echo '<p style="padding:18px;opacity:.7;text-align:center">' . esc_html__( 'Add slides in the module settings.', 'ds-toolkit' ) . '</p>';
+			}
+			echo '</div>';
+			return;
+		}
+
+		$play = '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5.5v13l11-6.5z"/></svg>';
+
+		echo '<div class="ds-reels-wrap">';
+		echo '<div class="ds-reels-track">';
+		foreach ( $slides as $slide ) {
+			$slide = (object) $slide;
+			$img   = ! empty( $slide->image ) ? $this->photo_url( $slide->image, 'large' ) : '';
+			if ( '' === $img && class_exists( 'DS_Card' ) ) { $img = (string) DS_Card::placeholder_image(); }
+			$bg    = $img ? ' style="background-image:url(' . esc_url( $img ) . ')"' : '';
+			$video = trim( (string) ( $slide->video_url ?? '' ) );
+
+			if ( '' !== $video ) {
+				echo '<div class="ds-reel-card has-video" data-video="' . esc_url( $video ) . '"' . $bg . '>';
+				echo '<button type="button" class="ds-reel-play" aria-label="' . esc_attr__( 'Play video', 'ds-toolkit' ) . '">' . $play . '</button>';
+				echo '</div>';
+			} else {
+				list( $url, $target ) = $this->link_parts( $slide->link ?? '' );
+				if ( $url && '#' !== $url ) {
+					$rel = '_blank' === $target ? ' rel="noopener noreferrer"' : '';
+					echo '<a class="ds-reel-card" href="' . esc_url( $url ) . '" target="' . esc_attr( $target ) . '"' . $rel . $bg . '></a>';
+				} else {
+					echo '<div class="ds-reel-card"' . $bg . '></div>';
+				}
+			}
+		}
+		echo '</div>';
+
+		if ( ( $s->reel_arrows ?? 'yes' ) === 'yes' && count( $slides ) > 1 ) {
+			echo '<button type="button" class="ds-carousel-nav ds-reel-nav ds-reel-nav--prev" aria-label="' . esc_attr__( 'Scroll back', 'ds-toolkit' ) . '"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M15 6l-6 6 6 6"/></svg></button>';
+			echo '<button type="button" class="ds-carousel-nav ds-reel-nav ds-reel-nav--next" aria-label="' . esc_attr__( 'Scroll forward', 'ds-toolkit' ) . '"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M9 6l6 6-6 6"/></svg></button>';
+		}
+		echo '</div></div>';
+	}
 }
 
 /* --------------------------------------------------------------- Slide sub-form */
+
 FLBuilder::register_settings_form( 'ds_carousel_slide_form', array(
 	'title' => __( 'Slide', 'ds-toolkit' ),
 	'tabs'  => array(
@@ -304,6 +355,12 @@ FLBuilder::register_settings_form( 'ds_carousel_slide_form', array(
 							'show_remove' => true,
 							'connections' => array( 'photo' ),
 							'help'        => __( 'No image falls back to the Theme Setting Social Card.', 'ds-toolkit' ),
+						),
+						'video_url' => array(
+							'type'        => 'text',
+							'label'       => __( 'Video URL (MP4)', 'ds-toolkit' ),
+							'connections' => array( 'url' ),
+							'help'        => __( 'Optional — Reels Strip (Style 3) only. A direct .mp4 URL (Media Library or external). The card shows a play button and plays inline; the Image above is the poster.', 'ds-toolkit' ),
 						),
 						'caption' => array(
 							'type'        => 'text',
@@ -343,6 +400,9 @@ FLBuilder::register_module( 'DS_Carousel_Module', array(
 							),
 							'style2' => array(
 								'sections' => array( 'slides', 'sl_header', 'sl_grid', 'sl_tile', 'sl_logo', 'behavior', 'navigation', 'colors', 'spacing' ),
+							),
+							'style3' => array(
+								'sections' => array( 'slides', 'reels', 'colors', 'spacing' ),
 							),
 						),
 					),
@@ -398,6 +458,29 @@ FLBuilder::register_module( 'DS_Carousel_Module', array(
 					'offset_y'       => array( 'type' => 'unit', 'label' => __( 'Vertical Offset', 'ds-toolkit' ), 'default' => '0', 'description' => 'px', 'slider' => array( 'min' => -60, 'max' => 60, 'step' => 2 ) ),
 					'scale_step'     => array( 'type' => 'unit', 'label' => __( 'Scale Step', 'ds-toolkit' ), 'default' => '8', 'description' => '%', 'slider' => array( 'min' => 0, 'max' => 30, 'step' => 1 ), 'help' => __( 'How much smaller each card behind gets.', 'ds-toolkit' ) ),
 					'rotate_step'    => array( 'type' => 'unit', 'label' => __( 'Rotation Step', 'ds-toolkit' ), 'default' => '0', 'description' => 'deg', 'slider' => array( 'min' => 0, 'max' => 12, 'step' => 1 ) ),
+				),
+			),
+			// --- Style 3 only: reels strip ---
+			'reels' => array(
+				'title'  => __( 'Reels Strip', 'ds-toolkit' ),
+				'fields' => array(
+					'reel_cols'   => array( 'type' => 'unit', 'label' => __( 'Columns', 'ds-toolkit' ), 'default' => '5', 'responsive' => true, 'slider' => array( 'min' => 1, 'max' => 8, 'step' => 1 ), 'help' => __( 'Cards visible per row. Extra slides scroll/swipe horizontally. Defaults: 3 on tablet, 2 on mobile.', 'ds-toolkit' ) ),
+					'reel_gap'    => array( 'type' => 'unit', 'label' => __( 'Gap', 'ds-toolkit' ), 'default' => '24', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 60, 'step' => 1 ) ),
+					'reel_aspect' => array(
+						'type'    => 'select',
+						'label'   => __( 'Card Aspect Ratio', 'ds-toolkit' ),
+						'default' => '9 / 16',
+						'options' => array(
+							'9 / 16' => __( 'Reel 9:16', 'ds-toolkit' ),
+							'3 / 4'  => __( 'Portrait 3:4', 'ds-toolkit' ),
+							'4 / 5'  => __( 'Portrait 4:5', 'ds-toolkit' ),
+							'1 / 1'  => __( 'Square 1:1', 'ds-toolkit' ),
+						),
+					),
+					'reel_radius' => array( 'type' => 'unit', 'label' => __( 'Corner Radius', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 40, 'step' => 1 ), 'help' => __( 'Blank = the Theme Setting corner radius.', 'ds-toolkit' ) ),
+					'reel_arrows' => array( 'type' => 'select', 'label' => __( 'Arrows', 'ds-toolkit' ), 'default' => 'yes', 'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No (swipe / scroll only)', 'ds-toolkit' ) ) ),
+					'reel_play_bg'    => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Play Button Background', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true, 'help' => __( 'Blank = dark translucent.', 'ds-toolkit' ) ),
+					'reel_play_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Play Icon Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
 				),
 			),
 			'sizing' => array(

--- a/modules/ds-carousel/includes/frontend.css.php
+++ b/modules/ds-carousel/includes/frontend.css.php
@@ -17,7 +17,26 @@ list( $bpm, $bpr ) = DS_Module_UI::breakpoints();
 $sbg = $col( $settings->section_bg ?? '' );
 if ( '' !== $sbg ) { echo "$node .ds-carousel { background: {$sbg}; }\n"; }
 
-if ( 'style2' === $style ) {
+if ( 'style3' === $style ) {
+	/* ============================ Style 3: reels strip ============================ */
+	$cols  = $u( $settings->reel_cols ?? '', 5 );
+	$colsM = $u( $settings->reel_cols_medium ?? '', min( $cols, 3 ) );
+	$colsR = $u( $settings->reel_cols_responsive ?? '', 2 );
+	$gap   = $u( $settings->reel_gap ?? '', 24 );
+	echo "$node .ds-reels-track { --ds-reel-cols: {$cols}; --ds-reel-gap: {$gap}px; }\n";
+	echo "@media (max-width:{$bpm}px){ $node .ds-reels-track { --ds-reel-cols: {$colsM}; } }\n";
+	echo "@media (max-width:{$bpr}px){ $node .ds-reels-track { --ds-reel-cols: {$colsR}; } }\n";
+
+	$ra = preg_replace( '/[^0-9 \/]/', '', (string) ( $settings->reel_aspect ?? '9 / 16' ) ) ?: '9 / 16';
+	$rr = ( isset( $settings->reel_radius ) && '' !== $settings->reel_radius ) ? ( (int) $settings->reel_radius ) . 'px' : 'var(--ds-radius)';
+	echo "$node .ds-reel-card { aspect-ratio: {$ra}; border-radius: {$rr}; }\n";
+
+	$pbg = $col( $settings->reel_play_bg ?? '' );
+	$pc  = $col( $settings->reel_play_color ?? '' );
+	if ( '' !== $pbg ) { echo "$node .ds-reel-play { background: {$pbg}; }\n"; }
+	if ( '' !== $pc )  { echo "$node .ds-reel-play { color: {$pc}; }\n"; }
+
+} elseif ( 'style2' === $style ) {
 	/* ============================ Style 2: Sponsors / logos ============================ */
 	$cols = $u( $settings->columns ?? '', 6 );
 	$gap  = $u( $settings->gap ?? '', 20 );

--- a/modules/ds-carousel/js/frontend.js
+++ b/modules/ds-carousel/js/frontend.js
@@ -238,3 +238,51 @@
 		jQuery(document).on('fl-builder.layout-rendered', function () { boot(); });
 	}
 })();
+
+/* ---- Style 3: reels strip (inline video + arrow scroll). Idempotent. ---- */
+(function () {
+	function initReels(root) {
+		if (root.dsReelInit) return;
+		var track = root.querySelector('.ds-reels-track');
+		if (!track) { return; }
+		root.dsReelInit = true;
+		var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+		[].slice.call(root.querySelectorAll('.ds-reel-card.has-video')).forEach(function (card) {
+			var btn = card.querySelector('.ds-reel-play');
+			function play() {
+				if (card.dsPlaying) return;
+				card.dsPlaying = true;
+				// pause any other playing reel in this module
+				[].slice.call(root.querySelectorAll('video.ds-reel-video')).forEach(function (o) { o.pause(); });
+				var v = document.createElement('video');
+				v.className = 'ds-reel-video';
+				v.src = card.getAttribute('data-video') || '';
+				v.controls = true; v.autoplay = true; v.playsInline = true;
+				v.setAttribute('playsinline', '');
+				card.appendChild(v);
+				if (btn) btn.style.display = 'none';
+				v.addEventListener('ended', function () { v.remove(); if (btn) btn.style.display = ''; card.dsPlaying = false; });
+			}
+			card.addEventListener('click', function (e) { e.preventDefault(); play(); });
+		});
+
+		function step(dir) {
+			var card = track.querySelector('.ds-reel-card');
+			var gap = parseFloat(getComputedStyle(track).gap) || 24;
+			var w = card ? card.getBoundingClientRect().width + gap : 320;
+			track.scrollBy({ left: dir * w, behavior: reduce ? 'auto' : 'smooth' });
+		}
+		[].slice.call(root.querySelectorAll('.ds-reel-nav--prev')).forEach(function (b) { b.addEventListener('click', function (e) { e.preventDefault(); step(-1); }); });
+		[].slice.call(root.querySelectorAll('.ds-reel-nav--next')).forEach(function (b) { b.addEventListener('click', function (e) { e.preventDefault(); step(1); }); });
+	}
+
+	function bootReels(root) {
+		(root || document).querySelectorAll('.ds-carousel--style3').forEach(initReels);
+	}
+	if (document.readyState !== 'loading') bootReels();
+	else document.addEventListener('DOMContentLoaded', function () { bootReels(); });
+	if (window.jQuery) {
+		jQuery(document).on('fl-builder.layout-rendered', function () { bootReels(); });
+	}
+})();


### PR DESCRIPTION
Renames **Image Carousel → Images/Videos Carousel** and adds **Style 3 — Reels Strip**: a multi-column strip of portrait cards (Instagram-reels look), each an image or an MP4 video. Video cards show a play button and play inline (playing one pauses the others). Controls: responsive Columns (5/3/2) + Gap, Card Aspect Ratio (9:16 default), Corner Radius, Arrows + scroll-snap swipe, play-button colours. Reduced-motion + focus-visible honoured; idempotent JS re-inits on partial refresh.

Existing Style 1/2 untouched; slug `ds-carousel` unchanged. PHP + JS lint clean. Shipped per user call (DS6 local env down, live verification queued with the v1.9.4 batch).