### PR TITLE
fix: banner-title visibility follows Theme Setting (1.9.22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.22] - 2026-07-10
+### Fixed
+- **Banner title on photo banners now obeys the Theme Setting.** Root cause of "Title on Photo Banners = Show" doing nothing on fleet sites: older blueprints baked the Hero module's per-instance "Hide (image only)" into the base template, and that value always beat the Theme Setting — the site-wide control could never win. Precedence flipped: **Theme Setting → Page Banner → Title on Photo Banners is the site-wide authority**; legacy baked module values follow it; only the module's new explicit per-instance choices ("Always show" / "Always hide — image only") override it. Verified against the live fleet test page markup.
+
 ## [1.9.21] - 2026-07-10
 ### Changed
 - **Admin toolbar: content actions moved to the end.** Final order after the site name: **Theme Setting · DS Toolkit · (Yoast) · + New · Edit Page · Beaver Builder** — the editing trio grouped at the last part of the bar.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.21
+ * Version:           1.9.22
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.21' );
+define( 'DS_TOOLKIT_VERSION', '1.9.22' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-hero/ds-hero.php
+++ b/modules/ds-hero/ds-hero.php
@@ -271,10 +271,18 @@ class DS_Hero_Module extends FLBuilderModule {
 
 		// Hide the auto heading/subtitle when there's a background image/video, for a
 		// clean image-only banner.
-		// Hide the auto title when the module says so, OR site-wide via Theme Setting
-		// -> Page Banner -> "Title on Photo Banners" (module Yes still wins per page).
-		$ts_hide   = class_exists( 'DS_Theme_Setting' ) && DS_Theme_Setting::banner_photo_title_hidden();
-		$hide_text = ( ( ( $s->banner_hide_text ?? 'no' ) === 'yes' ) || $ts_hide ) && $has_bg;
+		// Title on photo banners: the Theme Setting (Page Banner -> Title on Photo
+		// Banners) is the SITE-WIDE authority. Only the module's new explicit
+		// per-page values (force_show / force_hide) override it. Legacy baked
+		// values ('yes'/'no' from older blueprints) follow the Theme Setting too —
+		// they were build-time defaults, not per-page choices, and previously made
+		// the site-wide control impossible to honour.
+		$ts_hide = class_exists( 'DS_Theme_Setting' ) && DS_Theme_Setting::banner_photo_title_hidden();
+		$mode    = (string) ( $s->banner_hide_text ?? '' );
+		if ( 'force_show' === $mode )     { $hide = false; }
+		elseif ( 'force_hide' === $mode ) { $hide = true; }
+		else                              { $hide = $ts_hide; }
+		$hide_text = $hide && $has_bg;
 		if ( $hide_text ) {
 			$heading = ''; $sub = '';
 		} elseif ( '' === $heading && FLBuilderModel::is_builder_active() ) {
@@ -357,10 +365,11 @@ FLBuilder::register_module( 'DS_Hero_Module', array(
 					'banner_hide_text' => array(
 						'type'    => 'select',
 						'label'   => __( 'Text When Image Present', 'ds-toolkit' ),
-						'default' => 'no',
+						'default' => '',
 						'options' => array(
-							'no'  => __( 'Show heading & subtitle', 'ds-toolkit' ),
-							'yes' => __( 'Hide (image only)', 'ds-toolkit' ),
+							''           => __( 'Theme Setting default (recommended)', 'ds-toolkit' ),
+							'force_show' => __( 'Always show (this instance)', 'ds-toolkit' ),
+							'force_hide' => __( 'Always hide — image only (this instance)', 'ds-toolkit' ),
 						),
 						'help'    => __( 'When the banner has a background image or video, hide the auto heading / subtitle for a clean image-only banner.', 'ds-toolkit' ),
 					),


### PR DESCRIPTION
Live fleet diagnosis (summer-camps page): the banner title stayed hidden despite Theme Setting = Show because the base template baked the hero's per-instance `banner_hide_text = yes`, which always outranked the Theme Setting. Precedence flipped: the **Theme Setting is the site-wide authority**, legacy baked values follow it, and only the module's new explicit `force_show`/`force_hide` choices override per instance.