### PR TITLE
feat: Menu item divider between top-level items (1.9.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.11] - 2026-07-09
+### Added
+- **Menu — Item Divider.** New Style → Menu Bar option: a small vertical divider between top-level items (Solid / Dashed / Dotted, with colour, height, and width controls; colour defaults to the global line colour). Rendered as a real flex item, so it centres correctly for **every alignment including Justify**. Desktop bar only (hidden in the mobile overlay) and never shown before the CTA button.
+
 ## [1.9.10] - 2026-07-09
 ### Fixed
 - **Post Loop — Program card buttons now anchor to the card bottom.** With Same Height on, the Learn More / CTA button sat directly under the text, so buttons across a row didn't line up. The button now pins to the bottom of the card (`margin-top:auto` in the card's flex column), so all buttons align horizontally regardless of text length. No change for cards without Same Height.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.10
+ * Version:           1.9.11
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.10' );
+define( 'DS_TOOLKIT_VERSION', '1.9.11' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/ds-menu.php
+++ b/modules/ds-menu/ds-menu.php
@@ -143,7 +143,9 @@ class DS_Menu_Module extends FLBuilderModule {
 		$button_on = $is_top && isset( $this->settings->last_item_button ) && 'yes' === $this->settings->last_item_button;
 		$last_id   = ( $button_on && ! empty( $children[ $parent ] ) ) ? (int) end( $children[ $parent ] )->ID : 0;
 
-		echo '<ul class="' . ( $is_top ? 'ds-menu' : 'ds-submenu' ) . '">';
+		echo '<ul class="' . ( $is_top ? 'ds-menu' : 'ds-submenu' ) . '">';		
+		$sep_on = $is_top && ( $this->settings->bar_divider_style ?? 'none' ) !== 'none';
+		$sep_first = true;
 		foreach ( $children[ $parent ] as $item ) {
 			$has_children = ! empty( $children[ $item->ID ] );
 			$classes      = is_array( $item->classes ) ? $item->classes : array();
@@ -171,6 +173,12 @@ class DS_Menu_Module extends FLBuilderModule {
 			$extra = array_filter( $classes, function( $c ) { return $c && 0 !== strpos( $c, 'ds-cols-' ) && 'ds-no-mega' !== $c; } );
 			if ( $extra ) { $li_class .= ' ' . implode( ' ', array_map( 'sanitize_html_class', $extra ) ); }
 
+			// Bar divider: a real flex-item separator between top-level items (centres
+			// correctly for every alignment incl. Justify). Skipped before the CTA button.
+			if ( $sep_on ) {
+				if ( ! $sep_first && ! $is_button ) { echo '<li class="ds-menu-sep" aria-hidden="true"><span></span></li>'; }
+				$sep_first = false;
+			}
 			echo '<li class="' . esc_attr( $li_class ) . '">';
 			$target = $item->target ? ' target="' . esc_attr( $item->target ) . '" rel="noopener"' : '';
 			// CTA buttons never get the submenu indicator.
@@ -380,6 +388,26 @@ FLBuilder::register_module( 'DS_Menu_Module', array(
 				'fields' => array(
 					'text_color'   => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Text Color', 'ds-toolkit' ), 'show_reset' => true, 'show_alpha' => true ),
 					'hover_color'  => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Text Hover / Active Color', 'ds-toolkit' ), 'show_reset' => true, 'show_alpha' => true ),
+					'bar_divider_style'  => array(
+						'type'    => 'select',
+						'label'   => __( 'Item Divider', 'ds-toolkit' ),
+						'default' => 'none',
+						'options' => array(
+							'none'   => __( 'None', 'ds-toolkit' ),
+							'solid'  => __( 'Solid', 'ds-toolkit' ),
+							'dashed' => __( 'Dashed', 'ds-toolkit' ),
+							'dotted' => __( 'Dotted', 'ds-toolkit' ),
+						),
+						'help'    => __( 'A small vertical divider between top-level items on the desktop bar — pairs nicely with the Justify alignment. Hidden in the mobile overlay and never shown before the CTA button.', 'ds-toolkit' ),
+						'toggle'  => array(
+							'solid'  => array( 'fields' => array( 'bar_divider_color', 'bar_divider_height', 'bar_divider_width' ) ),
+							'dashed' => array( 'fields' => array( 'bar_divider_color', 'bar_divider_height', 'bar_divider_width' ) ),
+							'dotted' => array( 'fields' => array( 'bar_divider_color', 'bar_divider_height', 'bar_divider_width' ) ),
+						),
+					),
+					'bar_divider_color'  => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Divider Color', 'ds-toolkit' ), 'default' => 'var(--fl-global-line-color)', 'show_reset' => true, 'show_alpha' => true ),
+					'bar_divider_height' => array( 'type' => 'unit', 'label' => __( 'Divider Height', 'ds-toolkit' ), 'default' => '18', 'description' => 'px', 'slider' => array( 'min' => 6, 'max' => 60, 'step' => 1 ) ),
+					'bar_divider_width'  => array( 'type' => 'unit', 'label' => __( 'Divider Width', 'ds-toolkit' ), 'default' => '1', 'description' => 'px', 'slider' => array( 'min' => 1, 'max' => 6, 'step' => 1 ) ),
 					'hover_weight' => array(
 						'type'    => 'select',
 						'label'   => __( 'Hover Font Weight', 'ds-toolkit' ),

--- a/modules/ds-menu/includes/frontend.css.php
+++ b/modules/ds-menu/includes/frontend.css.php
@@ -42,6 +42,19 @@ $tbord = ( $tbw > 0 && $tbc ) ? "{$tbw}px solid {$tbc}" : '0';
 ?>
 <?php /* Item Spacing is a real GAP between items (independent of the link's own padding). */ ?>
 <?php echo $node; ?> .ds-menu { justify-content: <?php echo $justify; ?>; column-gap: <?php echo $spacing; ?>px; }
+<?php
+/* ---- Item divider: a small vertical rule between top-level items (desktop bar only).
+        Rendered as a real flex item so it centres for every alignment incl. Justify. ---- */
+$bds = $settings->bar_divider_style ?? 'none';
+if ( in_array( $bds, array( 'solid', 'dashed', 'dotted' ), true ) ) {
+	$bdc = $col( $settings->bar_divider_color ?? '' ) ?: 'var(--fl-global-line-color)';
+	$bdh = isset( $settings->bar_divider_height ) && '' !== $settings->bar_divider_height ? (int) $settings->bar_divider_height : 18;
+	$bdw = isset( $settings->bar_divider_width ) && '' !== $settings->bar_divider_width ? (int) $settings->bar_divider_width : 1;
+	echo "$node .ds-menu > .ds-menu-sep { list-style: none; display: flex; align-items: center; }\n";
+	echo "$node .ds-menu > .ds-menu-sep > span { display: block; width: 0; height: {$bdh}px; border-left: {$bdw}px {$bds} {$bdc}; }\n";
+	echo "@media (max-width: {$bp}px) { $node .ds-menu-sep { display: none !important; } }\n";
+}
+?>
 <?php echo $node; ?> .ds-menu > .ds-menu-item > a { padding: <?php echo $barpv; ?>px <?php echo $barph; ?>px; <?php if ( $text ) { echo 'color:' . $text . ';'; } ?> }
 <?php if ( $hover ) : ?>
 <?php echo $node; ?> .ds-menu > .ds-menu-item > a:hover,


### PR DESCRIPTION
New Style → Menu Bar → **Item Divider**: a small vertical rule between top-level items (Solid/Dashed/Dotted + colour/height/width, defaults to the global line colour). Rendered as a real flex item so it centres correctly for every alignment **including Justify** (a CSS pseudo-element can't centre with space-between). Desktop only; hidden in the mobile overlay; never before the CTA button.