### PR TITLE
feat: {outline} text + theme default, CTA card shadow, no-image banner title colour (1.9.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.19] - 2026-07-10
+### Added
+- **Outline Text.** Wrap a word in `{outline}…{/outline}` in any LeagueApps module heading (Hero, Heading, CTA, Post Loop, Org Stats) and it renders **transparent with a stroked border** (`-webkit-text-stroke`). The site-wide default (stroke colour + width) lives in **Theme Setting → General → Outline Text** (blank colour = the text's own colour as the stroke); each module's Style tab gains **Outline Text Colour / Width** overrides (blank = theme default, via CSS variables).
+- **CTA — Card Shadow.** New Style option (None / Soft / Medium / Strong) that shadows the cards / tiles / cells of whichever CTA style is selected.
+- **Theme Setting — Title Colour (no image).** Companion to "Title Colour (on photo)": sets the banner title colour for pages whose banner has **no** photo/video. (Fleet report: the photo colour was working — verified in the served CSS — but the tested page had a no-image banner, which had no control until now.)
+
 ## [1.9.18] - 2026-07-09
 ### Changed
 - **Theme Setting — accordion renamed "Page Banner Background (No Image)" → "Page Banner".** The section now covers all banner behaviour (Featured Image Banner per post type, Title on Photo Banners + colour, and the no-image background), so the old name no longer fit. The background controls sit under a "Background (when the banner has no image)" sub-heading; the Hero module's help text referencing the old name was updated too. Settings and stored values are unchanged.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.18
+ * Version:           1.9.19
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.18' );
+define( 'DS_TOOLKIT_VERSION', '1.9.19' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-theme-setting.php
+++ b/features/class-ds-theme-setting.php
@@ -183,9 +183,16 @@ CSS;
         if ( '' !== $blend && 'normal' !== $blend ) { $decl .= 'background-blend-mode:' . $blend . ';'; }
         if ( '' === $decl ) { return; }
         echo '<style id="ds-banner-nobg-css">.ds-banner--no-bg{' . $decl . '}</style>' . "\n";
+        $o_color = (string) get_theme_mod( 'ds-outline-color', '' );
+        $o_width = max( 1, (int) get_theme_mod( 'ds-outline-width', 2 ) );
+        echo '<style id="ds-outline-text-css">.ds-outline-text{color:transparent;-webkit-text-stroke:var(--ds-outline-w,' . $o_width . 'px) var(--ds-outline-c,' . ( '' !== $o_color ? esc_html( $o_color ) : 'currentColor' ) . ');}</style>' . "\n";
         $pt_color = (string) get_theme_mod( 'ds-banner-photo-title-color', '' );
         if ( '' !== $pt_color ) {
             echo '<style id="ds-banner-photo-title-css">.ds-banner--has-bg .ds-hero-title{color:' . esc_html( $pt_color ) . ';}</style>' . "\n";
+        }
+        $nt_color = (string) get_theme_mod( 'ds-banner-nobg-title-color', '' );
+        if ( '' !== $nt_color ) {
+            echo '<style id="ds-banner-nobg-title-css">.ds-banner--no-bg .ds-hero-title{color:' . esc_html( $nt_color ) . ';}</style>' . "\n";
         }
     }
 
@@ -836,6 +843,7 @@ JS;
                         echo $this->sel( 'general[banner_photo_title]', $mod( 'ds-banner-photo-title', 'show' ), array( 'show' => 'Show title', 'hide' => 'Hide title (image-only banner)' ) );
                         $this->field_close();
                         $this->color_field( 'Title Colour (on photo)', 'general[banner_photo_title_color]', $mod( 'ds-banner-photo-title-color', '' ) );
+                        $this->color_field( 'Title Colour (no image)', 'general[banner_nobg_title_color]', $mod( 'ds-banner-nobg-title-color', '' ) );
                         echo '<p class="ds-ts-help">When the banner <strong>has</strong> a photo or video: show or hide the auto page title, and optionally set its colour (blank = the default light title). The Hero Banner module can still override both per page.</p>';
                                                 echo '<p style="margin:18px 0 6px;font-weight:600;border-top:1px solid #e2e4e7;padding-top:14px;">Background (when the banner has no image)</p>';
                         $this->color_field( 'Background Color', 'general[banner_nobg_color]', $mod( 'ds-banner-nobg-color', 'var(--fl-global-light-background)' ) );
@@ -858,6 +866,14 @@ JS;
                     	echo '<input type="number" min="0" max="60" name="general[corner_radius]" value="' . esc_attr( $mod( 'ds-corner-radius', '8' ) ) . '" class="small-text" style="width:90px"> <span style="opacity:.6">px</span>';
                     	$this->field_close();
                     	echo '<p class="ds-ts-help">One global corner radius for the LeagueApps card surfaces (cards, image tiles). Modules with their Corner Radius left blank inherit this; set a value on a module to override it there.</p>';
+                    $this->acc_end();
+
+                    $this->acc( 'Outline Text', false );
+                        $this->color_field( 'Outline Colour', 'general[outline_color]', $mod( 'ds-outline-color', '' ) );
+                        $this->field_open( 'Outline Width' );
+                        echo '<input type="number" min="1" max="8" name="general[outline_width]" value="' . esc_attr( $mod( 'ds-outline-width', '2' ) ) . '" class="small-text" style="width:90px"> <span style="opacity:.6">px</span>';
+                        $this->field_close();
+                        echo '<p class="ds-ts-help">Site-wide default for <strong>outlined text</strong>: wrap a word in <code>{outline}&hellip;{/outline}</code> in any LeagueApps module heading and it renders transparent with this stroke. Blank colour = the text&rsquo;s own colour as the stroke. Each module&rsquo;s Style tab can override both per instance.</p>';
                     $this->acc_end();
 
                     $card_id  = (int) get_option( 'ds_social_card_id', 0 );
@@ -1085,7 +1101,10 @@ JS;
             }
             set_theme_mod( 'ds-banner-photo-title', ( $g['banner_photo_title'] ?? 'show' ) === 'hide' ? 'hide' : 'show' );
             set_theme_mod( 'ds-banner-photo-title-color', $this->sanitize_color( $g['banner_photo_title_color'] ?? '' ) );
+            set_theme_mod( 'ds-banner-nobg-title-color', $this->sanitize_color( $g['banner_nobg_title_color'] ?? '' ) );
             set_theme_mod( 'ds-corner-radius', isset( $g['corner_radius'] ) && '' !== $g['corner_radius'] ? max( 0, min( 60, (int) $g['corner_radius'] ) ) : 8 );
+            set_theme_mod( 'ds-outline-color', $this->sanitize_color( $g['outline_color'] ?? '' ) );
+            set_theme_mod( 'ds-outline-width', isset( $g['outline_width'] ) && '' !== $g['outline_width'] ? max( 1, min( 8, (int) $g['outline_width'] ) ) : 2 );
             // Custom code: LeagueApps-only surface; stored raw like the BB theme's Code section.
             set_theme_mod( 'fl-css-code', isset( $g['css_code'] ) ? trim( $g['css_code'] ) : '' );
             set_theme_mod( 'fl-js-code', isset( $g['js_code'] ) ? trim( $g['js_code'] ) : '' );

--- a/modules/ds-cta/ds-cta.php
+++ b/modules/ds-cta/ds-cta.php
@@ -50,6 +50,7 @@ class DS_CTA_Module extends FLBuilderModule {
 	private function heading_html( $raw ) {
 		$h = DS_Module_UI::inline( (string) $raw ); // safe inline HTML (span/strong/em...) allowed
 		$h = str_replace( array( '{a}', '{/a}' ), array( '<span class="ds-cta-accent">', '</span>' ), $h );
+		$h = str_replace( array( '{outline}', '{/outline}' ), array( '<span class="ds-outline-text">', '</span>' ), $h );
 		return nl2br( $h );
 	}
 
@@ -458,7 +459,7 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 						'label'   => __( 'Heading', 'ds-toolkit' ),
 						'rows'    => 2,
 						'default' => '{a}Lorem{/a} Ipsum Dolor',
-						'help'    => __( 'Wrap a word in {a}…{/a} to colour it with the header accent.', 'ds-toolkit' ),
+						'help'    => __( 'Wrap a word in {a}…{/a} to colour it with the header accent. {outline}…{/outline} renders outlined (transparent, stroked) text — default style in Theme Setting.', 'ds-toolkit' ),
 					),
 					'header_label' => array( 'type' => 'text', 'label' => __( 'Right-side Label', 'ds-toolkit' ), 'default' => 'Lorem ipsum →' ),
 					'header_desc'  => array( 'type' => 'textarea', 'label' => __( 'Header Description', 'ds-toolkit' ), 'rows' => 3, 'help' => __( 'Paragraph beside the heading (Bento / Style 3).', 'ds-toolkit' ) ),
@@ -506,7 +507,7 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 						'label'   => __( 'Heading', 'ds-toolkit' ),
 						'rows'    => 2,
 						'default' => 'Questions? {a}Contact Us.{/a}',
-						'help'    => __( 'Wrap a word in {a}…{/a} to colour it with the accent. Line breaks are kept.', 'ds-toolkit' ),
+						'help'    => __( 'Wrap a word in {a}…{/a} to colour it with the accent. Line breaks are kept. {outline}…{/outline} renders outlined (transparent, stroked) text — default style in Theme Setting.', 'ds-toolkit' ),
 					),
 					'hero_align'        => array(
 						'type'    => 'select',
@@ -697,6 +698,20 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 				'title'  => __( 'Colours', 'ds-toolkit' ),
 				'fields' => array(
 					'accent_color'        => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Accent (eyebrow, chevron, bar)', 'ds-toolkit' ), 'default' => 'var(--fl-global-accent)', 'show_reset' => true ),
+					'outline_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Outline Text Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Stroke colour for {outline}…{/outline} text in this module. Blank = the Theme Setting default.', 'ds-toolkit' ) ),
+					'outline_width' => array( 'type' => 'unit', 'label' => __( 'Outline Text Width', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'help' => __( 'Blank = the Theme Setting default.', 'ds-toolkit' ), 'slider' => array( 'min' => 1, 'max' => 8, 'step' => 1 ) ),
+					'cta_shadow' => array(
+						'type'    => 'select',
+						'label'   => __( 'Card Shadow', 'ds-toolkit' ),
+						'default' => '',
+						'options' => array(
+							''       => __( 'None', 'ds-toolkit' ),
+							'soft'   => __( 'Soft', 'ds-toolkit' ),
+							'medium' => __( 'Medium', 'ds-toolkit' ),
+							'strong' => __( 'Strong', 'ds-toolkit' ),
+						),
+						'help'    => __( 'Drop shadow on the cards / tiles / cells of the selected style.', 'ds-toolkit' ),
+					),
 					'title_color'         => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Card Title', 'ds-toolkit' ), 'default' => 'var(--fl-global-white)', 'show_reset' => true ),
 					'card_bg'             => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Card Background', 'ds-toolkit' ), 'default' => 'var(--fl-global-dark-background)', 'show_reset' => true ),
 					'header_color'        => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Header Text', 'ds-toolkit' ), 'default' => 'var(--fl-global-headings)', 'show_reset' => true ),

--- a/modules/ds-cta/includes/frontend.css.php
+++ b/modules/ds-cta/includes/frontend.css.php
@@ -333,3 +333,12 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 		}
 	}
 }
+
+/* ---- Outline text ({outline}...{/outline}) per-module override: blank = Theme Setting. ---- */
+$oc_ov = DS_Module_UI::color( $settings->outline_color ?? '' );
+if ( '' !== $oc_ov ) { echo "$node { --ds-outline-c: {$oc_ov}; }\n"; }
+if ( isset( $settings->outline_width ) && '' !== $settings->outline_width ) { echo "$node { --ds-outline-w: " . max( 1, (int) $settings->outline_width ) . "px; }\n"; }
+
+/* ---- Card shadow (all styles): soft / medium / strong. ---- */
+$csh = array( 'soft' => '0 4px 14px rgba(0,0,0,.10)', 'medium' => '0 8px 24px rgba(0,0,0,.16)', 'strong' => '0 16px 40px rgba(0,0,0,.24)' )[ $settings->cta_shadow ?? '' ] ?? '';
+if ( '' !== $csh ) { echo "$node .ds-cta-card, $node .ds-cta-tile, $node .ds-cta-bento-cell, $node .ds-cta-hero-box { box-shadow: {$csh}; }\n"; }

--- a/modules/ds-heading/ds-heading.php
+++ b/modules/ds-heading/ds-heading.php
@@ -46,6 +46,7 @@ class DS_Heading_Module extends FLBuilderModule {
 	private function heading_html( $raw ) {
 		$h = DS_Module_UI::inline( (string) $raw ); // safe inline HTML (span/strong/em...) allowed
 		$h = str_replace( array( '{a}', '{/a}' ), array( '<span class="ds-heading-accent">', '</span>' ), $h );
+		$h = str_replace( array( '{outline}', '{/outline}' ), array( '<span class="ds-outline-text">', '</span>' ), $h );
 		return nl2br( $h );
 	}
 
@@ -157,7 +158,7 @@ FLBuilder::register_module( 'DS_Heading_Module', array(
 						'rows'        => 2,
 						'default'     => 'Section {a}Heading{/a}',
 						'connections' => array( 'string' ),
-						'help'        => __( 'Wrap a word in {a}…{/a} to colour it with the accent. Line breaks are kept. Use the connect (+) icon to pull a dynamic field (post title, ACF, etc.).', 'ds-toolkit' ),
+						'help'        => __( 'Wrap a word in {a}…{/a} to colour it with the accent. Line breaks are kept. Use the connect (+) icon to pull a dynamic field (post title, ACF, etc.). {outline}…{/outline} renders outlined (transparent, stroked) text — default style in Theme Setting.', 'ds-toolkit' ),
 					),
 					'heading_tag'         => array(
 						'type'    => 'select',
@@ -242,6 +243,8 @@ FLBuilder::register_module( 'DS_Heading_Module', array(
 					'subheading_color'    => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Sub-heading', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true ),
 					'heading_color'       => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Heading', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true ),
 					'heading_accent_color'=> array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Heading Accent {a}…{/a}', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true ),
+					'outline_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Outline Text Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Stroke colour for {outline}…{/outline} text in this module. Blank = the Theme Setting default.', 'ds-toolkit' ) ),
+					'outline_width' => array( 'type' => 'unit', 'label' => __( 'Outline Text Width', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'help' => __( 'Blank = the Theme Setting default.', 'ds-toolkit' ), 'slider' => array( 'min' => 1, 'max' => 8, 'step' => 1 ) ),
 					'description_color'   => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Description', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true ),
 				),
 			),

--- a/modules/ds-heading/includes/frontend.css.php
+++ b/modules/ds-heading/includes/frontend.css.php
@@ -120,3 +120,8 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 		}
 	}
 }
+
+/* ---- Outline text ({outline}...{/outline}) per-module override: blank = Theme Setting. ---- */
+$oc_ov = DS_Module_UI::color( $settings->outline_color ?? '' );
+if ( '' !== $oc_ov ) { echo "$node { --ds-outline-c: {$oc_ov}; }\n"; }
+if ( isset( $settings->outline_width ) && '' !== $settings->outline_width ) { echo "$node { --ds-outline-w: " . max( 1, (int) $settings->outline_width ) . "px; }\n"; }

--- a/modules/ds-hero/ds-hero.php
+++ b/modules/ds-hero/ds-hero.php
@@ -33,6 +33,7 @@ class DS_Hero_Module extends FLBuilderModule {
 	private function heading_html( $raw ) {
 		$h = DS_Module_UI::inline( (string) $raw ); // safe inline HTML (span/strong/em...) allowed
 		$h = str_replace( array( '{a}', '{/a}' ), array( '<span class="ds-hero-accent">', '</span>' ), $h );
+		$h = str_replace( array( '{outline}', '{/outline}' ), array( '<span class="ds-outline-text">', '</span>' ), $h );
 		return nl2br( $h );
 	}
 
@@ -388,7 +389,7 @@ FLBuilder::register_module( 'DS_Hero_Module', array(
 						'label'   => __( 'Headline', 'ds-toolkit' ),
 						'rows'    => 3,
 						'default' => "Lorem Ipsum\nDolor {a}Sit{/a}",
-						'help'    => __( 'Line breaks are kept. Wrap a word in {a}…{/a} to colour it with the accent colour.', 'ds-toolkit' ),
+						'help'    => __( 'Line breaks are kept. Wrap a word in {a}…{/a} to colour it with the accent colour. {outline}…{/outline} renders outlined (transparent, stroked) text — default style in Theme Setting.', 'ds-toolkit' ),
 					),
 					'subtext' => array(
 						'type'    => 'textarea',
@@ -638,6 +639,8 @@ FLBuilder::register_module( 'DS_Hero_Module', array(
 					'eyebrow_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Eyebrow', 'ds-toolkit' ), 'default' => 'var(--fl-global-accent)', 'show_reset' => true ),
 					'title_color'   => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Headline', 'ds-toolkit' ), 'default' => 'var(--fl-global-white)', 'show_reset' => true ),
 					'accent_color'  => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Accent Word', 'ds-toolkit' ), 'default' => 'var(--fl-global-accent)', 'show_reset' => true, 'help' => __( 'Colour of {a}…{/a} text and the primary button.', 'ds-toolkit' ) ),
+					'outline_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Outline Text Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Stroke colour for {outline}…{/outline} text in this module. Blank = the Theme Setting default.', 'ds-toolkit' ) ),
+					'outline_width' => array( 'type' => 'unit', 'label' => __( 'Outline Text Width', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'help' => __( 'Blank = the Theme Setting default.', 'ds-toolkit' ), 'slider' => array( 'min' => 1, 'max' => 8, 'step' => 1 ) ),
 					'sub_color'     => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Subtext', 'ds-toolkit' ), 'default' => 'var(--fl-global-white)', 'show_reset' => true ),
 					'stat_num_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Stat Number', 'ds-toolkit' ), 'default' => 'var(--fl-global-white)', 'show_reset' => true ),
 					'stat_label_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Stat Label', 'ds-toolkit' ), 'default' => 'var(--fl-global-accent)', 'show_reset' => true ),

--- a/modules/ds-hero/includes/frontend.css.php
+++ b/modules/ds-hero/includes/frontend.css.php
@@ -256,3 +256,8 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 		}
 	}
 }
+
+/* ---- Outline text ({outline}...{/outline}) per-module override: blank = Theme Setting. ---- */
+$oc_ov = DS_Module_UI::color( $settings->outline_color ?? '' );
+if ( '' !== $oc_ov ) { echo "$node { --ds-outline-c: {$oc_ov}; }\n"; }
+if ( isset( $settings->outline_width ) && '' !== $settings->outline_width ) { echo "$node { --ds-outline-w: " . max( 1, (int) $settings->outline_width ) . "px; }\n"; }

--- a/modules/ds-orgstats/ds-orgstats.php
+++ b/modules/ds-orgstats/ds-orgstats.php
@@ -49,6 +49,7 @@ class DS_OrgStats_Module extends FLBuilderModule {
 	private function heading_html( $raw ) {
 		$h = esc_html( (string) $raw );
 		$h = str_replace( array( '{a}', '{/a}' ), array( '<span class="ds-orgstats-accent">', '</span>' ), $h );
+		$h = str_replace( array( '{outline}', '{/outline}' ), array( '<span class="ds-outline-text">', '</span>' ), $h );
 		return nl2br( $h );
 	}
 
@@ -255,7 +256,7 @@ FLBuilder::register_module( 'DS_OrgStats_Module', array(
 						'rows'        => 2,
 						'default'     => 'Lorem {a}Ipsum{/a}',
 						'connections' => array( 'string' ),
-						'help'        => __( 'Line breaks kept. Wrap a word in {a}…{/a} to colour it with the accent.', 'ds-toolkit' ),
+						'help'        => __( 'Line breaks kept. Wrap a word in {a}…{/a} to colour it with the accent. {outline}…{/outline} renders outlined (transparent, stroked) text — default style in Theme Setting.', 'ds-toolkit' ),
 					),
 				),
 			),
@@ -395,6 +396,8 @@ FLBuilder::register_module( 'DS_OrgStats_Module', array(
 					'eyebrow_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Eyebrow', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Blank falls back to the global Accent colour. The leading rule tracks this colour.', 'ds-toolkit' ) ),
 					'heading_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Heading', 'ds-toolkit' ), 'default' => 'var(--fl-global-white)', 'show_reset' => true ),
 					'accent_color'  => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Accent (heading word, prefix, suffix)', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Blank falls back to the global Accent colour.', 'ds-toolkit' ) ),
+					'outline_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Outline Text Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Stroke colour for {outline}…{/outline} text in this module. Blank = the Theme Setting default.', 'ds-toolkit' ) ),
+					'outline_width' => array( 'type' => 'unit', 'label' => __( 'Outline Text Width', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'help' => __( 'Blank = the Theme Setting default.', 'ds-toolkit' ), 'slider' => array( 'min' => 1, 'max' => 8, 'step' => 1 ) ),
 					'number_color'  => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Number', 'ds-toolkit' ), 'default' => 'var(--fl-global-white)', 'show_reset' => true ),
 					'label_color'   => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Label', 'ds-toolkit' ), 'default' => 'var(--fl-global-accent)', 'show_reset' => true ),
 				),

--- a/modules/ds-orgstats/includes/frontend.css.php
+++ b/modules/ds-orgstats/includes/frontend.css.php
@@ -163,3 +163,8 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 		}
 	}
 }
+
+/* ---- Outline text ({outline}...{/outline}) per-module override: blank = Theme Setting. ---- */
+$oc_ov = DS_Module_UI::color( $settings->outline_color ?? '' );
+if ( '' !== $oc_ov ) { echo "$node { --ds-outline-c: {$oc_ov}; }\n"; }
+if ( isset( $settings->outline_width ) && '' !== $settings->outline_width ) { echo "$node { --ds-outline-w: " . max( 1, (int) $settings->outline_width ) . "px; }\n"; }

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -95,6 +95,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 	private function heading_html( $raw ) {
 		$h = DS_Module_UI::inline( (string) $raw ); // safe inline HTML (span/strong/em...) allowed
 		$h = str_replace( array( '{a}', '{/a}' ), array( '<span class="ds-news-accent">', '</span>' ), $h );
+		$h = str_replace( array( '{outline}', '{/outline}' ), array( '<span class="ds-outline-text">', '</span>' ), $h );
 		return nl2br( $h );
 	}
 
@@ -935,7 +936,7 @@ $ds_pl_form = array(
 						'label'   => __( 'Heading', 'ds-toolkit' ),
 						'rows'    => 2,
 						'default' => '{a}Lorem{/a} Ipsum',
-						'help'    => __( 'Wrap a word in {a}…{/a} to colour it with the header accent.', 'ds-toolkit' ),
+						'help'    => __( 'Wrap a word in {a}…{/a} to colour it with the header accent. {outline}…{/outline} renders outlined (transparent, stroked) text — default style in Theme Setting.', 'ds-toolkit' ),
 					),
 					'show_button'  => array(
 						'type'    => 'select',
@@ -1298,6 +1299,8 @@ $ds_pl_form = array(
 					'section_bg'          => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Section Background', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
 					'heading_color'       => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Heading Text', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
 					'heading_accent_color'=> array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Heading Accent', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+					'outline_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Outline Text Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Stroke colour for {outline}…{/outline} text in this module. Blank = the Theme Setting default.', 'ds-toolkit' ) ),
+					'outline_width' => array( 'type' => 'unit', 'label' => __( 'Outline Text Width', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'help' => __( 'Blank = the Theme Setting default.', 'ds-toolkit' ), 'slider' => array( 'min' => 1, 'max' => 8, 'step' => 1 ) ),
 					'heading_typography'  => array( 'type' => 'typography', 'label' => __( 'Heading Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-news-heading' ) ),
 					'btn_global' => array(
 						'type'    => 'select',

--- a/modules/ds-post-loop/includes/frontend.css.php
+++ b/modules/ds-post-loop/includes/frontend.css.php
@@ -486,3 +486,8 @@ if ( ( $settings->card_layout ?? '' ) === 'program' ) {
 		if ( '' !== $bhd ) { echo "$node .ds-programs .ds-program-card .ds-program-btn:hover,$node .ds-programs .ds-program-card:hover .ds-program-btn{{$bhd}}\n"; }
 	}
 }
+
+/* ---- Outline text ({outline}...{/outline}) per-module override: blank = Theme Setting. ---- */
+$oc_ov = DS_Module_UI::color( $settings->outline_color ?? '' );
+if ( '' !== $oc_ov ) { echo "$node { --ds-outline-c: {$oc_ov}; }\n"; }
+if ( isset( $settings->outline_width ) && '' !== $settings->outline_width ) { echo "$node { --ds-outline-w: " . max( 1, (int) $settings->outline_width ) . "px; }\n"; }


### PR DESCRIPTION
Three items:
- **Outline Text:** `{outline}…{/outline}` in any module heading renders transparent, stroked text. Site default in **Theme Setting → Outline Text** (colour + width, CSS-var based); per-module Style overrides in Hero, Heading, CTA, Post Loop, Org Stats.
- **CTA Card Shadow:** None/Soft/Medium/Strong across all CTA styles.
- **Title Colour (no image):** the fleet report "title colour doesn't work" was diagnosed live — the emitted CSS was correct but the tested page's banner is `ds-banner--no-bg`, which the "(on photo)" control deliberately doesn't touch. Added the companion no-image colour control.