### PR TITLE
feat: declutter admin toolbar (Customize, updates counter, WPE Quick Links) (1.9.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.15] - 2026-07-09
+### Changed
+- **Admin toolbar decluttered.** The toolbar quick-links feature now also removes the **Customize** link (the fleet styles through Theme Setting / Beaver Builder, not the Customizer), the **updates counter**, and the **WP Engine Quick Links** menu. Capabilities are untouched — those screens stay reachable by URL; only the toolbar noise goes.
+
 ## [1.9.14] - 2026-07-09
 ### Added
 - **Theme Setting — Featured Image Banner control.** New checkbox list inside **General → Page Banner Background (No Image)**: which content types may use their **Featured Image** as the banner photo on their single pages. Unchecked types always show the **text-only banner** over the No-Image background (colour / pattern) configured right below it. **Staff is off by default** — portrait headshots crop badly in a wide banner, so staff singles now show a clean heading banner automatically (no setting change needed). Existing behaviour for pages, posts, teams, etc. is unchanged.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.14
+ * Version:           1.9.15
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.14' );
+define( 'DS_TOOLKIT_VERSION', '1.9.15' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-admin-bar-links.php
+++ b/features/class-ds-admin-bar-links.php
@@ -19,6 +19,22 @@ class DS_Admin_Bar_Links {
 
 	public function init() {
 		add_action( 'admin_bar_menu', array( $this, 'add_links' ), 82 );
+		add_action( 'admin_bar_menu', array( $this, 'remove_noise' ), 999 );
+	}
+
+	/**
+	 * Declutters the toolbar for everyone: the theme Customizer link (the fleet
+	 * styles through Theme Setting / Beaver Builder, not the Customizer), the
+	 * plugin-updates counter (updates are managed centrally / auto-update), and
+	 * the WP Engine Quick Links host menu. Capabilities are untouched — the
+	 * screens themselves stay reachable directly.
+	 *
+	 * @param WP_Admin_Bar $bar
+	 */
+	public function remove_noise( $bar ) {
+		$bar->remove_node( 'customize' );
+		$bar->remove_node( 'updates' );
+		$bar->remove_node( 'wpengine_adminbar' ); // WP Engine "Quick Links" (mu-plugin)
 	}
 
 	/** @param WP_Admin_Bar $bar */


### PR DESCRIPTION
Extends the toolbar-links feature (gen-6): removes the **Customize** link, the **updates counter**, and the **WP Engine Quick Links** node from the admin bar. Capabilities untouched; screens stay reachable by URL.