### PR TITLE
fix: menu nested-flyout row anchoring + edge flip (1.9.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.17] - 2026-07-09
+### Fixed
+- **Menu — nested submenu overlap.** Two flyout bugs on deep dropdowns (e.g. a "More" item near the right edge): the nested flyout anchored to the **top of the whole panel** instead of its own row (submenu items were never positioned), and it always opened **rightward**, clipping off-screen / overlapping near the viewport edge. Flyouts now align to their row, and a lightweight edge check flips any dropdown or flyout to open **leftward** when it would overflow the right edge. Desktop only; the mobile overlay is untouched.
+
 ## [1.9.16] - 2026-07-09
 ### Added
 - **Theme Setting — Title on Photo Banners.** In General → Page Banner Background (No Image): choose whether page banners that **have** a photo/video show the auto page title (**Show** / **Hide** for an image-only banner), plus an optional **Title Colour (on photo)** (blank = the default light title). Site-wide defaults; the Hero Banner module can still override both per page.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.16
+ * Version:           1.9.17
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.16' );
+define( 'DS_TOOLKIT_VERSION', '1.9.17' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/css/frontend.css
+++ b/modules/ds-menu/css/frontend.css
@@ -22,7 +22,11 @@
 	transition: opacity .15s ease, transform .15s ease, visibility .15s;
 	box-shadow: 0 8px 24px rgba(0,0,0,.12); border-radius: var(--ds-radius); padding: 4px 0;
 }
+.ds-menu .ds-submenu .ds-menu-item { position: relative; } /* anchor flyouts to their OWN row, not the panel top */
 .ds-menu .ds-submenu .ds-submenu { top: 0; left: 100%; }
+/* Edge flip (class set by js when a panel would overflow the viewport's right edge). */
+.ds-menu .ds-submenu .ds-menu-item.ds-flip > .ds-submenu { left: auto; right: 100%; }
+.ds-menu > .ds-menu-item.ds-flip > .ds-submenu { left: auto; right: 0; }
 .ds-menu-item:hover > .ds-submenu,
 .ds-menu-item:focus-within > .ds-submenu {
 	opacity: 1; visibility: visible; transform: translateY(0);

--- a/modules/ds-menu/js/frontend.js
+++ b/modules/ds-menu/js/frontend.js
@@ -87,7 +87,29 @@
 		} );
 	}
 
-	function boot() { document.querySelectorAll( '.ds-menu-wrap' ).forEach( init ); }
+	/* Edge flip: when a dropdown / nested flyout would overflow the viewport's
+	   right edge (e.g. the last "More" item), flip it to open leftward instead
+	   of overlapping or clipping. Desktop only — the overlay renders submenus
+	   statically. Measured on hover (panels have layout while hidden). */
+	function initFlip( wrap ) {
+		if ( wrap.dsFlipInit ) { return; }
+		wrap.dsFlipInit = true;
+		wrap.addEventListener( 'mouseover', function ( e ) {
+			if ( wrap.classList.contains( 'ds-menu-open' ) ) { return; } // mobile overlay
+			var li = e.target && e.target.closest ? e.target.closest( '.ds-menu-item.has-children' ) : null;
+			if ( ! li || ! wrap.contains( li ) ) { return; }
+			var sub = null;
+			for ( var i = 0; i < li.children.length; i++ ) {
+				if ( li.children[ i ].classList && li.children[ i ].classList.contains( 'ds-submenu' ) ) { sub = li.children[ i ]; break; }
+			}
+			if ( ! sub ) { return; }
+			li.classList.remove( 'ds-flip' );
+			var r = sub.getBoundingClientRect();
+			if ( r.width > 0 && r.right > window.innerWidth - 8 ) { li.classList.add( 'ds-flip' ); }
+		} );
+	}
+
+	function boot() { document.querySelectorAll( '.ds-menu-wrap' ).forEach( function ( w ) { init( w ); initFlip( w ); } ); }
 
 	if ( 'loading' !== document.readyState ) { boot(); } else { document.addEventListener( 'DOMContentLoaded', boot ); }
 	// Re-init after a Beaver Builder partial refresh while editing.


### PR DESCRIPTION
From the fleet test (the "More" dropdown): nested flyouts anchored to the top of the whole panel (submenu items lacked `position:relative`) and always opened rightward, clipping off-screen near the right edge. Flyouts now anchor to their own row, and a hover-time edge check adds `.ds-flip` to open leftward when the panel would overflow the viewport. Desktop only; overlay untouched.