### PR TITLE
fix: full theme-Button sync everywhere + Default shape reset; carousel Auto Scroll (1.9.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.9] - 2026-07-08
+### Fixed
+- **"Match site Button" now truly matches — everywhere, including borders and shadow.** Root cause found on a live fleet test (risevolleyball): with Button Shape = **Default**, the Theme Setting emitted no shape CSS at all, so the blueprint's decorative clip-path baked into module buttons (e.g. the Post Loop "See all" parallelogram) was never cleared — the button ignored the theme radius no matter what the sync emitted. Default now emits an explicit clip-path **reset** across all button surfaces. On top of that, every module's global-button mode previously synced only background / text / hover / radius / typography; a new shared `DS_Module_UI::global_button_css()` also syncs the **full border (style / width / colour), border hover colour, and box-shadow** from Theme Setting → Elements → Button. Rewired: **Hero Banner** primary (ghost keeps radius + typography), **Menu CTA (Last Item)**, **Post Loop** "See all" + **Tournament** + **Program** (theme mode), **Page Cards** button, **CTA** bento + hero buttons.
+
+### Added
+- **Images/Videos Carousel — Auto Scroll (Reels Strip).** The strip advances one card at a time on a timer (interval setting, default 4s) and loops back to the start. Pauses on hover / touch / focus, only runs while on screen, and stays off for reduced-motion visitors.
+
 ## [1.9.8] - 2026-07-07
 ### Changed
 - **Renamed "Info List" → "Post Details"** and scoped it to its intended context: the module now only appears in the builder panel while editing a **Themer layout** (via the `fl_builder_register_module` filter). Its rows read ACF fields off the rendered post, which is meaningless on a normal page. Instances already placed on pages keep rendering — the gate only controls the panel listing. Slug (`ds-info-list`) and saved settings unchanged.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.8
+ * Version:           1.9.9
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.8' );
+define( 'DS_TOOLKIT_VERSION', '1.9.9' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-theme-setting.php
+++ b/features/class-ds-theme-setting.php
@@ -230,19 +230,30 @@ CSS;
         );
     }
 
-    /** Front-end CSS for a chosen button shape (empty for Default / unknown). */
+    /** Front-end CSS for a chosen button shape. Default emits a clip-path RESET:
+     *  several blueprint modules ship a decorative clip-path in their static CSS
+     *  (e.g. the Post Loop "See all" parallelogram), and without this reset the
+     *  Default shape's "standard button with the global radius" never actually
+     *  showed — the static clip stayed and the button ignored the Theme Setting. */
     public static function button_style_css( $style ) {
         $styles = self::button_styles();
         if ( ! isset( $styles[ $style ] ) || '' === $styles[ $style ]['clip'] ) {
-            return '';
+            $sel = self::button_shape_selectors();
+            return "{$sel}{-webkit-clip-path:none;clip-path:none;}";
         }
         $clip = $styles[ $style ]['clip'];
         // Filled site-button surfaces: standard BB/UABB buttons (.fl-button — UABB
         // buttons get it via Global JS), the nav CTA (DS Menu is-button), and the
         // hero primary CTA. Outline/ghost buttons are left alone — a clip-path
         // would slice their visible border.
-        $sel = '.fl-button, a.fl-button, .ds-menu-item.is-button, .ds-hero-btn--primary, .ds-cta-bento-btn, .ds-cta-hero-btn, .ds-news-seeall, .forminator-custom-form button.forminator-button-submit, .dst-card-btn--button, .ds-program-btn, .ds-tourn-btn';
-        return "{$sel}:not(.ds-no-clip){overflow:hidden;-webkit-clip-path:{$clip};clip-path:{$clip};border-radius:0 !important;}";
+        $sel = self::button_shape_selectors( ':not(.ds-no-clip)' );
+        return "{$sel}{overflow:hidden;-webkit-clip-path:{$clip};clip-path:{$clip};border-radius:0 !important;}";
+    }
+
+    /** The button surfaces the Button Shape system owns (shared by shape + Default reset). */
+    private static function button_shape_selectors( $suffix = '' ) {
+        $list = array( '.fl-button', 'a.fl-button', '.ds-menu-item.is-button', '.ds-hero-btn--primary', '.ds-cta-bento-btn', '.ds-cta-hero-btn', '.ds-news-seeall', '.forminator-custom-form button.forminator-button-submit', '.dst-card-btn--button', '.ds-program-btn', '.ds-tourn-btn' );
+        return implode( $suffix . ', ', $list ) . $suffix;
     }
 
     /* ----------------------------------------------------------------- Menu */

--- a/includes/class-ds-module-ui.php
+++ b/includes/class-ds-module-ui.php
@@ -65,6 +65,64 @@ class DS_Module_UI {
 		return $c ? "color-mix(in srgb, {$c} {$opacity_pct}%, transparent)" : '';
 	}
 
+	/**
+	 * Emit the FULL Theme Setting global Button style onto a selector:
+	 * background, text colour, hover colours, complete border (style/width/
+	 * colour + radius + box-shadow via FLBuilderCSS::border_field_rule), and
+	 * typography. One call per button surface keeps every module's "match the
+	 * site Button" mode honest — including borders and shadow.
+	 *
+	 * @param string      $selector       Full selector (already node-scoped).
+	 * @param string|null $hover_selector Hover selector; null derives ":hover".
+	 * @return bool True when global styles existed and something was emitted.
+	 */
+	public static function global_button_css( $selector, $hover_selector = null ) {
+		if ( ! class_exists( 'FLBuilderGlobalStyles' ) ) { return false; }
+		$gs = FLBuilderGlobalStyles::get_settings( false );
+		if ( ! $gs ) { return false; }
+		if ( null === $hover_selector ) { $hover_selector = $selector . ':hover'; }
+
+		$bg    = self::color( $gs->button_background ?? '' );
+		$text  = self::color( $gs->button_color ?? '' );
+		$bgh   = self::color( $gs->button_hover_background ?? '' ) ?: $bg;
+		$texth = self::color( $gs->button_hover_color ?? '' ) ?: $text;
+
+		$p = '';
+		if ( $bg )   { $p .= "background:{$bg} !important;"; }
+		if ( $text ) { $p .= "color:{$text} !important;"; }
+		if ( '' !== $p ) { echo "{$selector} { {$p} }\n"; }
+		if ( $bgh || $texth ) {
+			echo "{$hover_selector} { " . ( $bgh ? "background:{$bgh} !important;" : '' ) . ( $texth ? "color:{$texth} !important;" : '' ) . "filter:none; }\n";
+		}
+
+		// Full border: style/width/colour + corner radius + box-shadow. Deferred
+		// via FLBuilderCSS (the module css.php runner flushes it).
+		if ( class_exists( 'FLBuilderCSS' ) && ! empty( $gs->button_border ) ) {
+			// Deep-cast: the compound holds NESTED objects (radius / shadow / width);
+			// a top-level (array) cast would leave them stdClass and border_field_rule
+			// would silently skip them (is_array checks) — the shadow especially.
+			$border = json_decode( wp_json_encode( $gs->button_border ), true );
+			FLBuilderCSS::border_field_rule( array(
+				'settings'     => (object) array( 'gbborder' => is_array( $border ) ? $border : array() ),
+				'setting_name' => 'gbborder',
+				'selector'     => $selector,
+			) );
+			$bh = self::color( $gs->button_border_hover_color ?? '' );
+			if ( $bh ) { echo "{$hover_selector} { border-color:{$bh}; }\n"; }
+		}
+
+		if ( class_exists( 'FLBuilderCSS' ) && ! empty( $gs->button_typography ) ) {
+			$gt = (object) array(
+				'gbtypo'            => $gs->button_typography,
+				'gbtypo_large'      => $gs->button_typography_large ?? '',
+				'gbtypo_medium'     => $gs->button_typography_medium ?? '',
+				'gbtypo_responsive' => $gs->button_typography_responsive ?? '',
+			);
+			FLBuilderCSS::typography_field_rule( array( 'settings' => $gt, 'setting_name' => 'gbtypo', 'selector' => $selector ) );
+		}
+		return true;
+	}
+
 	/** [ medium, responsive ] global breakpoints in px, with Beaver Builder defaults. */
 	public static function breakpoints() {
 		$g  = class_exists( 'FLBuilderModel' ) ? FLBuilderModel::get_global_settings() : null;

--- a/modules/ds-carousel/ds-carousel.php
+++ b/modules/ds-carousel/ds-carousel.php
@@ -306,7 +306,9 @@ class DS_Carousel_Module extends FLBuilderModule {
 		$play = '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8 5.5v13l11-6.5z"/></svg>';
 
 		echo '<div class="ds-reels-wrap">';
-		echo '<div class="ds-reels-track" data-autoplay="' . esc_attr( ( $s->reel_autoplay ?? 'no' ) === 'yes' ? 'yes' : 'no' ) . '">';
+		$asc = ( $s->reel_autoscroll ?? 'no' ) === 'yes' ? 'yes' : 'no';
+		$asi = max( 1, (float) ( $s->reel_autoscroll_interval ?? 4 ) );
+		echo '<div class="ds-reels-track" data-autoplay="' . esc_attr( ( $s->reel_autoplay ?? 'no' ) === 'yes' ? 'yes' : 'no' ) . '" data-autoscroll="' . esc_attr( $asc ) . '" data-interval="' . esc_attr( $asi ) . '">';
 		foreach ( $slides as $slide ) {
 			$slide = (object) $slide;
 			$img   = ! empty( $slide->image ) ? $this->photo_url( $slide->image, 'large' ) : '';
@@ -493,6 +495,15 @@ FLBuilder::register_module( 'DS_Carousel_Module', array(
 					),
 					'reel_radius' => array( 'type' => 'unit', 'label' => __( 'Corner Radius', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 40, 'step' => 1 ), 'help' => __( 'Blank = the Theme Setting corner radius.', 'ds-toolkit' ) ),
 					'reel_arrows' => array( 'type' => 'select', 'label' => __( 'Arrows', 'ds-toolkit' ), 'default' => 'yes', 'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No (swipe / scroll only)', 'ds-toolkit' ) ) ),
+			'reel_autoscroll' => array(
+				'type'    => 'select',
+				'label'   => __( 'Auto Scroll', 'ds-toolkit' ),
+				'default' => 'no',
+				'options' => array( 'no' => __( 'No', 'ds-toolkit' ), 'yes' => __( 'Yes', 'ds-toolkit' ) ),
+				'help'    => __( 'The strip advances one card at a time on a timer (loops back to the start). Pauses while hovering or interacting; off for reduced-motion visitors.', 'ds-toolkit' ),
+				'toggle'  => array( 'yes' => array( 'fields' => array( 'reel_autoscroll_interval' ) ) ),
+			),
+			'reel_autoscroll_interval' => array( 'type' => 'unit', 'label' => __( 'Scroll Every', 'ds-toolkit' ), 'default' => '4', 'description' => 's', 'slider' => array( 'min' => 1, 'max' => 15, 'step' => 0.5 ) ),
 			'reel_autoplay' => array(
 				'type'    => 'select',
 				'label'   => __( 'Autoplay Videos', 'ds-toolkit' ),

--- a/modules/ds-carousel/js/frontend.js
+++ b/modules/ds-carousel/js/frontend.js
@@ -314,6 +314,26 @@
 		}
 		[].slice.call(root.querySelectorAll('.ds-reel-nav--prev')).forEach(function (b) { b.addEventListener('click', function (e) { e.preventDefault(); step(-1); }); });
 		[].slice.call(root.querySelectorAll('.ds-reel-nav--next')).forEach(function (b) { b.addEventListener('click', function (e) { e.preventDefault(); step(1); }); });
+
+		// Auto scroll: advance one card on a timer, loop to the start at the end.
+		// Pauses on hover / touch / focus; disabled entirely for reduced motion.
+		if (track.getAttribute('data-autoscroll') === 'yes' && !reduce) {
+			var ms = Math.max(1, parseFloat(track.getAttribute('data-interval') || '4')) * 1000;
+			var paused = false, timer = null;
+			function tick() {
+				if (paused) return;
+				var atEnd = track.scrollLeft + track.clientWidth >= track.scrollWidth - 4;
+				if (atEnd) { track.scrollTo({ left: 0, behavior: 'smooth' }); }
+				else { step(1); }
+			}
+			function start() { if (!timer) timer = window.setInterval(tick, ms); }
+			function stop()  { if (timer) { window.clearInterval(timer); timer = null; } }
+			['mouseenter', 'touchstart', 'pointerdown', 'focusin'].forEach(function (t) { track.addEventListener(t, function () { paused = true; }, { passive: true }); });
+			['mouseleave', 'focusout'].forEach(function (t) { track.addEventListener(t, function () { paused = false; }, { passive: true }); });
+			if ('IntersectionObserver' in window) {
+				new IntersectionObserver(function (en) { (en[0] && en[0].isIntersecting) ? start() : stop(); }, { threshold: 0.1 }).observe(track);
+			} else { start(); }
+		}
 	}
 
 	function bootReels(root) {

--- a/modules/ds-cta/includes/frontend.css.php
+++ b/modules/ds-cta/includes/frontend.css.php
@@ -120,18 +120,8 @@ if ( 'style3' === $style ) {
 		if ( '' !== ( $tl . $tr . $bl . $brr ) ) { $ru = function( $v ) { return ( '' === $v ? '0' : (int) $v ) . 'px'; }; $gradius = $ru( $tl ) . ' ' . $ru( $tr ) . ' ' . $ru( $brr ) . ' ' . $ru( $bl ); }
 	}
 	if ( $btn_global && $gs ) {
-		$gbg = $col( $gs->button_background ?? '' ); $gtext = $col( $gs->button_color ?? '' );
-		$gbgh = $col( $gs->button_hover_background ?? '' ) ?: $gbg; $gtexth = $col( $gs->button_hover_color ?? '' ) ?: $gtext;
-		$p = '';
-		if ( $gbg )   { $p .= "background:{$gbg} !important;"; }
-		if ( $gtext ) { $p .= "color:{$gtext} !important;"; }
-		if ( '' !== $gradius ) { $p .= "border-radius:{$gradius};"; }
-		if ( '' !== $p ) { echo "$node .ds-cta-bento-btn { {$p} }\n"; }
-		if ( $gbgh || $gtexth ) { echo "$node .ds-cta-bento-btn:hover { " . ( $gbgh ? "background:{$gbgh} !important;" : '' ) . ( $gtexth ? "color:{$gtexth} !important;" : '' ) . "filter:none; }\n"; }
-		if ( class_exists( 'FLBuilderCSS' ) && ! empty( $gs->button_typography ) ) {
-			$gt = (object) array( 'gbtypo' => $gs->button_typography, 'gbtypo_large' => $gs->button_typography_large ?? '', 'gbtypo_medium' => $gs->button_typography_medium ?? '', 'gbtypo_responsive' => $gs->button_typography_responsive ?? '' );
-			FLBuilderCSS::typography_field_rule( array( 'settings' => $gt, 'setting_name' => 'gbtypo', 'selector' => "$node .ds-cta-bento-btn" ) );
-		}
+		// FULL theme Button sync (bg, text, hover, border + radius + shadow, typography).
+		DS_Module_UI::global_button_css( "$node .ds-cta-bento-btn" );
 	} elseif ( $accent ) {
 		echo "$node .ds-cta-bento-btn { background: {$accent} !important; color: var(--fl-global-white) !important; }\n";
 	}
@@ -252,23 +242,8 @@ if ( 'style3' === $style ) {
 	$mode = $settings->hero_btn_global ?? 'global';
 	$gs   = class_exists( 'FLBuilderGlobalStyles' ) ? FLBuilderGlobalStyles::get_settings( false ) : null;
 	if ( 'global' === $mode && $gs ) {
-		$gbg = $col( $gs->button_background ?? '' ); $gtext = $col( $gs->button_color ?? '' );
-		$gbgh = $col( $gs->button_hover_background ?? '' ) ?: $gbg; $gtexth = $col( $gs->button_hover_color ?? '' ) ?: $gtext;
-		$gradius = '';
-		$bb = isset( $gs->button_border ) ? (array) $gs->button_border : array();
-		$r  = isset( $bb['radius'] ) ? (array) $bb['radius'] : array();
-		$tl = $r['top_left'] ?? ''; $tr = $r['top_right'] ?? ''; $bl = $r['bottom_left'] ?? ''; $brr = $r['bottom_right'] ?? '';
-		if ( '' !== ( $tl . $tr . $bl . $brr ) ) { $ru = function( $v ) { return ( '' === $v ? '0' : (int) $v ) . 'px'; }; $gradius = $ru( $tl ) . ' ' . $ru( $tr ) . ' ' . $ru( $brr ) . ' ' . $ru( $bl ); }
-		$p = '';
-		if ( $gbg )   { $p .= "background:{$gbg} !important;"; }
-		if ( $gtext ) { $p .= "color:{$gtext} !important;"; }
-		if ( '' !== $gradius ) { $p .= "border-radius:{$gradius};"; }
-		if ( '' !== $p ) { echo "$node .ds-cta-hero-btn { {$p} }\n"; }
-		if ( $gbgh || $gtexth ) { echo "$node .ds-cta-hero-btn:hover { " . ( $gbgh ? "background:{$gbgh} !important;" : '' ) . ( $gtexth ? "color:{$gtexth} !important;" : '' ) . "filter:none; }\n"; }
-		if ( class_exists( 'FLBuilderCSS' ) && ! empty( $gs->button_typography ) ) {
-			$gt = (object) array( 'gbtypo' => $gs->button_typography, 'gbtypo_large' => $gs->button_typography_large ?? '', 'gbtypo_medium' => $gs->button_typography_medium ?? '', 'gbtypo_responsive' => $gs->button_typography_responsive ?? '' );
-			FLBuilderCSS::typography_field_rule( array( 'settings' => $gt, 'setting_name' => 'gbtypo', 'selector' => "$node .ds-cta-hero-btn" ) );
-		}
+		// FULL theme Button sync (bg, text, hover, border + radius + shadow, typography).
+		DS_Module_UI::global_button_css( "$node .ds-cta-hero-btn" );
 	} elseif ( 'custom' === $mode ) {
 		$cbg = $col( $settings->hero_btn_bg ?? '' ); $ctx = $col( $settings->hero_btn_text_color ?? '' );
 		$cbgh = $col( $settings->hero_btn_hover_bg ?? '' ) ?: $cbg; $ctxh = $col( $settings->hero_btn_hover_text ?? '' ) ?: $ctx;

--- a/modules/ds-hero/includes/frontend.css.php
+++ b/modules/ds-hero/includes/frontend.css.php
@@ -188,17 +188,10 @@ if ( $gs ) {
 }
 
 if ( $btn_global && $gs ) {
-	$gbg    = $col( $gs->button_background ?? '' );
-	$gtext  = $col( $gs->button_color ?? '' );
-	$gbgh   = $col( $gs->button_hover_background ?? '' ) ?: $gbg;
-	$gtexth = $col( $gs->button_hover_color ?? '' ) ?: $gtext;
-	$p = '';
-	if ( $gbg )   { $p .= "background:{$gbg} !important;"; }
-	if ( $gtext ) { $p .= "color:{$gtext} !important;"; }
-	if ( '' !== $p ) { echo "$node .ds-hero-btn--primary { {$p} }\n"; }
-	if ( $gbgh || $gtexth ) { echo "$node .ds-hero-btn--primary:hover { " . ( $gbgh ? "background:{$gbgh} !important;" : '' ) . ( $gtexth ? "color:{$gtexth} !important;" : '' ) . "filter:none; }\n"; }
-	// Corner radius + typography on BOTH buttons so the ghost matches the theme too.
-	if ( '' !== $gradius ) { echo "$node .ds-hero-btn { border-radius: {$gradius}; }\n"; }
+	// FULL theme Button sync (bg, text, hover, border + radius + shadow, typography).
+	DS_Module_UI::global_button_css( "$node .ds-hero-btn--primary" );
+	// Corner radius + typography on the GHOST button too so it matches the theme.
+	if ( '' !== $gradius ) { echo "$node .ds-hero-btn--ghost { border-radius: {$gradius}; }\n"; }
 	if ( class_exists( 'FLBuilderCSS' ) && ! empty( $gs->button_typography ) ) {
 		$gt = (object) array(
 			'gbtypo'            => $gs->button_typography,
@@ -206,7 +199,7 @@ if ( $btn_global && $gs ) {
 			'gbtypo_medium'     => $gs->button_typography_medium ?? '',
 			'gbtypo_responsive' => $gs->button_typography_responsive ?? '',
 		);
-		FLBuilderCSS::typography_field_rule( array( 'settings' => $gt, 'setting_name' => 'gbtypo', 'selector' => "$node .ds-hero-btn" ) );
+		FLBuilderCSS::typography_field_rule( array( 'settings' => $gt, 'setting_name' => 'gbtypo', 'selector' => "$node .ds-hero-btn--ghost" ) );
 	}
 } else {
 	// Accent colour primary button.

--- a/modules/ds-menu/includes/frontend.css.php
+++ b/modules/ds-menu/includes/frontend.css.php
@@ -256,26 +256,9 @@ if ( ( $settings->last_item_button ?? 'no' ) === 'yes' ) {
 
 	if ( $gs && ( $settings->button_global ?? 'yes' ) === 'yes' ) {
 		$cta_global = true;
-		$gbg    = $col( $gs->button_background ?? '' );
-		$gtext  = $col( $gs->button_color ?? '' );
-		$gbgh   = $col( $gs->button_hover_background ?? '' ) ?: $gbg;
-		$gtexth = $col( $gs->button_hover_color ?? '' ) ?: $gtext;
-		$d = '';
-		if ( $gbg )   { $d .= "background:{$gbg};"; }
-		if ( $gtext ) { $d .= "color:{$gtext};"; }
-		if ( '' !== $gbtn_radius ) { $d .= "border-radius:{$gbtn_radius};"; }
-		$d .= "padding:0.6em {$bpad}px;";
-		echo "$cta { {$d} }\n";
-		if ( $gbgh || $gtexth ) { echo "$cta_hover {" . ( $gbgh ? "background:{$gbgh};" : '' ) . ( $gtexth ? "color:{$gtexth};" : '' ) . "}\n"; }
-		if ( class_exists( 'FLBuilderCSS' ) && ! empty( $gs->button_typography ) ) {
-			$gt = (object) array(
-				'gbtypo'            => $gs->button_typography,
-				'gbtypo_large'      => $gs->button_typography_large ?? '',
-				'gbtypo_medium'     => $gs->button_typography_medium ?? '',
-				'gbtypo_responsive' => $gs->button_typography_responsive ?? '',
-			);
-			FLBuilderCSS::typography_field_rule( array( 'settings' => $gt, 'setting_name' => 'gbtypo', 'selector' => $cta ) );
-		}
+		// FULL theme Button sync (bg, text, hover, border + radius + shadow, typography).
+		DS_Module_UI::global_button_css( $cta, $cta_hover );
+		echo "$cta { padding:0.6em {$bpad}px; }\n";
 	} else {
 		$bbg    = $col( $settings->button_bg ?? '' ) ?: 'var(--fl-global-button)';
 		$btext  = $col( $settings->button_text ?? '' ) ?: 'var(--fl-global-white)';

--- a/modules/ds-page-cards/includes/frontend.css.php
+++ b/modules/ds-page-cards/includes/frontend.css.php
@@ -45,29 +45,7 @@ if ( ( $settings->image_position ?? 'top' ) === 'left' ) {
 if ( $tc = $col( $settings->title_color ?? '' ) )   { echo "$node .dst-card-title{color:$tc;}\n"; }
 if ( $ec = $col( $settings->excerpt_color ?? '' ) ) { echo "$node .dst-card-excerpt{color:$ec;}\n"; }
 
-// ---- "Button" link style: follow the Theme Setting global Button (the static CSS only
-//      borrowed its colour; radius/typography/hover now sync too). ----
-if ( ( $settings->button_style ?? 'link' ) === 'button' && class_exists( 'FLBuilderGlobalStyles' ) ) {
-	$gs = FLBuilderGlobalStyles::get_settings( false );
-	if ( $gs ) {
-		$gbg    = $col( $gs->button_background ?? '' );
-		$gtext  = $col( $gs->button_color ?? '' );
-		$gbgh   = $col( $gs->button_hover_background ?? '' ) ?: $gbg;
-		$gtexth = $col( $gs->button_hover_color ?? '' ) ?: $gtext;
-		$gradius = '';
-		$bb = isset( $gs->button_border ) ? (array) $gs->button_border : array();
-		$r  = isset( $bb['radius'] ) ? (array) $bb['radius'] : array();
-		$tl = $r['top_left'] ?? ''; $tr = $r['top_right'] ?? ''; $bl = $r['bottom_left'] ?? ''; $brr = $r['bottom_right'] ?? '';
-		if ( '' !== ( $tl . $tr . $bl . $brr ) ) { $ru = function( $v ) { return ( '' === $v ? '0' : (int) $v ) . 'px'; }; $gradius = $ru( $tl ) . ' ' . $ru( $tr ) . ' ' . $ru( $brr ) . ' ' . $ru( $bl ); }
-		$p = '';
-		if ( $gbg )   { $p .= "background:{$gbg} !important;"; }
-		if ( $gtext ) { $p .= "color:{$gtext} !important;"; }
-		if ( '' !== $gradius ) { $p .= "border-radius:{$gradius};"; }
-		if ( '' !== $p ) { echo "$node .dst-card-btn--button { {$p} }\n"; }
-		if ( $gbgh || $gtexth ) { echo "$node .dst-card:hover .dst-card-btn--button { " . ( $gbgh ? "background:{$gbgh} !important;" : '' ) . ( $gtexth ? "color:{$gtexth} !important;" : '' ) . " }\n"; }
-		if ( class_exists( 'FLBuilderCSS' ) && ! empty( $gs->button_typography ) ) {
-			$gt = (object) array( 'gbtypo' => $gs->button_typography, 'gbtypo_large' => $gs->button_typography_large ?? '', 'gbtypo_medium' => $gs->button_typography_medium ?? '', 'gbtypo_responsive' => $gs->button_typography_responsive ?? '' );
-			FLBuilderCSS::typography_field_rule( array( 'settings' => $gt, 'setting_name' => 'gbtypo', 'selector' => "$node .dst-card-btn--button" ) );
-		}
-	}
+// ---- "Button" link style: FULL theme Button sync (bg, text, hover, border + radius + shadow, typography). ----
+if ( ( $settings->button_style ?? 'link' ) === 'button' ) {
+	DS_Module_UI::global_button_css( "$node .dst-card-btn--button", "$node .dst-card-btn--button:hover, $node .dst-card:hover .dst-card-btn--button" );
 }

--- a/modules/ds-post-loop/includes/frontend.css.php
+++ b/modules/ds-post-loop/includes/frontend.css.php
@@ -169,26 +169,8 @@ if ( $hac ) { echo "$node .ds-news-accent { color: {$hac}; }\n"; }
 $btn = $settings->btn_global ?? 'yes';
 $gs  = class_exists( 'FLBuilderGlobalStyles' ) ? FLBuilderGlobalStyles::get_settings( false ) : null;
 if ( 'yes' === $btn && $gs ) {
-	$gbg    = $col( $gs->button_background ?? '' );
-	$gtext  = $col( $gs->button_color ?? '' );
-	$gbgh   = $col( $gs->button_hover_background ?? '' ) ?: $gbg;
-	$gtexth = $col( $gs->button_hover_color ?? '' ) ?: $gtext;
-	// Border radius compound (CSS order TL TR BR BL).
-	$gradius = '';
-	$bb = isset( $gs->button_border ) ? (array) $gs->button_border : array();
-	$r  = isset( $bb['radius'] ) ? (array) $bb['radius'] : array();
-	$tl = $r['top_left'] ?? ''; $tr = $r['top_right'] ?? ''; $bl = $r['bottom_left'] ?? ''; $brr = $r['bottom_right'] ?? '';
-	if ( '' !== ( $tl . $tr . $bl . $brr ) ) { $ru = function( $v ) { return ( '' === $v ? '0' : (int) $v ) . 'px'; }; $gradius = $ru( $tl ) . ' ' . $ru( $tr ) . ' ' . $ru( $brr ) . ' ' . $ru( $bl ); }
-	$p = '';
-	if ( $gbg )   { $p .= "background:{$gbg} !important;"; }
-	if ( $gtext ) { $p .= "color:{$gtext} !important;"; }
-	if ( '' !== $gradius ) { $p .= "border-radius:{$gradius};"; } // theme Button Shape (clip-path) still applies; radius shows only when shape = Default.
-	if ( '' !== $p ) { echo "$node .ds-news-seeall { {$p} }\n"; }
-	if ( $gbgh || $gtexth ) { echo "$node .ds-news-seeall:hover { " . ( $gbgh ? "background:{$gbgh} !important;" : '' ) . ( $gtexth ? "color:{$gtexth} !important;" : '' ) . "filter:none; }\n"; }
-	if ( class_exists( 'FLBuilderCSS' ) && ! empty( $gs->button_typography ) ) {
-		$gt = (object) array( 'gbtypo' => $gs->button_typography, 'gbtypo_large' => $gs->button_typography_large ?? '', 'gbtypo_medium' => $gs->button_typography_medium ?? '', 'gbtypo_responsive' => $gs->button_typography_responsive ?? '' );
-		FLBuilderCSS::typography_field_rule( array( 'settings' => $gt, 'setting_name' => 'gbtypo', 'selector' => "$node .ds-news-seeall" ) );
-	}
+	// FULL theme Button sync (bg, text, hover, border + radius + shadow, typography).
+	DS_Module_UI::global_button_css( "$node .ds-news-seeall" );
 } elseif ( 'accent' === $btn ) {
 	$ac = $col( $settings->heading_accent_color ?? 'var(--fl-global-accent)' );
 	echo "$node .ds-news-seeall { background: {$ac} !important; color: var(--fl-global-white) !important; }\n";
@@ -199,28 +181,9 @@ if ( 'yes' === $btn && $gs ) {
 	if ( $dtx ) { echo "$node .ds-news-seeall { color: {$dtx} !important; }\n"; }
 }
 
-// ---- Tournament card button: follow the Theme Setting global Button (bg, text, hover,
-//      radius, typography) — the static CSS only borrowed its colour before. ----
+// ---- Tournament card button: FULL theme Button sync (incl. border + shadow). ----
 if ( $gs && ( $settings->card_layout ?? '' ) === 'tournament' ) {
-	$tbg    = $col( $gs->button_background ?? '' );
-	$ttext  = $col( $gs->button_color ?? '' );
-	$tbgh   = $col( $gs->button_hover_background ?? '' ) ?: $tbg;
-	$ttexth = $col( $gs->button_hover_color ?? '' ) ?: $ttext;
-	$tradius = '';
-	$tbb = isset( $gs->button_border ) ? (array) $gs->button_border : array();
-	$trr = isset( $tbb['radius'] ) ? (array) $tbb['radius'] : array();
-	$ttl = $trr['top_left'] ?? ''; $ttr = $trr['top_right'] ?? ''; $tbl = $trr['bottom_left'] ?? ''; $tbr = $trr['bottom_right'] ?? '';
-	if ( '' !== ( $ttl . $ttr . $tbl . $tbr ) ) { $tru = function( $v ) { return ( '' === $v ? '0' : (int) $v ) . 'px'; }; $tradius = $tru( $ttl ) . ' ' . $tru( $ttr ) . ' ' . $tru( $tbr ) . ' ' . $tru( $tbl ); }
-	$tp = '';
-	if ( $tbg )   { $tp .= "background:{$tbg} !important;"; }
-	if ( $ttext ) { $tp .= "color:{$ttext} !important;"; }
-	if ( '' !== $tradius ) { $tp .= "border-radius:{$tradius};"; }
-	if ( '' !== $tp ) { echo "$node .ds-tourn-btn { {$tp} }\n"; }
-	if ( $tbgh || $ttexth ) { echo "$node .ds-tourn-card:hover .ds-tourn-btn { " . ( $tbgh ? "background:{$tbgh} !important;" : '' ) . ( $ttexth ? "color:{$ttexth} !important;" : '' ) . " }\n"; }
-	if ( class_exists( 'FLBuilderCSS' ) && ! empty( $gs->button_typography ) ) {
-		$tgt = (object) array( 'gbtypo' => $gs->button_typography, 'gbtypo_large' => $gs->button_typography_large ?? '', 'gbtypo_medium' => $gs->button_typography_medium ?? '', 'gbtypo_responsive' => $gs->button_typography_responsive ?? '' );
-		FLBuilderCSS::typography_field_rule( array( 'settings' => $tgt, 'setting_name' => 'gbtypo', 'selector' => "$node .ds-tourn-btn" ) );
-	}
+	DS_Module_UI::global_button_css( "$node .ds-tourn-btn", "$node .ds-tourn-btn:hover, $node .ds-tourn-card:hover .ds-tourn-btn" );
 }
 
 // ---- Spacing: padding on the wrap, margin on the section (deferred) ----
@@ -506,6 +469,13 @@ if ( ( $settings->card_layout ?? '' ) === 'program' ) {
 	$pc = $col( $settings->pg_sub_color ?? '' );   if ( $pc ) { echo "$node .ds-program-sub{color:{$pc};}\n"; }
 	$pc = $col( $settings->pg_title_color ?? '' ); if ( $pc ) { echo "$node .ds-program-title{color:{$pc};}\n"; }
 	$pc = $col( $settings->pg_desc_color ?? '' );  if ( $pc ) { echo "$node .ds-program-desc{color:{$pc};}\n"; }
+	if ( ( $settings->pg_btn_style ?? 'theme' ) !== 'custom' ) {
+		// FULL theme Button sync (bg, text, hover, border + radius + shadow, typography).
+		DS_Module_UI::global_button_css(
+			"$node .ds-programs .ds-program-card .ds-program-btn",
+			"$node .ds-programs .ds-program-card .ds-program-btn:hover, $node .ds-programs .ds-program-card:hover .ds-program-btn"
+		);
+	}
 	if ( ( $settings->pg_btn_style ?? 'theme' ) === 'custom' ) {
 		$bbg = $col( $settings->pg_btn_bg ?? '' ); $btc = $col( $settings->pg_btn_color ?? '' );
 		$bdecl = ''; if ( $bbg ) { $bdecl .= "background:{$bbg};"; } if ( $btc ) { $bdecl .= "color:{$btc};"; }


### PR DESCRIPTION
Diagnosed live on https://risevolleyball.wpenginepowered.com/: the button sync WAS emitting (bg/radius/typography), but with **Button Shape = Default** the Theme Setting emitted no shape CSS, so the blueprint's static clip-path (the "See all" parallelogram) never cleared — buttons visually ignored the theme. Default now emits a clip-path **reset** across all button surfaces.

Also, all module button syncs were partial (no border, no shadow). New shared `DS_Module_UI::global_button_css()` syncs bg/text/hover + **full border (style/width/colour + radius + box-shadow**, deep-cast compound) + border-hover colour + typography. Rewired: Hero primary, Menu CTA (Last Item), Post Loop (See all / Tournament / Program theme-mode), Page Cards, CTA bento + hero.

Plus: **Reels Strip Auto Scroll** (interval, loops, pauses on hover/interaction, on-screen only, reduced-motion off).