### PR TITLE
feat: toolbar content trio last + hard Launchpad-6 lock (1.9.21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.21] - 2026-07-10
+### Changed
+- **Admin toolbar: content actions moved to the end.** Final order after the site name: **Theme Setting · DS Toolkit · (Yoast) · + New · Edit Page · Beaver Builder** — the editing trio grouped at the last part of the bar.
+- **Toolbar customisations hard-locked to Launchpad 6.** All toolbar changes (quick links, declutter, reorder) were already blueprint-6 gated via the feature registry; the class now also refuses to run below blueprint 6 outright, so older installs can never receive them.
+
 ## [1.9.20] - 2026-07-10
 ### Changed
 - **Description / body textareas are now WYSIWYG editors** across the LeagueApps modules (like the Program card in 1.9.12): CTA bento-cell Description + Header Description, Post Loop Sponsor Description, Hero Subtext + Banner Subtitle, and the Heading module Description. All render sanitised HTML (`wp_kses_post`, auto-paragraphs). **Heading fields intentionally stay plain textareas** — a visual editor injects `<p>` wrappers, which would corrupt the `<h1>/<h2>` markup; they keep their `{a}` / `{outline}` tokens and line-break support.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.20
+ * Version:           1.9.21
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.20' );
+define( 'DS_TOOLKIT_VERSION', '1.9.21' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-admin-bar-links.php
+++ b/features/class-ds-admin-bar-links.php
@@ -18,6 +18,13 @@ class DS_Admin_Bar_Links {
 	}
 
 	public function init() {
+		// HARD LOCK: every toolbar customisation in this class (links, declutter,
+		// reorder) is Launchpad 6+ ONLY. The feature registry already gates this
+		// via min_blueprint => 6; this guard makes the lock explicit even if the
+		// settings key were ever set on an older install.
+		if ( DS_Toolkit::blueprint_version() < 6 ) {
+			return;
+		}
 		add_action( 'admin_bar_menu', array( $this, 'add_links' ), 82 );
 		add_action( 'admin_bar_menu', array( $this, 'remove_noise' ), 999 );
 		add_action( 'admin_bar_menu', array( $this, 'reorder' ), 2000 );
@@ -32,7 +39,10 @@ class DS_Admin_Bar_Links {
 	 * @param WP_Admin_Bar $bar
 	 */
 	public function reorder( $bar ) {
-		$sequence = array( 'fl-builder-frontend-edit-link', 'ds-theme-setting', 'ds-toolkit-settings', 'wpseo-menu' );
+		// Final order after the site name: Theme Setting, DS Toolkit, (Yoast…),
+		// then the CONTENT ACTIONS grouped at the very end of the bar:
+		// + New · Edit Page · Beaver Builder.
+		$sequence = array( 'ds-theme-setting', 'ds-toolkit-settings', 'wpseo-menu', 'new-content', 'edit', 'fl-builder-frontend-edit-link' );
 		$nodes    = array();
 		foreach ( $sequence as $nid ) {
 			$n = $bar->get_node( $nid );


### PR DESCRIPTION
Per fleet feedback: **+ New · Edit Page · Beaver Builder** now sit grouped at the END of the admin bar (after Theme Setting · DS Toolkit · Yoast). All toolbar customisations are hard-locked to Launchpad 6: on top of the `min_blueprint => 6` registry gate, the class itself now bails below blueprint 6. Verified the other admin-bar-touching features (disable-comments, content-router) are also gen-6 registered.