### PR TITLE
feat: WYSIWYG description fields across modules (1.9.20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.20] - 2026-07-10
+### Changed
+- **Description / body textareas are now WYSIWYG editors** across the LeagueApps modules (like the Program card in 1.9.12): CTA bento-cell Description + Header Description, Post Loop Sponsor Description, Hero Subtext + Banner Subtitle, and the Heading module Description. All render sanitised HTML (`wp_kses_post`, auto-paragraphs). **Heading fields intentionally stay plain textareas** — a visual editor injects `<p>` wrappers, which would corrupt the `<h1>/<h2>` markup; they keep their `{a}` / `{outline}` tokens and line-break support.
+
 ## [1.9.19] - 2026-07-10
 ### Added
 - **Outline Text.** Wrap a word in `{outline}…{/outline}` in any LeagueApps module heading (Hero, Heading, CTA, Post Loop, Org Stats) and it renders **transparent with a stroked border** (`-webkit-text-stroke`). The site-wide default (stroke colour + width) lives in **Theme Setting → General → Outline Text** (blank colour = the text's own colour as the stroke); each module's Style tab gains **Outline Text Colour / Width** overrides (blank = theme default, via CSS variables).

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.19
+ * Version:           1.9.20
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.19' );
+define( 'DS_TOOLKIT_VERSION', '1.9.20' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-cta/css/frontend.css
+++ b/modules/ds-cta/css/frontend.css
@@ -122,3 +122,7 @@
 @media (prefers-reduced-motion:reduce){
   .ds-cta--style4 .ds-cta-hero-bg,.ds-cta--style4 .ds-cta-hero-btn,.ds-cta--style4 .ds-cta-hero-btn-arrow svg,.ds-cta--style4 .ds-cta-hero-social-link{transition:none;}
 }
+
+/* WYSIWYG descriptions render <p>s inside the desc containers. */
+.ds-cta--style3 .ds-cta-bento-desc p{margin:0 0 .6em;}
+.ds-cta--style3 .ds-cta-bento-desc p:last-child{margin-bottom:0;}

--- a/modules/ds-cta/ds-cta.php
+++ b/modules/ds-cta/ds-cta.php
@@ -191,7 +191,7 @@ class DS_CTA_Module extends FLBuilderModule {
 		if ( ( $s->show_header ?? 'yes' ) === 'yes' && ( ! empty( $s->heading ) || ! empty( $s->header_desc ) ) ) {
 			echo '<div class="ds-cta-bento-head">';
 			if ( ! empty( $s->heading ) ) { echo '<h2 class="ds-cta-heading">' . $this->heading_html( $s->heading ) . '</h2>'; }
-			if ( ! empty( $s->header_desc ) ) { echo '<p class="ds-cta-bento-desc">' . nl2br( esc_html( $s->header_desc ) ) . '</p>'; }
+			if ( ! empty( $s->header_desc ) ) { echo '<div class="ds-cta-bento-desc">' . wpautop( wp_kses_post( $s->header_desc ) ) . '</div>'; }
 			echo '</div>';
 		}
 
@@ -404,7 +404,7 @@ FLBuilder::register_settings_form( 'ds_cta_card_form', array(
 							'toggle'  => array( 'text' => array( 'fields' => array( 'desc' ) ) ),
 							'help'    => __( 'Bento (Style 3) only. Image cells use the Background Image; Text cells use Title + Description + the Link Text button.', 'ds-toolkit' ),
 						),
-						'desc'     => array( 'type' => 'textarea', 'label' => __( 'Description', 'ds-toolkit' ), 'rows' => 3, 'help' => __( 'Plain text; line breaks kept. Basic inline HTML (e.g. <strong>, <a>) is allowed.', 'ds-toolkit' ) ),
+						'desc'     => array( 'type' => 'editor', 'media_buttons' => false, 'rows' => 6, 'wpautop' => false, 'label' => __( 'Description', 'ds-toolkit' ) ),
 						'col_span' => array( 'type' => 'unit', 'label' => __( 'Column Span', 'ds-toolkit' ), 'default' => '1', 'slider' => array( 'min' => 1, 'max' => 4, 'step' => 1 ) ),
 						'row_span' => array( 'type' => 'unit', 'label' => __( 'Row Span', 'ds-toolkit' ), 'default' => '1', 'slider' => array( 'min' => 1, 'max' => 3, 'step' => 1 ) ),
 					),
@@ -462,7 +462,7 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 						'help'    => __( 'Wrap a word in {a}…{/a} to colour it with the header accent. {outline}…{/outline} renders outlined (transparent, stroked) text — default style in Theme Setting.', 'ds-toolkit' ),
 					),
 					'header_label' => array( 'type' => 'text', 'label' => __( 'Right-side Label', 'ds-toolkit' ), 'default' => 'Lorem ipsum →' ),
-					'header_desc'  => array( 'type' => 'textarea', 'label' => __( 'Header Description', 'ds-toolkit' ), 'rows' => 3, 'help' => __( 'Paragraph beside the heading (Bento / Style 3).', 'ds-toolkit' ) ),
+					'header_desc'  => array( 'type' => 'editor', 'media_buttons' => false, 'rows' => 6, 'wpautop' => false, 'label' => __( 'Header Description', 'ds-toolkit' ), 'help' => __( 'Paragraph beside the heading (Bento / Style 3).', 'ds-toolkit' ) ),
 				),
 			),
 			'cards' => array(

--- a/modules/ds-heading/ds-heading.php
+++ b/modules/ds-heading/ds-heading.php
@@ -186,7 +186,7 @@ FLBuilder::register_module( 'DS_Heading_Module', array(
 						'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No', 'ds-toolkit' ) ),
 						'toggle'  => array( 'yes' => array( 'fields' => array( 'description' ) ) ),
 					),
-					'description'      => array( 'type' => 'textarea', 'label' => __( 'Description', 'ds-toolkit' ), 'rows' => 4, 'connections' => array( 'string' ), 'help' => __( 'Paragraph under the heading. Line breaks kept; basic inline HTML (e.g. <strong>, <a>) allowed. Use the connect (+) icon for a dynamic field.', 'ds-toolkit' ) ),
+					'description'      => array( 'type' => 'editor', 'media_buttons' => false, 'wpautop' => false, 'label' => __( 'Description', 'ds-toolkit' ), 'rows' => 4, 'connections' => array( 'string' ), 'help' => __( 'Paragraph under the heading. Line breaks kept; basic inline HTML (e.g. <strong>, <a>) allowed. Use the connect (+) icon for a dynamic field.', 'ds-toolkit' ) ),
 				),
 			),
 		),

--- a/modules/ds-hero/css/frontend.css
+++ b/modules/ds-hero/css/frontend.css
@@ -118,3 +118,7 @@
 .ds-banner-crumbs a:hover{text-decoration:underline;}
 .ds-banner--has-bg .ds-banner-crumbs,.ds-banner--has-bg .ds-banner-crumbs a,.ds-banner--has-bg .ds-banner-crumbs .breadcrumb_last{color:rgba(255,255,255,.85);}
 .ds-banner--no-bg .ds-banner-crumbs,.ds-banner--no-bg .ds-banner-crumbs a,.ds-banner--no-bg .ds-banner-crumbs .breadcrumb_last{color:var(--fl-global-body,#5b6671);}
+
+/* WYSIWYG subtext/subtitle paragraphs (rendered in a div wrapper). */
+.ds-hero-sub p{margin:0 0 .6em;}
+.ds-hero-sub p:last-child{margin-bottom:0;}

--- a/modules/ds-hero/ds-hero.php
+++ b/modules/ds-hero/ds-hero.php
@@ -202,7 +202,7 @@ class DS_Hero_Module extends FLBuilderModule {
 			echo '<h1 class="ds-hero-title">' . $this->heading_html( $s->heading ) . '</h1>';
 		}
 		if ( ! empty( $s->subtext ) ) {
-			echo '<p class="ds-hero-sub">' . nl2br( esc_html( $s->subtext ) ) . '</p>';
+			echo '<div class="ds-hero-sub">' . wpautop( wp_kses_post( $s->subtext ) ) . '</div>';
 		}
 
 		$b1 = $this->button( $s->btn1_text ?? '', $s->btn1_link ?? '', $s->btn1_style ?? 'primary', true );
@@ -314,7 +314,7 @@ class DS_Hero_Module extends FLBuilderModule {
 		if ( '' !== $crumbs && 'top' === $crumb_pos ) { echo $crumbs; }
 		if ( '' !== $eyebrow ) { echo '<span class="ds-banner-eyebrow">' . esc_html( $eyebrow ) . '</span>'; }
 		if ( '' !== $heading ) { echo '<h1 class="ds-hero-title">' . $this->heading_html( $heading ) . '</h1>'; }
-		if ( '' !== $sub )     { echo '<p class="ds-hero-sub">' . nl2br( esc_html( $sub ) ) . '</p>'; }
+		if ( '' !== $sub )     { echo '<div class="ds-hero-sub">' . wpautop( wp_kses_post( $sub ) ) . '</div>'; }
 		if ( '' !== $crumbs && 'below' === $crumb_pos ) { echo $crumbs; }
 		echo '</div></div></section>';
 	}
@@ -351,7 +351,7 @@ FLBuilder::register_module( 'DS_Hero_Module', array(
 				'fields'      => array(
 					'banner_eyebrow'  => array( 'type' => 'text', 'label' => __( 'Sub-heading (eyebrow)', 'ds-toolkit' ), 'default' => '', 'connections' => array( 'string' ), 'help' => __( 'Small line above the heading (optional).', 'ds-toolkit' ) ),
 					'banner_heading'  => array( 'type' => 'text', 'label' => __( 'Heading', 'ds-toolkit' ), 'default' => '', 'connections' => array( 'string' ), 'help' => __( 'Blank = the page’s Banner Title, or the page name.', 'ds-toolkit' ) ),
-					'banner_subtitle' => array( 'type' => 'textarea', 'label' => __( 'Subtitle', 'ds-toolkit' ), 'default' => '', 'rows' => 2, 'connections' => array( 'string' ), 'help' => __( 'Blank = the page’s Banner Subtitle.', 'ds-toolkit' ) ),
+					'banner_subtitle' => array( 'type' => 'editor', 'media_buttons' => false, 'wpautop' => false, 'label' => __( 'Subtitle', 'ds-toolkit' ), 'default' => '', 'rows' => 2, 'connections' => array( 'string' ), 'help' => __( 'Blank = the page’s Banner Subtitle.', 'ds-toolkit' ) ),
 					'banner_image'    => array( 'type' => 'photo', 'label' => __( 'Background Photo', 'ds-toolkit' ), 'show_remove' => true, 'connections' => array( 'photo' ), 'help' => __( 'Blank = the page’s Banner photo.', 'ds-toolkit' ) ),
 					'banner_video'    => array( 'type' => 'text', 'label' => __( 'Background Video URL', 'ds-toolkit' ), 'default' => '', 'connections' => array( 'string' ), 'help' => __( 'Optional MP4 URL. Blank = the page’s Banner video.', 'ds-toolkit' ) ),
 					'banner_hide_text' => array(
@@ -392,7 +392,7 @@ FLBuilder::register_module( 'DS_Hero_Module', array(
 						'help'    => __( 'Line breaks are kept. Wrap a word in {a}…{/a} to colour it with the accent colour. {outline}…{/outline} renders outlined (transparent, stroked) text — default style in Theme Setting.', 'ds-toolkit' ),
 					),
 					'subtext' => array(
-						'type'    => 'textarea',
+						'type'    => 'editor', 'media_buttons' => false, 'wpautop' => false,
 						'label'   => __( 'Subtext', 'ds-toolkit' ),
 						'rows'    => 3,
 						'default' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt.',

--- a/modules/ds-post-loop/css/frontend.css
+++ b/modules/ds-post-loop/css/frontend.css
@@ -197,3 +197,7 @@
 .ds-tourn-card:hover .ds-tourn-btn{background:var(--fl-global-accent);}
 @media(max-width:1024px){.ds-tourn-grid{grid-template-columns:repeat(2,1fr);}}
 @media(max-width:600px){.ds-tourn-grid{grid-template-columns:1fr;}}
+
+/* WYSIWYG sponsor description paragraphs. */
+.ds-sponsor-desc p{margin:0 0 .5em;}
+.ds-sponsor-desc p:last-child{margin-bottom:0;}

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -657,7 +657,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			if ( $has ) { echo '<a class="ds-card-link" href="' . esc_url( $url ) . '"' . ( '_blank' === $target ? ' target="_blank" rel="noopener"' : '' ) . ' aria-label="' . esc_attr( $cap ) . '"></a>'; }
 			if ( '' !== $img )  { echo '<div class="ds-sponsor-logo"><img src="' . esc_url( $img ) . '" alt="' . esc_attr( $cap ) . '" loading="lazy" /></div>'; }
 			if ( '' !== $cap )  { echo '<h3 class="ds-sponsor-name">' . esc_html( $cap ) . '</h3>'; }
-			if ( '' !== $desc ) { echo '<p class="ds-sponsor-desc">' . esc_html( $desc ) . '</p>'; }
+			if ( '' !== $desc ) { echo '<div class="ds-sponsor-desc">' . wpautop( wp_kses_post( $desc ) ) . '</div>'; }
 			echo '</div>';
 		}
 		$this->loop_close();
@@ -811,7 +811,7 @@ FLBuilder::register_settings_form( 'ds_sponsor_form', array(
 						'sponsor_image'   => array( 'type' => 'photo', 'label' => __( 'Logo / Image', 'ds-toolkit' ), 'show_remove' => true, 'connections' => array( 'photo' ) ),
 						'sponsor_caption' => array( 'type' => 'text', 'label' => __( 'Caption / Name', 'ds-toolkit' ), 'connections' => array( 'string' ) ),
 						'sponsor_url'     => array( 'type' => 'link', 'label' => __( 'Link URL', 'ds-toolkit' ), 'connections' => array( 'url' ) ),
-						'sponsor_desc'    => array( 'type' => 'textarea', 'label' => __( 'Description', 'ds-toolkit' ), 'rows' => 3 ),
+						'sponsor_desc'    => array( 'type' => 'editor', 'media_buttons' => false, 'rows' => 6, 'wpautop' => false, 'label' => __( 'Description', 'ds-toolkit' ) ),
 					),
 				),
 			),


### PR DESCRIPTION
Converts every description/body textarea in the LeagueApps modules to the WP visual editor (matching the 1.9.12 Program card): CTA bento Description + Header Description, Post Loop Sponsor Description, Hero Subtext + Banner Subtitle, Heading Description. Rendered via `wpautop( wp_kses_post() )` in div wrappers with paragraph CSS. **Heading textareas stay** — editor `<p>` wrappers would corrupt h-tag markup; they keep `{a}`/`{outline}` tokens.