### PR TITLE
feat: admin toolbar quick links to Theme Setting + DS Toolkit (1.9.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.7] - 2026-07-06
+### Added
+- **Admin toolbar quick links** (`ds_admin_bar_links_enabled`, blueprint 6+, auto-on): **Theme Setting** and, beside it, **DS Toolkit** in the WP admin bar (wp-admin and front end). LeagueApps-email users only, and each link also requires its page's capability (Theme Setting: `edit_posts` + the feature enabled; DS Toolkit: `manage_options`), so partners never see them and there are no dead links.
+
 ## [1.9.6] - 2026-07-06
 ### Added
 - **Reels Strip — Media Library videos.** New **Video (Media Library)** field per slide (Beaver's native video picker) for uploading/picking MP4s; takes priority over the Video URL field (kept for externally-hosted files).

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.6
+ * Version:           1.9.7
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.6' );
+define( 'DS_TOOLKIT_VERSION', '1.9.7' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-admin-bar-links.php
+++ b/features/class-ds-admin-bar-links.php
@@ -1,0 +1,50 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Adds quick links to the WP admin toolbar for LeagueApps users:
+ * "Theme Setting" (the DS Theme Setting page) and, beside it, "DS Toolkit"
+ * (the plugin settings page). Shown in wp-admin AND on the front end, so
+ * either page is one click away while reviewing a site. Each link only
+ * renders for users who can actually open its page (capability + the
+ * LeagueApps email gate), so partners never see dead links.
+ */
+class DS_Admin_Bar_Links {
+
+	private $settings;
+
+	public function __construct( $settings = array() ) {
+		$this->settings = $settings;
+	}
+
+	public function init() {
+		add_action( 'admin_bar_menu', array( $this, 'add_links' ), 82 );
+	}
+
+	/** @param WP_Admin_Bar $bar */
+	public function add_links( $bar ) {
+		if ( ! DS_Toolkit::is_leagueapps_user() ) {
+			return;
+		}
+
+		// Theme Setting — only when the feature is on (the page exists) and the
+		// user clears its gate (edit_posts).
+		if ( ! empty( $this->settings['theme_setting_enabled'] ) && current_user_can( 'edit_posts' ) ) {
+			$slug = class_exists( 'DS_Theme_Setting' ) ? DS_Theme_Setting::PAGE_SLUG : 'ds-theme-setting';
+			$bar->add_node( array(
+				'id'    => 'ds-theme-setting',
+				'title' => 'Theme Setting',
+				'href'  => admin_url( 'admin.php?page=' . $slug ),
+			) );
+		}
+
+		// DS Toolkit settings — admins only (matches the page's own gate).
+		if ( current_user_can( 'manage_options' ) ) {
+			$bar->add_node( array(
+				'id'    => 'ds-toolkit-settings',
+				'title' => 'DS Toolkit',
+				'href'  => admin_url( 'options-general.php?page=ds-toolkit' ),
+			) );
+		}
+	}
+}

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -172,6 +172,11 @@ class DS_Toolkit {
             'class'         => 'DS_Builder_Defaults',
             'min_blueprint' => 6,
         ),
+        'ds_admin_bar_links_enabled' => array(
+            'file'          => 'features/class-ds-admin-bar-links.php',
+            'class'         => 'DS_Admin_Bar_Links',
+            'min_blueprint' => 6,
+        ),
     );
 
     /**
@@ -318,6 +323,7 @@ class DS_Toolkit {
             $defaults['ds_page_cards_module_enabled'] = 1;
             $defaults['ds_team_detail_module_enabled'] = 1;
             $defaults['ds_builder_defaults_enabled']   = 1;
+            $defaults['ds_admin_bar_links_enabled']    = 1;
         }
 
         return $defaults;


### PR DESCRIPTION
Adds **Theme Setting** and **DS Toolkit** quick links to the WP admin toolbar (wp-admin + front end). Gated to LeagueApps-email users, each link additionally requires its page's capability (Theme Setting: `edit_posts` + feature enabled; DS Toolkit: `manage_options`) — partners never see them, no dead links. New gen-6 feature `ds_admin_bar_links_enabled`, auto-on via the defaults backfill.