### PR TITLE
fix: Reels Auto Scroll = seamless continuous infinite loop (1.9.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.13] - 2026-07-09
+### Changed
+- **Images/Videos Carousel — Auto Scroll is now a seamless infinite loop.** Instead of stepping card-by-card and visibly rewinding to the start, the Reels Strip now drifts continuously marquee-style: the card set is cloned and the scroll position wraps invisibly, so it loops forever in one direction. The interval setting is now **Speed** (seconds per card; lower = faster). Still pauses on hover / touch / focus and off-screen, arrows still work (drift pauses briefly after a manual step), and it stays off for reduced-motion visitors.
+
 ## [1.9.12] - 2026-07-09
 ### Fixed
 - **Program cards — buttons now truly bottom-anchor.** The 1.9.10 `margin-top:auto` was correct but the button sits inside `.ds-program-body`, which only sized to its content, so there was no space to push into. The body now stretches to fill the card (`flex:1 1 auto`), and buttons line up across a Same Height row for real this time. Verified against the live markup on the fleet test site.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.12
+ * Version:           1.9.13
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.12' );
+define( 'DS_TOOLKIT_VERSION', '1.9.13' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-carousel/ds-carousel.php
+++ b/modules/ds-carousel/ds-carousel.php
@@ -500,10 +500,10 @@ FLBuilder::register_module( 'DS_Carousel_Module', array(
 				'label'   => __( 'Auto Scroll', 'ds-toolkit' ),
 				'default' => 'no',
 				'options' => array( 'no' => __( 'No', 'ds-toolkit' ), 'yes' => __( 'Yes', 'ds-toolkit' ) ),
-				'help'    => __( 'The strip advances one card at a time on a timer (loops back to the start). Pauses while hovering or interacting; off for reduced-motion visitors.', 'ds-toolkit' ),
+				'help'    => __( 'The strip drifts continuously in a seamless infinite loop (it never rewinds). Pauses while hovering or interacting and while off-screen; off for reduced-motion visitors.', 'ds-toolkit' ),
 				'toggle'  => array( 'yes' => array( 'fields' => array( 'reel_autoscroll_interval' ) ) ),
 			),
-			'reel_autoscroll_interval' => array( 'type' => 'unit', 'label' => __( 'Scroll Every', 'ds-toolkit' ), 'default' => '4', 'description' => 's', 'slider' => array( 'min' => 1, 'max' => 15, 'step' => 0.5 ) ),
+			'reel_autoscroll_interval' => array( 'type' => 'unit', 'label' => __( 'Speed', 'ds-toolkit' ), 'default' => '4', 'description' => __( 's per card', 'ds-toolkit' ), 'help' => __( 'Seconds each card takes to drift past. Lower = faster.', 'ds-toolkit' ), 'slider' => array( 'min' => 1, 'max' => 15, 'step' => 0.5 ) ),
 			'reel_autoplay' => array(
 				'type'    => 'select',
 				'label'   => __( 'Autoplay Videos', 'ds-toolkit' ),

--- a/modules/ds-carousel/js/frontend.js
+++ b/modules/ds-carousel/js/frontend.js
@@ -315,24 +315,57 @@
 		[].slice.call(root.querySelectorAll('.ds-reel-nav--prev')).forEach(function (b) { b.addEventListener('click', function (e) { e.preventDefault(); step(-1); }); });
 		[].slice.call(root.querySelectorAll('.ds-reel-nav--next')).forEach(function (b) { b.addEventListener('click', function (e) { e.preventDefault(); step(1); }); });
 
-		// Auto scroll: advance one card on a timer, loop to the start at the end.
-		// Pauses on hover / touch / focus; disabled entirely for reduced motion.
+		// Auto scroll: a CONTINUOUS, seamless infinite loop (marquee style). The
+		// card set is cloned and scrollLeft wraps at the original width, so the
+		// strip drifts forever without ever visibly rewinding. The interval
+		// setting = seconds each card takes to pass (speed). Pauses on hover /
+		// touch / focus and while off-screen; disabled for reduced motion.
 		if (track.getAttribute('data-autoscroll') === 'yes' && !reduce) {
-			var ms = Math.max(1, parseFloat(track.getAttribute('data-interval') || '4')) * 1000;
-			var paused = false, timer = null;
-			function tick() {
-				if (paused) return;
-				var atEnd = track.scrollLeft + track.clientWidth >= track.scrollWidth - 4;
-				if (atEnd) { track.scrollTo({ left: 0, behavior: 'smooth' }); }
-				else { step(1); }
+			var perCard = Math.max(0.5, parseFloat(track.getAttribute('data-interval') || '4'));
+			var originals = [].slice.call(track.children);
+			if (originals.length) {
+				track.style.scrollSnapType = 'none'; // snap would fight the drift
+				var setWidth = 0;
+				var measure = function () {
+					var last = originals[originals.length - 1];
+					var gap = parseFloat(getComputedStyle(track).gap) || 24;
+					setWidth = last.offsetLeft + last.offsetWidth + gap - originals[0].offsetLeft;
+				};
+				measure();
+				// Clone the set until there's enough runway to wrap invisibly.
+				var copies = 0;
+				while (track.scrollWidth < track.clientWidth + setWidth * 2 && copies < 6) {
+					originals.forEach(function (el) {
+						var c = el.cloneNode(true);
+						c.setAttribute('data-ds-clone', '1');
+						c.setAttribute('aria-hidden', 'true');
+						track.appendChild(c);
+					});
+					copies++;
+				}
+				var pausedHover = false, pausedUser = 0, visible = true, lastT = 0;
+				function frame(t) {
+					window.requestAnimationFrame(frame);
+					if (!lastT) { lastT = t; return; }
+					var dt = (t - lastT) / 1000; lastT = t;
+					if (pausedHover || !visible || t < pausedUser) return;
+					var card = originals[0];
+					var speed = (card ? card.offsetWidth : 300) / perCard; // px per second
+					track.scrollLeft += speed * dt;
+					if (setWidth > 0 && track.scrollLeft >= setWidth) { track.scrollLeft -= setWidth; }
+				}
+				['mouseenter', 'touchstart', 'pointerdown', 'focusin'].forEach(function (t) { track.addEventListener(t, function () { pausedHover = true; }, { passive: true }); });
+				['mouseleave', 'focusout', 'touchend', 'touchcancel'].forEach(function (t) { track.addEventListener(t, function () { pausedHover = false; }, { passive: true }); });
+				// Arrow clicks pause the drift briefly so manual steps are not overridden.
+				[].slice.call(root.querySelectorAll('.ds-reel-nav--prev, .ds-reel-nav--next')).forEach(function (b) {
+					b.addEventListener('click', function () { pausedUser = performance.now() + 4000; });
+				});
+				if ('IntersectionObserver' in window) {
+					new IntersectionObserver(function (en) { visible = !!(en[0] && en[0].isIntersecting); }, { threshold: 0.05 }).observe(track);
+				}
+				window.addEventListener('resize', measure);
+				window.requestAnimationFrame(frame);
 			}
-			function start() { if (!timer) timer = window.setInterval(tick, ms); }
-			function stop()  { if (timer) { window.clearInterval(timer); timer = null; } }
-			['mouseenter', 'touchstart', 'pointerdown', 'focusin'].forEach(function (t) { track.addEventListener(t, function () { paused = true; }, { passive: true }); });
-			['mouseleave', 'focusout'].forEach(function (t) { track.addEventListener(t, function () { paused = false; }, { passive: true }); });
-			if ('IntersectionObserver' in window) {
-				new IntersectionObserver(function (en) { (en[0] && en[0].isIntersecting) ? start() : stop(); }, { threshold: 0.1 }).observe(track);
-			} else { start(); }
 		}
 	}
 


### PR DESCRIPTION
User report: Auto Scroll should loop infinitely and continuously, not step forward and rewind. The Reels Strip now drifts marquee-style via requestAnimationFrame: the card set is cloned and `scrollLeft` wraps at the original set width, so the loop is invisible and unidirectional. Interval → **Speed** (s per card). Scroll-snap is disabled while drifting (it would fight the motion). Pauses on hover/touch/focus/off-screen; arrow steps pause the drift for 4s; reduced-motion keeps it off.