### PR TITLE
fix: anchor Program card CTA button to the card bottom (1.9.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.10] - 2026-07-09
+### Fixed
+- **Post Loop — Program card buttons now anchor to the card bottom.** With Same Height on, the Learn More / CTA button sat directly under the text, so buttons across a row didn't line up. The button now pins to the bottom of the card (`margin-top:auto` in the card's flex column), so all buttons align horizontally regardless of text length. No change for cards without Same Height.
+
 ## [1.9.9] - 2026-07-08
 ### Fixed
 - **"Match site Button" now truly matches — everywhere, including borders and shadow.** Root cause found on a live fleet test (risevolleyball): with Button Shape = **Default**, the Theme Setting emitted no shape CSS at all, so the blueprint's decorative clip-path baked into module buttons (e.g. the Post Loop "See all" parallelogram) was never cleared — the button ignored the theme radius no matter what the sync emitted. Default now emits an explicit clip-path **reset** across all button surfaces. On top of that, every module's global-button mode previously synced only background / text / hover / radius / typography; a new shared `DS_Module_UI::global_button_css()` also syncs the **full border (style / width / colour), border hover colour, and box-shadow** from Theme Setting → Elements → Button. Rewired: **Hero Banner** primary (ghost keeps radius + typography), **Menu CTA (Last Item)**, **Post Loop** "See all" + **Tournament** + **Program** (theme mode), **Page Cards** button, **CTA** bento + hero buttons.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.9
+ * Version:           1.9.10
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.9' );
+define( 'DS_TOOLKIT_VERSION', '1.9.10' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-post-loop/css/frontend.css
+++ b/modules/ds-post-loop/css/frontend.css
@@ -176,7 +176,7 @@
 .ds-program-sub{font-size:.85rem;font-weight:600;opacity:.85;}
 .ds-program-title{margin:0;color:var(--fl-global-headings);font-size:1.25rem;line-height:1.2;}
 .ds-program-desc{margin:0;color:var(--fl-global-body);font-size:.95rem;line-height:1.5;}
-.fl-builder-content .ds-program-card .ds-program-btn{align-self:flex-start;margin-top:6px;display:inline-block;background:var(--fl-global-button);color:var(--fl-global-white);padding:10px 22px;border-radius:6px;font-weight:700;font-size:.82rem;letter-spacing:1px;text-transform:uppercase;text-decoration:none;transition:background .2s ease;position:relative;z-index:2;}
+.fl-builder-content .ds-program-card .ds-program-btn{align-self:flex-start;margin-top:auto;display:inline-block;background:var(--fl-global-button);color:var(--fl-global-white);padding:10px 22px;border-radius:6px;font-weight:700;font-size:.82rem;letter-spacing:1px;text-transform:uppercase;text-decoration:none;transition:background .2s ease;position:relative;z-index:2;}
 .fl-builder-content .ds-program-card .ds-program-btn:hover,.fl-builder-content .ds-program-card:hover .ds-program-btn{background:var(--fl-global-accent);color:var(--fl-global-white);}
 
 /* ── Tournament cards (events): center-center image + overlapping details card ── */


### PR DESCRIPTION
One-property fix from the risevolleyball test (https://risevolleyball.wpenginepowered.com/where-do-i-start/): Program cards are equal-height flex columns, but the button had `margin-top:6px` so it sat under the text. Now `margin-top:auto` pins it to the card bottom — buttons line up across the row regardless of text length. The card's flex `gap` still guarantees spacing; cards without Same Height are unaffected.