### PR TITLE
fix: Info List → Post Details, Themer-only gate + recursion guard (1.9.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.8] - 2026-07-07
+### Changed
+- **Renamed "Info List" → "Post Details"** and scoped it to its intended context: the module now only appears in the builder panel while editing a **Themer layout** (via the `fl_builder_register_module` filter). Its rows read ACF fields off the rendered post, which is meaningless on a normal page. Instances already placed on pages keep rendering — the gate only controls the panel listing. Slug (`ds-info-list`) and saved settings unchanged.
+
+### Fixed
+- **Post Details — editor memory error on normal pages.** A row's Value connected to the "Post Content" dynamic field (or a `[wpbb post:content]` shortcode) on a regular page rendered the page inside itself (infinite recursion → memory exhaustion in the builder). `render()` now has a re-entry guard, so the loop physically can't happen even on existing page instances.
+
 ## [1.9.7] - 2026-07-06
 ### Added
 - **Admin toolbar quick links** (`ds_admin_bar_links_enabled`, blueprint 6+, auto-on): **Theme Setting** and, beside it, **DS Toolkit** in the WP admin bar (wp-admin and front end). LeagueApps-email users only, and each link also requires its page's capability (Theme Setting: `edit_posts` + the feature enabled; DS Toolkit: `manage_options`), so partners never see them and there are no dead links.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.7
+ * Version:           1.9.8
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.7' );
+define( 'DS_TOOLKIT_VERSION', '1.9.8' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -227,7 +227,7 @@ class DS_Toolkit {
             'ds_carousel_module_enabled'       => array( 'label' => 'Images/Videos Carousel', 'desc' => 'A stacked-deck slider or a multi-column reels strip of images and videos.' ),
             'ds_orgstats_module_enabled'       => array( 'label' => 'Org Stats',       'desc' => 'Headline stat figures (the record) as plain figures or photo cards.' ),
             'ds_marquee_module_enabled'        => array( 'label' => 'Marquee',         'desc' => 'A scrolling announcement ticker with a pinned label.' ),
-            'ds_info_list_module_enabled'      => array( 'label' => 'Info List',       'desc' => 'An icon-and-text list for hours, contact details, or quick facts.' ),
+            'ds_info_list_module_enabled'      => array( 'label' => 'Post Details',    'desc' => 'Icon-and-text rows from the current post\'s ACF fields, for Themer single templates (staff, events); empty rows hide.' ),
             'ds_cta_module_enabled'            => array( 'label' => 'CTA',             'desc' => 'A call-to-action band with a heading, text, and buttons.' ),
             'ds_heading_module_enabled'        => array( 'label' => 'Heading',         'desc' => 'A styled section heading with an eyebrow line and accent options.' ),
             'ds_divider_module_enabled'        => array( 'label' => 'Divider',         'desc' => 'A horizontal or vertical divider with gradient-fade, running-light, glow, and dashed effects.' ),

--- a/modules/ds-info-list/ds-info-list.php
+++ b/modules/ds-info-list/ds-info-list.php
@@ -18,8 +18,8 @@ class DS_Info_List_Module extends FLBuilderModule {
 
 	public function __construct() {
 		parent::__construct( array(
-			'name'            => __( 'Info List', 'ds-toolkit' ),
-			'description'     => __( 'Icon + text + link rows bound to ACF fields; empty rows hide automatically.', 'ds-toolkit' ),
+			'name'            => __( 'Post Details', 'ds-toolkit' ),
+			'description'     => __( 'Icon + text + link rows from the current post\'s ACF fields — for Themer single templates (staff, events). Empty rows hide automatically.', 'ds-toolkit' ),
 			'category'        => __( 'LeagueApps', 'ds-toolkit' ),
 			'dir'             => DS_TOOLKIT_PATH . 'modules/ds-info-list/',
 			'url'             => DS_TOOLKIT_URL . 'modules/ds-info-list/',
@@ -78,6 +78,18 @@ class DS_Info_List_Module extends FLBuilderModule {
 	}
 
 	public function render() {
+		// Re-entry guard. A row's Value connected to "Post Content" (or a
+		// [wpbb post:content] shortcode) on a normal page renders the page
+		// inside itself -> infinite recursion -> memory exhaustion. Render
+		// once per request depth; a nested call bails out empty.
+		static $depth = 0;
+		if ( $depth > 0 ) { return; }
+		$depth++;
+		$this->render_inner();
+		$depth--;
+	}
+
+	private function render_inner() {
 		$s     = $this->settings;
 		$items = ( isset( $s->items ) && is_array( $s->items ) ) ? $s->items : array();
 		$out   = '';
@@ -232,3 +244,19 @@ FLBuilder::register_module( 'DS_Info_List_Module', array(
 		),
 	),
 ) );
+
+/* Offer this module in the builder panel ONLY while editing a Themer layout
+   (fl-theme-layout): its rows read ACF fields off the rendered post, which is
+   meaningless on a normal page and — via a "Post Content" connection — can even
+   recurse. Instances already placed on pages keep rendering (the flag only
+   controls the panel listing). */
+add_filter( 'fl_builder_register_module', function ( $enabled, $instance ) {
+	if ( ! isset( $instance->slug ) || 'ds-info-list' !== $instance->slug ) {
+		return $enabled;
+	}
+	$pid = class_exists( 'FLBuilderModel' ) ? FLBuilderModel::get_post_id() : 0;
+	if ( ! $pid ) {
+		return $enabled;
+	}
+	return 'fl-theme-layout' === get_post_type( $pid );
+}, 10, 2 );


### PR DESCRIPTION
From a user report (editor error when the module is placed on a normal page):
- **Root cause:** a row's Value connected to the **Post Content** dynamic field (or `[wpbb post:content]`) on a regular page renders the page inside itself → infinite recursion → memory error in the builder. `render()` now has a re-entry guard, so the loop can't happen even on existing page instances.
- **Scoped to context:** the module now only appears in the builder panel while editing a **Themer layout** (`fl_builder_register_module` filter). Placed instances keep rendering everywhere — the flag only controls the panel listing.
- **Renamed** to **Post Details** to make the intended use obvious (slug `ds-info-list` and saved settings unchanged).