### PR TITLE
fix: program button anchor (body flex-fill) + WYSIWYG description (1.9.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.12] - 2026-07-09
+### Fixed
+- **Program cards — buttons now truly bottom-anchor.** The 1.9.10 `margin-top:auto` was correct but the button sits inside `.ds-program-body`, which only sized to its content, so there was no space to push into. The body now stretches to fill the card (`flex:1 1 auto`), and buttons line up across a Same Height row for real this time. Verified against the live markup on the fleet test site.
+
+### Changed
+- **Program card Description is now a WordPress WYSIWYG editor** (like the Beaver Builder Text Editor field) instead of a plain textarea, and it renders as real HTML (`wp_kses_post`, auto-paragraphs). Typed markup in existing descriptions (e.g. `<br>`, `<b>…</b>`) now renders instead of printing literally.
+
 ## [1.9.11] - 2026-07-09
 ### Added
 - **Menu — Item Divider.** New Style → Menu Bar option: a small vertical divider between top-level items (Solid / Dashed / Dotted, with colour, height, and width controls; colour defaults to the global line colour). Rendered as a real flex item, so it centres correctly for **every alignment including Justify**. Desktop bar only (hidden in the mobile overlay) and never shown before the CTA button.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.11
+ * Version:           1.9.12
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.11' );
+define( 'DS_TOOLKIT_VERSION', '1.9.12' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-post-loop/css/frontend.css
+++ b/modules/ds-post-loop/css/frontend.css
@@ -171,7 +171,9 @@
 .ds-program-ico{display:inline-flex;color:var(--fl-global-accent);font-size:40px;line-height:1;}
 .ds-program-media{width:100%;height:180px;border-radius:var(--ds-radius);overflow:hidden;}
 .ds-program-media img{width:100%;height:100%;object-fit:cover;display:block;}
-.ds-program-body{display:flex;flex-direction:column;gap:6px;width:100%;}
+.ds-program-body{display:flex;flex-direction:column;gap:6px;width:100%;flex:1 1 auto;}
+.ds-program-desc p{margin:0 0 .6em;}
+.ds-program-desc p:last-child{margin-bottom:0;}
 .ds-program-date{font-size:.8rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:var(--fl-global-accent);}
 .ds-program-sub{font-size:.85rem;font-weight:600;opacity:.85;}
 .ds-program-title{margin:0;color:var(--fl-global-headings);font-size:1.25rem;line-height:1.2;}

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -758,7 +758,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			if ( '' !== $date )  { echo '<span class="ds-program-date">' . esc_html( $date ) . '</span>'; }
 			if ( '' !== $sub )   { echo '<span class="ds-program-sub">' . esc_html( $sub ) . '</span>'; }
 			if ( '' !== $title ) { echo '<h3 class="ds-program-title">' . DS_Module_UI::inline( $title ) . '</h3>'; }
-			if ( '' !== $desc )  { echo '<p class="ds-program-desc">' . esc_html( $desc ) . '</p>'; }
+			if ( '' !== $desc )  { echo '<div class="ds-program-desc">' . wpautop( wp_kses_post( $desc ) ) . '</div>'; }
 			if ( '' !== $btn && $hasurl ) { echo '<a class="' . esc_attr( $btn_cls ) . '" href="' . esc_url( $url ) . '"' . $tgt . '>' . esc_html( $btn ) . '</a>'; }
 			echo '</div></div>';
 		}
@@ -832,7 +832,7 @@ FLBuilder::register_settings_form( 'ds_program_form', array(
 						'prog_date'       => array( 'type' => 'text', 'label' => __( 'Date', 'ds-toolkit' ), 'connections' => array( 'string' ) ),
 						'prog_subheading' => array( 'type' => 'text', 'label' => __( 'Sub-heading', 'ds-toolkit' ), 'connections' => array( 'string' ) ),
 						'prog_title'      => array( 'type' => 'text', 'label' => __( 'Title', 'ds-toolkit' ), 'connections' => array( 'string' ) ),
-						'prog_desc'       => array( 'type' => 'textarea', 'label' => __( 'Description', 'ds-toolkit' ), 'rows' => 3, 'connections' => array( 'string' ) ),
+						'prog_desc'       => array( 'type' => 'editor', 'label' => __( 'Description', 'ds-toolkit' ), 'media_buttons' => false, 'rows' => 6, 'wpautop' => false, 'connections' => array( 'string' ) ),
 						'prog_url'        => array( 'type' => 'link', 'label' => __( 'Link', 'ds-toolkit' ), 'show_target' => true, 'connections' => array( 'url' ) ),
 						'prog_btn'        => array( 'type' => 'text', 'label' => __( 'Button Text', 'ds-toolkit' ), 'help' => __( 'Optional. With text a button shows; blank makes the whole card the link.', 'ds-toolkit' ) ),
 					),


### PR DESCRIPTION
Diagnosed on https://risevolleyball.wpenginepowered.com/where-do-i-start/2026-2027-tryouts/ — the 1.9.10 `margin-top:auto` was live but the button is nested in `.ds-program-body`, which sized to content; the body now `flex:1 1 auto` so the anchor works. Also: **Description** is now a WP WYSIWYG editor field rendered via `wpautop( wp_kses_post() )` — the literal `<br>`/`<b>` visible on the live cards now renders as intended.