### PR TITLE
feat: photo-banner title control + toolbar grouping (1.9.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.16] - 2026-07-09
+### Added
+- **Theme Setting — Title on Photo Banners.** In General → Page Banner Background (No Image): choose whether page banners that **have** a photo/video show the auto page title (**Show** / **Hide** for an image-only banner), plus an optional **Title Colour (on photo)** (blank = the default light title). Site-wide defaults; the Hero Banner module can still override both per page.
+
+### Changed
+- **Admin toolbar order.** The content actions now sit side by side: **+ New · Edit Page · Beaver Builder**, followed by **Theme Setting · DS Toolkit** (other nodes such as Yoast move after).
+
 ## [1.9.15] - 2026-07-09
 ### Changed
 - **Admin toolbar decluttered.** The toolbar quick-links feature now also removes the **Customize** link (the fleet styles through Theme Setting / Beaver Builder, not the Customizer), the **updates counter**, and the **WP Engine Quick Links** menu. Capabilities are untouched — those screens stay reachable by URL; only the toolbar noise goes.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.15
+ * Version:           1.9.16
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.15' );
+define( 'DS_TOOLKIT_VERSION', '1.9.16' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-admin-bar-links.php
+++ b/features/class-ds-admin-bar-links.php
@@ -20,6 +20,27 @@ class DS_Admin_Bar_Links {
 	public function init() {
 		add_action( 'admin_bar_menu', array( $this, 'add_links' ), 82 );
 		add_action( 'admin_bar_menu', array( $this, 'remove_noise' ), 999 );
+		add_action( 'admin_bar_menu', array( $this, 'reorder' ), 2000 );
+	}
+
+	/**
+	 * Groups the content actions side by side: + New, Edit Page, Beaver Builder,
+	 * then Theme Setting and DS Toolkit (other nodes, e.g. Yoast, move after).
+	 * Works by removing and re-adding nodes in the desired order — the admin bar
+	 * renders root nodes in insertion order.
+	 *
+	 * @param WP_Admin_Bar $bar
+	 */
+	public function reorder( $bar ) {
+		$sequence = array( 'fl-builder-frontend-edit-link', 'ds-theme-setting', 'ds-toolkit-settings', 'wpseo-menu' );
+		$nodes    = array();
+		foreach ( $sequence as $nid ) {
+			$n = $bar->get_node( $nid );
+			if ( $n ) { $nodes[ $nid ] = $n; $bar->remove_node( $nid ); }
+		}
+		foreach ( $sequence as $nid ) {
+			if ( isset( $nodes[ $nid ] ) ) { $bar->add_node( (array) $nodes[ $nid ] ); }
+		}
 	}
 
 	/**

--- a/features/class-ds-theme-setting.php
+++ b/features/class-ds-theme-setting.php
@@ -146,6 +146,11 @@ CSS;
      * Default (never saved yet): every eligible type EXCEPT staff — portrait
      * headshots crop badly in a wide banner.
      */
+    /** Site-wide default: hide the auto title/subtitle on banners that HAVE a photo/video. */
+    public static function banner_photo_title_hidden() {
+        return 'hide' === get_theme_mod( 'ds-banner-photo-title', 'show' );
+    }
+
     public static function banner_featured_types() {
         $mod = get_theme_mod( 'ds-banner-featured-types', null );
         if ( is_array( $mod ) ) {
@@ -178,6 +183,10 @@ CSS;
         if ( '' !== $blend && 'normal' !== $blend ) { $decl .= 'background-blend-mode:' . $blend . ';'; }
         if ( '' === $decl ) { return; }
         echo '<style id="ds-banner-nobg-css">.ds-banner--no-bg{' . $decl . '}</style>' . "\n";
+        $pt_color = (string) get_theme_mod( 'ds-banner-photo-title-color', '' );
+        if ( '' !== $pt_color ) {
+            echo '<style id="ds-banner-photo-title-css">.ds-banner--has-bg .ds-hero-title{color:' . esc_html( $pt_color ) . ';}</style>' . "\n";
+        }
     }
 
     /**
@@ -823,7 +832,12 @@ JS;
                             <p class="ds-ts-help" style="margin:4px 0 0">Content types that may use their <strong>Featured Image</strong> as the banner photo on their single pages. Unchecked types always show the <strong>text-only banner</strong> over the background below &mdash; recommended off for <strong>Staff</strong>, whose portrait headshots crop badly in a wide banner.</p>
                         </div></div>
                         <?php
-                        $this->color_field( 'Background Color', 'general[banner_nobg_color]', $mod( 'ds-banner-nobg-color', 'var(--fl-global-light-background)' ) );
+                        $this->field_open( 'Title on Photo Banners' );
+                        echo $this->sel( 'general[banner_photo_title]', $mod( 'ds-banner-photo-title', 'show' ), array( 'show' => 'Show title', 'hide' => 'Hide title (image-only banner)' ) );
+                        $this->field_close();
+                        $this->color_field( 'Title Colour (on photo)', 'general[banner_photo_title_color]', $mod( 'ds-banner-photo-title-color', '' ) );
+                        echo '<p class="ds-ts-help">When the banner <strong>has</strong> a photo or video: show or hide the auto page title, and optionally set its colour (blank = the default light title). The Hero Banner module can still override both per page.</p>';
+                                                $this->color_field( 'Background Color', 'general[banner_nobg_color]', $mod( 'ds-banner-nobg-color', 'var(--fl-global-light-background)' ) );
                         ?>
                         <div class="ds-ts-field ds-ts-media"><label>Pattern / Image</label><div class="ds-ts-input">
                             <input type="hidden" class="ds-ts-media-url" name="general[banner_nobg_image]" value="<?php echo esc_attr( $bnbg_img ); ?>">
@@ -1068,6 +1082,8 @@ JS;
             if ( isset( $g['banner_featured_types_set'] ) ) {
                 set_theme_mod( 'ds-banner-featured-types', array_map( 'sanitize_key', (array) ( $g['banner_featured_types'] ?? array() ) ) );
             }
+            set_theme_mod( 'ds-banner-photo-title', ( $g['banner_photo_title'] ?? 'show' ) === 'hide' ? 'hide' : 'show' );
+            set_theme_mod( 'ds-banner-photo-title-color', $this->sanitize_color( $g['banner_photo_title_color'] ?? '' ) );
             set_theme_mod( 'ds-corner-radius', isset( $g['corner_radius'] ) && '' !== $g['corner_radius'] ? max( 0, min( 60, (int) $g['corner_radius'] ) ) : 8 );
             // Custom code: LeagueApps-only surface; stored raw like the BB theme's Code section.
             set_theme_mod( 'fl-css-code', isset( $g['css_code'] ) ? trim( $g['css_code'] ) : '' );

--- a/modules/ds-hero/ds-hero.php
+++ b/modules/ds-hero/ds-hero.php
@@ -270,7 +270,10 @@ class DS_Hero_Module extends FLBuilderModule {
 
 		// Hide the auto heading/subtitle when there's a background image/video, for a
 		// clean image-only banner.
-		$hide_text = ( ( $s->banner_hide_text ?? 'no' ) === 'yes' ) && $has_bg;
+		// Hide the auto title when the module says so, OR site-wide via Theme Setting
+		// -> Page Banner -> "Title on Photo Banners" (module Yes still wins per page).
+		$ts_hide   = class_exists( 'DS_Theme_Setting' ) && DS_Theme_Setting::banner_photo_title_hidden();
+		$hide_text = ( ( ( $s->banner_hide_text ?? 'no' ) === 'yes' ) || $ts_hide ) && $has_bg;
 		if ( $hide_text ) {
 			$heading = ''; $sub = '';
 		} elseif ( '' === $heading && FLBuilderModel::is_builder_active() ) {


### PR DESCRIPTION
Two fleet-test requests:
- **Theme Setting → Page Banner:** new **Title on Photo Banners** (Show / Hide for an image-only banner) + **Title Colour (on photo)**. Site-wide defaults emitted via wp_head; the Hero Banner's per-page fields still override (module Hide=Yes wins; node-scoped colour beats the global rule).
- **Admin toolbar:** content actions grouped side by side — **+ New · Edit Page · Beaver Builder · Theme Setting · DS Toolkit** (Yoast et al. move after). Reorder via remove + re-add at priority 2000 (the bar renders root nodes in insertion order).