### PR TITLE
fix: Post Loop titles + theme-button sync; Reels media video, autoplay, play styles (1.9.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.6] - 2026-07-06
+### Added
+- **Reels Strip — Media Library videos.** New **Video (Media Library)** field per slide (Beaver's native video picker) for uploading/picking MP4s; takes priority over the Video URL field (kept for externally-hosted files).
+- **Reels Strip — Autoplay Videos.** Optional Instagram-style behaviour: videos autoplay muted + looped while on screen and pause off-screen (IntersectionObserver); click pauses/resumes. Reduced-motion visitors get click-to-play instead.
+- **Reels Strip — Play Button styles.** Circle (default), **Icon only** (no circle, larger glyph with drop shadow), or **Hidden** (the whole card is the play target). Colour fields show per style; the button auto-hides in autoplay mode.
+
+### Fixed
+- **Post Loop — inline HTML now works in titles.** The section heading and every card title (featured / news grid / card grid / tournament / program / staff names + roles / team names / the `{title}` custom-loop token) now go through the shared safe inline-HTML whitelist, so `<span>` styling renders instead of printing literally. Also swept the last stragglers elsewhere: Page Cards titles, Team Detail coaches-section title, and Images/Videos Carousel captions.
+- **Post Loop — Tournament button now follows Theme Setting → Elements → Button** (background, text, hover, border-radius, typography). It previously only borrowed the button colour with a hardcoded 6px radius.
+- **Page Cards — the "Button (follows theme)" link style now actually follows the theme Button** (bg, text, hover, radius, typography); it previously had no sync behind the label.
+- **Reels Strip — clicks on the native video controls** (pause / scrub / fullscreen) no longer re-trigger the card's play handler.
+
 ## [1.9.5] - 2026-07-05
 ### Added
 - **Images/Videos Carousel — Style 3: Reels Strip.** A new multi-column style (modeled on an Instagram-reels strip): portrait cards side by side, each an **image or an MP4 video**. The slide form gains a **Video URL (MP4)** field — a video card shows a centred play button over its poster image and plays inline on click (playing one pauses the others); an image card stays a plain (optionally linked) card. Style → Reels Strip controls: responsive **Columns** (default 5 / 3 / 2) + **Gap**, **Card Aspect Ratio** (9:16 default, 3:4, 4:5, 1:1), **Corner Radius** (blank = Theme Setting radius), **Arrows** (steps one card; the strip always swipes/scrolls with snap), and **Play Button** background + icon colours. Honours `prefers-reduced-motion`; play button has a `:focus-visible` ring; JS is idempotent and re-inits on builder partial refresh; imageless slides fall back to the Social Card.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.5
+ * Version:           1.9.6
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.5' );
+define( 'DS_TOOLKIT_VERSION', '1.9.6' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-carousel/css/frontend.css
+++ b/modules/ds-carousel/css/frontend.css
@@ -106,6 +106,10 @@
 .ds-reel-card:hover .ds-reel-play{transform:translate(-50%,-50%) scale(1.1);background:rgba(10,14,21,.85);}
 .ds-reel-play svg{width:22px;height:22px;display:block;margin-left:2px;}
 .ds-reel-play:focus-visible{outline:2px solid var(--fl-global-accent,#0b57d0);outline-offset:2px;}
+.ds-reel-play--plain{background:none !important;width:auto;height:auto;filter:drop-shadow(0 2px 10px rgba(0,0,0,.55));}
+.ds-reel-play--plain svg{width:44px;height:44px;margin-left:0;}
+.ds-reel-card:hover .ds-reel-play--plain{transform:translate(-50%,-50%) scale(1.12);}
+.ds-reel-card.has-video{cursor:pointer;}
 .ds-reel-video{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;background:#000;}
 .ds-reel-nav--prev{left:-6px;}
 .ds-reel-nav--next{right:-6px;}

--- a/modules/ds-carousel/ds-carousel.php
+++ b/modules/ds-carousel/ds-carousel.php
@@ -164,7 +164,7 @@ class DS_Carousel_Module extends FLBuilderModule {
 				echo '<span class="ds-carousel-img" style="background-image:url(' . esc_url( $slide['image'] ) . ')"></span>';
 			}
 			if ( '' !== $slide['caption'] ) {
-				echo '<span class="ds-carousel-caption">' . esc_html( $slide['caption'] ) . '</span>';
+				echo '<span class="ds-carousel-caption">' . DS_Module_UI::inline( $slide['caption'] ) . '</span>';
 			}
 			echo '</' . $tag . '>';
 		}
@@ -306,17 +306,26 @@ class DS_Carousel_Module extends FLBuilderModule {
 		$play = '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5.5v13l11-6.5z"/></svg>';
 
 		echo '<div class="ds-reels-wrap">';
-		echo '<div class="ds-reels-track">';
+		echo '<div class="ds-reels-track" data-autoplay="' . esc_attr( ( $s->reel_autoplay ?? 'no' ) === 'yes' ? 'yes' : 'no' ) . '">';
 		foreach ( $slides as $slide ) {
 			$slide = (object) $slide;
 			$img   = ! empty( $slide->image ) ? $this->photo_url( $slide->image, 'large' ) : '';
 			if ( '' === $img && class_exists( 'DS_Card' ) ) { $img = (string) DS_Card::placeholder_image(); }
 			$bg    = $img ? ' style="background-image:url(' . esc_url( $img ) . ')"' : '';
-			$video = trim( (string) ( $slide->video_url ?? '' ) );
+			// Media Library video (attachment id) wins; else a direct URL.
+			$video = '';
+			if ( ! empty( $slide->video_media ) ) {
+				$vm = is_object( $slide->video_media ) ? ( $slide->video_media->id ?? 0 ) : ( is_array( $slide->video_media ) ? ( $slide->video_media['id'] ?? 0 ) : $slide->video_media );
+				if ( is_numeric( $vm ) ) { $video = (string) wp_get_attachment_url( (int) $vm ); }
+			}
+			if ( '' === $video ) { $video = trim( (string) ( $slide->video_url ?? '' ) ); }
 
 			if ( '' !== $video ) {
 				echo '<div class="ds-reel-card has-video" data-video="' . esc_url( $video ) . '"' . $bg . '>';
-				echo '<button type="button" class="ds-reel-play" aria-label="' . esc_attr__( 'Play video', 'ds-toolkit' ) . '">' . $play . '</button>';
+				$pstyle = $s->reel_play_style ?? 'circle';
+				if ( 'none' !== $pstyle && ( $s->reel_autoplay ?? 'no' ) !== 'yes' ) {
+					echo '<button type="button" class="ds-reel-play' . ( 'plain' === $pstyle ? ' ds-reel-play--plain' : '' ) . '" aria-label="' . esc_attr__( 'Play video', 'ds-toolkit' ) . '">' . $play . '</button>';
+				}
 				echo '</div>';
 			} else {
 				list( $url, $target ) = $this->link_parts( $slide->link ?? '' );
@@ -356,11 +365,16 @@ FLBuilder::register_settings_form( 'ds_carousel_slide_form', array(
 							'connections' => array( 'photo' ),
 							'help'        => __( 'No image falls back to the Theme Setting Social Card.', 'ds-toolkit' ),
 						),
+						'video_media' => array(
+							'type'  => 'video',
+							'label' => __( 'Video (Media Library)', 'ds-toolkit' ),
+							'help'  => __( 'Optional — Reels Strip (Style 3) only. Upload / pick an MP4 from the Media Library. Takes priority over the Video URL below; the Image above is the poster.', 'ds-toolkit' ),
+						),
 						'video_url' => array(
 							'type'        => 'text',
 							'label'       => __( 'Video URL (MP4)', 'ds-toolkit' ),
 							'connections' => array( 'url' ),
-							'help'        => __( 'Optional — Reels Strip (Style 3) only. A direct .mp4 URL (Media Library or external). The card shows a play button and plays inline; the Image above is the poster.', 'ds-toolkit' ),
+							'help'        => __( 'Optional — Reels Strip (Style 3) only. A direct .mp4 URL if the video is hosted elsewhere.', 'ds-toolkit' ),
 						),
 						'caption' => array(
 							'type'        => 'text',
@@ -479,6 +493,27 @@ FLBuilder::register_module( 'DS_Carousel_Module', array(
 					),
 					'reel_radius' => array( 'type' => 'unit', 'label' => __( 'Corner Radius', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 40, 'step' => 1 ), 'help' => __( 'Blank = the Theme Setting corner radius.', 'ds-toolkit' ) ),
 					'reel_arrows' => array( 'type' => 'select', 'label' => __( 'Arrows', 'ds-toolkit' ), 'default' => 'yes', 'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No (swipe / scroll only)', 'ds-toolkit' ) ) ),
+			'reel_autoplay' => array(
+				'type'    => 'select',
+				'label'   => __( 'Autoplay Videos', 'ds-toolkit' ),
+				'default' => 'no',
+				'options' => array( 'no' => __( 'No (click to play)', 'ds-toolkit' ), 'yes' => __( 'Yes (muted loop when visible)', 'ds-toolkit' ) ),
+				'help'    => __( 'Videos autoplay muted and looped while on screen (like Instagram reels) and pause off-screen. Click pauses/resumes. Visitors with reduced-motion get click-to-play instead.', 'ds-toolkit' ),
+			),
+			'reel_play_style' => array(
+				'type'    => 'select',
+				'label'   => __( 'Play Button', 'ds-toolkit' ),
+				'default' => 'circle',
+				'options' => array(
+					'circle' => __( 'Circle (default)', 'ds-toolkit' ),
+					'plain'  => __( 'Icon only (no circle)', 'ds-toolkit' ),
+					'none'   => __( 'Hidden (whole card plays)', 'ds-toolkit' ),
+				),
+				'toggle'  => array(
+					'circle' => array( 'fields' => array( 'reel_play_bg', 'reel_play_color' ) ),
+					'plain'  => array( 'fields' => array( 'reel_play_color' ) ),
+				),
+			),
 					'reel_play_bg'    => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Play Button Background', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true, 'help' => __( 'Blank = dark translucent.', 'ds-toolkit' ) ),
 					'reel_play_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Play Icon Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
 				),

--- a/modules/ds-carousel/js/frontend.js
+++ b/modules/ds-carousel/js/frontend.js
@@ -239,7 +239,7 @@
 	}
 })();
 
-/* ---- Style 3: reels strip (inline video + arrow scroll). Idempotent. ---- */
+/* ---- Style 3: reels strip (inline/auto video + arrow scroll). Idempotent. ---- */
 (function () {
 	function initReels(root) {
 		if (root.dsReelInit) return;
@@ -247,25 +247,64 @@
 		if (!track) { return; }
 		root.dsReelInit = true;
 		var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+		var auto   = track.getAttribute('data-autoplay') === 'yes' && !reduce;
 
-		[].slice.call(root.querySelectorAll('.ds-reel-card.has-video')).forEach(function (card) {
-			var btn = card.querySelector('.ds-reel-play');
-			function play() {
-				if (card.dsPlaying) return;
-				card.dsPlaying = true;
-				// pause any other playing reel in this module
-				[].slice.call(root.querySelectorAll('video.ds-reel-video')).forEach(function (o) { o.pause(); });
-				var v = document.createElement('video');
-				v.className = 'ds-reel-video';
-				v.src = card.getAttribute('data-video') || '';
-				v.controls = true; v.autoplay = true; v.playsInline = true;
-				v.setAttribute('playsinline', '');
-				card.appendChild(v);
-				if (btn) btn.style.display = 'none';
-				v.addEventListener('ended', function () { v.remove(); if (btn) btn.style.display = ''; card.dsPlaying = false; });
+		function mount(card, opts) {
+			var v = document.createElement('video');
+			v.className = 'ds-reel-video';
+			v.src = card.getAttribute('data-video') || '';
+			v.playsInline = true; v.setAttribute('playsinline', '');
+			if (opts.auto) { v.muted = true; v.loop = true; v.autoplay = true; v.setAttribute('muted', ''); }
+			else { v.controls = true; v.autoplay = true; }
+			card.appendChild(v);
+			return v;
+		}
+
+		var cards = [].slice.call(root.querySelectorAll('.ds-reel-card.has-video'));
+
+		if (auto) {
+			// Instagram-style: muted looped videos that play while visible, pause off-screen.
+			cards.forEach(function (card) { card.dsVideo = mount(card, { auto: true }); });
+			if ('IntersectionObserver' in window) {
+				var io = new IntersectionObserver(function (entries) {
+					entries.forEach(function (en) {
+						var v = en.target.dsVideo;
+						if (!v) return;
+						if (en.isIntersecting && en.intersectionRatio >= 0.4) { if (!en.target.dsUserPaused) v.play().catch(function () {}); }
+						else { v.pause(); }
+					});
+				}, { threshold: [0, 0.4] });
+				cards.forEach(function (card) { io.observe(card); });
 			}
-			card.addEventListener('click', function (e) { e.preventDefault(); play(); });
-		});
+			cards.forEach(function (card) {
+				card.addEventListener('click', function (e) {
+					if (e.target && e.target.tagName === 'VIDEO' && !card.dsVideo) return;
+					e.preventDefault();
+					var v = card.dsVideo; if (!v) return;
+					if (v.paused) { card.dsUserPaused = false; v.play().catch(function () {}); }
+					else { card.dsUserPaused = true; v.pause(); }
+				});
+			});
+		} else {
+			// Click-to-play with native controls; playing one pauses the others.
+			cards.forEach(function (card) {
+				var btn = card.querySelector('.ds-reel-play');
+				function play() {
+					if (card.dsPlaying) return;
+					card.dsPlaying = true;
+					[].slice.call(root.querySelectorAll('video.ds-reel-video')).forEach(function (o) { o.pause(); });
+					var v = mount(card, { auto: false });
+					if (btn) btn.style.display = 'none';
+					v.addEventListener('ended', function () { v.remove(); if (btn) btn.style.display = ''; card.dsPlaying = false; });
+				}
+				card.addEventListener('click', function (e) {
+					// Let native <video> control clicks through once the video is mounted.
+					if (e.target && e.target.tagName === 'VIDEO') return;
+					e.preventDefault();
+					play();
+				});
+			});
+		}
 
 		function step(dir) {
 			var card = track.querySelector('.ds-reel-card');

--- a/modules/ds-page-cards/ds-page-cards.php
+++ b/modules/ds-page-cards/ds-page-cards.php
@@ -73,7 +73,7 @@ class DS_Page_Cards_Module extends FLBuilderModule {
 		}
 
 		$h .= '<div class="dst-card-body">';
-		$h .= '<h3 class="dst-card-title">' . esc_html( $title ) . '</h3>';
+		$h .= '<h3 class="dst-card-title">' . DS_Module_UI::inline( $title ) . '</h3>';
 
 		if ( ( $s->show_excerpt ?? 'no' ) === 'yes' ) {
 			$ex = trim( (string) $child->post_excerpt ); // manual excerpt only (BB page content isn't excerpt-friendly).

--- a/modules/ds-page-cards/includes/frontend.css.php
+++ b/modules/ds-page-cards/includes/frontend.css.php
@@ -44,3 +44,30 @@ if ( ( $settings->image_position ?? 'top' ) === 'left' ) {
 // ── Text colours (blank inherits the theme) ──
 if ( $tc = $col( $settings->title_color ?? '' ) )   { echo "$node .dst-card-title{color:$tc;}\n"; }
 if ( $ec = $col( $settings->excerpt_color ?? '' ) ) { echo "$node .dst-card-excerpt{color:$ec;}\n"; }
+
+// ---- "Button" link style: follow the Theme Setting global Button (the static CSS only
+//      borrowed its colour; radius/typography/hover now sync too). ----
+if ( ( $settings->button_style ?? 'link' ) === 'button' && class_exists( 'FLBuilderGlobalStyles' ) ) {
+	$gs = FLBuilderGlobalStyles::get_settings( false );
+	if ( $gs ) {
+		$gbg    = $col( $gs->button_background ?? '' );
+		$gtext  = $col( $gs->button_color ?? '' );
+		$gbgh   = $col( $gs->button_hover_background ?? '' ) ?: $gbg;
+		$gtexth = $col( $gs->button_hover_color ?? '' ) ?: $gtext;
+		$gradius = '';
+		$bb = isset( $gs->button_border ) ? (array) $gs->button_border : array();
+		$r  = isset( $bb['radius'] ) ? (array) $bb['radius'] : array();
+		$tl = $r['top_left'] ?? ''; $tr = $r['top_right'] ?? ''; $bl = $r['bottom_left'] ?? ''; $brr = $r['bottom_right'] ?? '';
+		if ( '' !== ( $tl . $tr . $bl . $brr ) ) { $ru = function( $v ) { return ( '' === $v ? '0' : (int) $v ) . 'px'; }; $gradius = $ru( $tl ) . ' ' . $ru( $tr ) . ' ' . $ru( $brr ) . ' ' . $ru( $bl ); }
+		$p = '';
+		if ( $gbg )   { $p .= "background:{$gbg} !important;"; }
+		if ( $gtext ) { $p .= "color:{$gtext} !important;"; }
+		if ( '' !== $gradius ) { $p .= "border-radius:{$gradius};"; }
+		if ( '' !== $p ) { echo "$node .dst-card-btn--button { {$p} }\n"; }
+		if ( $gbgh || $gtexth ) { echo "$node .dst-card:hover .dst-card-btn--button { " . ( $gbgh ? "background:{$gbgh} !important;" : '' ) . ( $gtexth ? "color:{$gtexth} !important;" : '' ) . " }\n"; }
+		if ( class_exists( 'FLBuilderCSS' ) && ! empty( $gs->button_typography ) ) {
+			$gt = (object) array( 'gbtypo' => $gs->button_typography, 'gbtypo_large' => $gs->button_typography_large ?? '', 'gbtypo_medium' => $gs->button_typography_medium ?? '', 'gbtypo_responsive' => $gs->button_typography_responsive ?? '' );
+			FLBuilderCSS::typography_field_rule( array( 'settings' => $gt, 'setting_name' => 'gbtypo', 'selector' => "$node .dst-card-btn--button" ) );
+		}
+	}
+}

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -93,7 +93,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 
 	/** Heading markup: escape, {a}..{/a} -> accent span, newlines -> <br>. */
 	private function heading_html( $raw ) {
-		$h = esc_html( (string) $raw );
+		$h = DS_Module_UI::inline( (string) $raw ); // safe inline HTML (span/strong/em...) allowed
 		$h = str_replace( array( '{a}', '{/a}' ), array( '<span class="ds-news-accent">', '</span>' ), $h );
 		return nl2br( $h );
 	}
@@ -300,8 +300,8 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			echo '<div class="ds-people-card">'; echo $this->card_link( $id );
 			echo '<div class="ds-people-photo"' . ( $img ? ' style="background-image:url(' . esc_url( $img ) . ')"' : '' ) . '></div>';
 			echo '<div class="ds-people-body">';
-			if ( '' !== $name )  { echo '<h3 class="ds-people-name">' . esc_html( $name ) . '</h3>'; }
-			if ( '' !== $title ) { echo '<span class="ds-people-role">' . esc_html( $title ) . '</span>'; }
+			if ( '' !== $name )  { echo '<h3 class="ds-people-name">' . DS_Module_UI::inline( $name ) . '</h3>'; }
+			if ( '' !== $title ) { echo '<span class="ds-people-role">' . DS_Module_UI::inline( $title ) . '</span>'; }
 			if ( '' !== $icons ) { echo '<div class="ds-people-contacts">' . $icons . '</div>'; }
 			echo '</div></div>';
 		}
@@ -326,7 +326,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			echo '<div class="ds-commit-card">'; echo $this->card_link( $id );
 			echo '<div class="ds-people-photo"' . ( $img ? ' style="background-image:url(' . esc_url( $img ) . ')"' : '' ) . '></div>';
 			echo '<div class="ds-people-body">';
-			if ( '' !== $name )   { echo '<h3 class="ds-people-name">' . esc_html( $name ) . '</h3>'; }
+			if ( '' !== $name )   { echo '<h3 class="ds-people-name">' . DS_Module_UI::inline( $name ) . '</h3>'; }
 			if ( '' !== $school ) { echo '<span class="ds-people-role">' . esc_html( $school ) . '</span>'; }
 			echo '</div></div>';
 		}
@@ -348,7 +348,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			echo '<div class="ds-commit-row">'; echo $this->card_link( $id );
 			echo '<div class="ds-commit-row-logo">' . ( $logo ? '<img src="' . esc_url( $logo ) . '" alt="' . esc_attr( $school ) . '" loading="lazy" />' : '' ) . '</div>';
 			echo '<div class="ds-commit-row-body">';
-			if ( '' !== $name )   { echo '<h3 class="ds-people-name">' . esc_html( $name ) . '</h3>'; }
+			if ( '' !== $name )   { echo '<h3 class="ds-people-name">' . DS_Module_UI::inline( $name ) . '</h3>'; }
 			if ( '' !== $school ) { echo '<span class="ds-people-role">' . esc_html( $school ) . '</span>'; }
 			echo '</div></div>';
 		}
@@ -376,7 +376,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			echo '<div class="ds-commit-action-body">';
 			echo '<div class="ds-commit-action-logo">' . ( $logo ? '<img src="' . esc_url( $logo ) . '" alt="' . esc_attr( $school ) . '" loading="lazy" />' : '' ) . '</div>';
 			echo '<div class="ds-commit-action-text">';
-			if ( '' !== $name ) { echo '<h3 class="ds-people-name">' . esc_html( $name ) . '</h3>'; }
+			if ( '' !== $name ) { echo '<h3 class="ds-people-name">' . DS_Module_UI::inline( $name ) . '</h3>'; }
 			if ( '' !== $meta ) { echo '<span class="ds-people-role">' . esc_html( $meta ) . '</span>'; }
 			echo '</div></div></div>';
 		}
@@ -402,7 +402,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			$url     = $is_ext ? $extlink : get_permalink( $id );
 			$tgt     = $is_ext ? ' target="_blank" rel="noopener noreferrer"' : '';
 			echo '<a class="ds-team-row" href="' . esc_url( $url ) . '"' . $tgt . '>';
-			echo '<span class="ds-team-name">' . esc_html( $name ) . '</span>';
+			echo '<span class="ds-team-name">' . DS_Module_UI::inline( $name ) . '</span>';
 			echo '<span class="ds-team-btn">' . ( $is_ext ? $ext : $arrow ) . '</span>';
 			echo '</a>';
 		}
@@ -486,7 +486,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		echo '<div class="ds-news-feature-overlay" aria-hidden="true"></div>';
 		echo '<div class="ds-news-feature-body">';
 		if ( '' !== $badge )              { echo '<span class="ds-news-badge">' . esc_html( $badge ) . '</span>'; }
-		if ( '' !== ( $f['title'] ?? '' ) )   { echo '<h3 class="ds-news-feature-title">' . esc_html( $f['title'] ) . '</h3>'; }
+		if ( '' !== ( $f['title'] ?? '' ) )   { echo '<h3 class="ds-news-feature-title">' . DS_Module_UI::inline( $f['title'] ) . '</h3>'; }
 		if ( '' !== ( $f['excerpt'] ?? '' ) ) { echo '<p class="ds-news-feature-excerpt">' . esc_html( $f['excerpt'] ) . '</p>'; }
 		if ( '' !== $readmore ) {
 			echo '<span class="ds-news-readmore">' . esc_html( $readmore ) . ' <span class="ds-news-readmore-arrow" aria-hidden="true">&rarr;</span></span>';
@@ -502,7 +502,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		echo '<a class="ds-news-card" href="' . esc_url( $url ) . '" target="' . esc_attr( $tar ) . '"' . $rel . '>';
 		echo '<div class="ds-news-card-top">';
 		if ( '' !== ( $c['eyebrow'] ?? '' ) ) { echo '<span class="ds-news-card-cat">' . esc_html( $c['eyebrow'] ) . '</span>'; }
-		if ( '' !== ( $c['title'] ?? '' ) )   { echo '<h3 class="ds-news-card-title">' . esc_html( $c['title'] ) . '</h3>'; }
+		if ( '' !== ( $c['title'] ?? '' ) )   { echo '<h3 class="ds-news-card-title">' . DS_Module_UI::inline( $c['title'] ) . '</h3>'; }
 		echo '</div>';
 		echo '<div class="ds-news-card-foot">';
 		echo '<span class="ds-news-card-date">' . esc_html( $c['date'] ?? '' ) . '</span>';
@@ -523,7 +523,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 
 		$map = array(
 			'{id}'         => (string) ( $c['id'] ?? '' ),
-			'{title}'      => esc_html( $c['title'] ?? '' ),
+			'{title}'      => DS_Module_UI::inline( $c['title'] ?? '' ),
 			'{permalink}'  => esc_url( $c['url'] ?? '#' ),
 			'{url}'        => esc_url( $c['url'] ?? '#' ),
 			'{date}'       => esc_html( $c['date'] ?? '' ),
@@ -596,7 +596,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		echo '</div>';
 		echo '<div class="ds-news-card2-body">';
 		if ( '' !== ( $c['date'] ?? '' ) )  { echo '<span class="ds-news-card2-date">' . esc_html( $c['date'] ) . '</span>'; }
-		if ( '' !== ( $c['title'] ?? '' ) ) { echo '<h3 class="ds-news-card2-title">' . esc_html( $c['title'] ) . '</h3>'; }
+		if ( '' !== ( $c['title'] ?? '' ) ) { echo '<h3 class="ds-news-card2-title">' . DS_Module_UI::inline( $c['title'] ) . '</h3>'; }
 		if ( '' !== $readmore ) {
 			echo '<span class="ds-news-card2-more">' . esc_html( $readmore ) . ' <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg></span>';
 		}
@@ -713,7 +713,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			if ( '' !== $evt ) { echo '<span class="ds-tourn-logo"><img src="' . esc_url( $evt ) . '" alt="" loading="lazy" /></span>'; }
 			echo '</div>';
 			echo '<div class="ds-tourn-body">';
-			echo '<h3 class="ds-tourn-title">' . esc_html( $title ) . '</h3>';
+			echo '<h3 class="ds-tourn-title">' . DS_Module_UI::inline( $title ) . '</h3>';
 			echo '<div class="ds-tourn-meta">';
 			if ( '' !== $it['raw'] ) { echo '<span class="ds-tourn-date">' . $cal . '<span>' . esc_html( $it['raw'] ) . '</span></span>'; }
 			if ( '' !== $loc )       { echo '<span class="ds-tourn-loc">' . $pin . '<span>' . esc_html( $loc ) . '</span></span>'; }
@@ -757,7 +757,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			echo '<div class="ds-program-body">';
 			if ( '' !== $date )  { echo '<span class="ds-program-date">' . esc_html( $date ) . '</span>'; }
 			if ( '' !== $sub )   { echo '<span class="ds-program-sub">' . esc_html( $sub ) . '</span>'; }
-			if ( '' !== $title ) { echo '<h3 class="ds-program-title">' . esc_html( $title ) . '</h3>'; }
+			if ( '' !== $title ) { echo '<h3 class="ds-program-title">' . DS_Module_UI::inline( $title ) . '</h3>'; }
 			if ( '' !== $desc )  { echo '<p class="ds-program-desc">' . esc_html( $desc ) . '</p>'; }
 			if ( '' !== $btn && $hasurl ) { echo '<a class="' . esc_attr( $btn_cls ) . '" href="' . esc_url( $url ) . '"' . $tgt . '>' . esc_html( $btn ) . '</a>'; }
 			echo '</div></div>';

--- a/modules/ds-post-loop/includes/frontend.css.php
+++ b/modules/ds-post-loop/includes/frontend.css.php
@@ -199,6 +199,30 @@ if ( 'yes' === $btn && $gs ) {
 	if ( $dtx ) { echo "$node .ds-news-seeall { color: {$dtx} !important; }\n"; }
 }
 
+// ---- Tournament card button: follow the Theme Setting global Button (bg, text, hover,
+//      radius, typography) — the static CSS only borrowed its colour before. ----
+if ( $gs && ( $settings->card_layout ?? '' ) === 'tournament' ) {
+	$tbg    = $col( $gs->button_background ?? '' );
+	$ttext  = $col( $gs->button_color ?? '' );
+	$tbgh   = $col( $gs->button_hover_background ?? '' ) ?: $tbg;
+	$ttexth = $col( $gs->button_hover_color ?? '' ) ?: $ttext;
+	$tradius = '';
+	$tbb = isset( $gs->button_border ) ? (array) $gs->button_border : array();
+	$trr = isset( $tbb['radius'] ) ? (array) $tbb['radius'] : array();
+	$ttl = $trr['top_left'] ?? ''; $ttr = $trr['top_right'] ?? ''; $tbl = $trr['bottom_left'] ?? ''; $tbr = $trr['bottom_right'] ?? '';
+	if ( '' !== ( $ttl . $ttr . $tbl . $tbr ) ) { $tru = function( $v ) { return ( '' === $v ? '0' : (int) $v ) . 'px'; }; $tradius = $tru( $ttl ) . ' ' . $tru( $ttr ) . ' ' . $tru( $tbr ) . ' ' . $tru( $tbl ); }
+	$tp = '';
+	if ( $tbg )   { $tp .= "background:{$tbg} !important;"; }
+	if ( $ttext ) { $tp .= "color:{$ttext} !important;"; }
+	if ( '' !== $tradius ) { $tp .= "border-radius:{$tradius};"; }
+	if ( '' !== $tp ) { echo "$node .ds-tourn-btn { {$tp} }\n"; }
+	if ( $tbgh || $ttexth ) { echo "$node .ds-tourn-card:hover .ds-tourn-btn { " . ( $tbgh ? "background:{$tbgh} !important;" : '' ) . ( $ttexth ? "color:{$ttexth} !important;" : '' ) . " }\n"; }
+	if ( class_exists( 'FLBuilderCSS' ) && ! empty( $gs->button_typography ) ) {
+		$tgt = (object) array( 'gbtypo' => $gs->button_typography, 'gbtypo_large' => $gs->button_typography_large ?? '', 'gbtypo_medium' => $gs->button_typography_medium ?? '', 'gbtypo_responsive' => $gs->button_typography_responsive ?? '' );
+		FLBuilderCSS::typography_field_rule( array( 'settings' => $tgt, 'setting_name' => 'gbtypo', 'selector' => "$node .ds-tourn-btn" ) );
+	}
+}
+
 // ---- Spacing: padding on the wrap, margin on the section (deferred) ----
 if ( class_exists( 'FLBuilderCSS' ) ) {
 	FLBuilderCSS::dimension_field_rule( array(

--- a/modules/ds-team-detail/ds-team-detail.php
+++ b/modules/ds-team-detail/ds-team-detail.php
@@ -116,7 +116,7 @@ class DS_Team_Detail_Module extends FLBuilderModule {
 				. $link
 				. '<div class="ds-people-photo"' . $bg . '></div>'
 				. '<div class="ds-people-body">'
-				. ( '' !== $name ? '<h3 class="ds-people-name">' . esc_html( $name ) . '</h3>' : '' )
+				. ( '' !== $name ? '<h3 class="ds-people-name">' . DS_Module_UI::inline( $name ) . '</h3>' : '' )
 				. ( '' !== $role ? '<span class="ds-people-role">' . esc_html( $role ) . '</span>' : '' )
 				. ( '' !== $icons ? '<div class="ds-people-contacts">' . $icons . '</div>' : '' )
 				. '</div></div>';
@@ -126,7 +126,7 @@ class DS_Team_Detail_Module extends FLBuilderModule {
 		$title = (string) ( $s->coach_title ?? 'Coaches' );
 		$head  = '';
 		if ( '' !== trim( $title ) ) {
-			$head  = '<' . $tag . ' class="ds-teamdetail-title">' . esc_html( $title ) . '</' . $tag . '>';
+			$head  = '<' . $tag . ' class="ds-teamdetail-title">' . DS_Module_UI::inline( $title ) . '</' . $tag . '>';
 			if ( ( $s->divider_show ?? 'yes' ) === 'yes' ) { $head .= '<span class="ds-teamdetail-divider" aria-hidden="true"></span>'; }
 		}
 		return '<section class="ds-teamdetail-section ds-teamdetail-section--coaches">' . $head . '<div class="ds-people-grid ds-people-grid--coaches">' . $cards . '</div></section>';


### PR DESCRIPTION
From user reports:
- **Post Loop:** `<span>` now works in the section heading and every card title (shared inline-HTML whitelist); tournament button now truly follows **Theme Setting → Elements → Button**. Swept the same two issue classes across all modules: Page Cards title + its theme-button sync (the option label had no sync behind it), Team Detail coaches title, carousel captions.
- **Reels Strip:** per-slide **Media Library video** picker, **Autoplay** (muted loop while visible, pause off-screen, reduced-motion safe), **Play Button styles** (circle / icon-only / hidden), and a click-guard fix so native video controls don't re-trigger the card handler.

PHP + JS lint clean. Shipped per user call; live verification backlog (v1.9.4–1.9.6 + fonts diagnosis) queued for when the DS6 local env is back up.