### PR TITLE
fix: bento/program buttons never flex-shrink (1.9.23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.23] - 2026-07-10
+### Fixed
+- **CTA (Bento) button label no longer clipped.** In a fixed-height bento text cell (a flex column), flexbox was allowed to compress the button below its content height (measured live: a 26px box holding 44px of content); harmless before, but the Button Shape's `overflow:hidden` (required for the clip-path) then sliced the label. Buttons in flex-column cards now never shrink (`flex-shrink:0`) — applied to the Bento button and, preventively, the Program card button (same pattern).
+
 ## [1.9.22] - 2026-07-10
 ### Fixed
 - **Banner title on photo banners now obeys the Theme Setting.** Root cause of "Title on Photo Banners = Show" doing nothing on fleet sites: older blueprints baked the Hero module's per-instance "Hide (image only)" into the base template, and that value always beat the Theme Setting — the site-wide control could never win. Precedence flipped: **Theme Setting → Page Banner → Title on Photo Banners is the site-wide authority**; legacy baked module values follow it; only the module's new explicit per-instance choices ("Always show" / "Always hide — image only") override it. Verified against the live fleet test page markup.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.22
+ * Version:           1.9.23
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.22' );
+define( 'DS_TOOLKIT_VERSION', '1.9.23' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-cta/css/frontend.css
+++ b/modules/ds-cta/css/frontend.css
@@ -71,7 +71,7 @@
 .ds-cta--style3 .ds-cta-bento-celldesc{color:#c7ccd2;font-size:.95rem;line-height:1.5;margin-bottom:18px;}
 .ds-cta--style3 .ds-cta-bento-celldesc p{margin:0 0 8px;}
 .ds-cta--style3 .ds-cta-bento-celldesc strong,.ds-cta--style3 .ds-cta-bento-celldesc b{color:var(--fl-global-white);}
-.ds-cta--style3 .ds-cta-bento-btn{align-self:flex-start;display:inline-block;background:var(--fl-global-accent);color:var(--fl-global-white);font-weight:700;font-size:.78rem;letter-spacing:.1em;text-transform:uppercase;padding:13px 22px;text-decoration:none;transition:filter .2s ease,transform .2s ease;}
+.ds-cta--style3 .ds-cta-bento-btn{align-self:flex-start;flex-shrink:0;display:inline-block;background:var(--fl-global-accent);color:var(--fl-global-white);font-weight:700;font-size:.78rem;letter-spacing:.1em;text-transform:uppercase;padding:13px 22px;text-decoration:none;transition:filter .2s ease,transform .2s ease;}
 .ds-cta--style3 .ds-cta-bento-btn:hover{filter:brightness(1.08);transform:translateY(-1px);}
 /* Cell eyebrow: small accent label in text cells; overlay pill on image cells. */
 .ds-cta--style3 .ds-cta-bento-eyebrow{font-size:.75rem;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--fl-global-accent);margin:0 0 10px;}

--- a/modules/ds-post-loop/css/frontend.css
+++ b/modules/ds-post-loop/css/frontend.css
@@ -178,7 +178,7 @@
 .ds-program-sub{font-size:.85rem;font-weight:600;opacity:.85;}
 .ds-program-title{margin:0;color:var(--fl-global-headings);font-size:1.25rem;line-height:1.2;}
 .ds-program-desc{margin:0;color:var(--fl-global-body);font-size:.95rem;line-height:1.5;}
-.fl-builder-content .ds-program-card .ds-program-btn{align-self:flex-start;margin-top:auto;display:inline-block;background:var(--fl-global-button);color:var(--fl-global-white);padding:10px 22px;border-radius:6px;font-weight:700;font-size:.82rem;letter-spacing:1px;text-transform:uppercase;text-decoration:none;transition:background .2s ease;position:relative;z-index:2;}
+.fl-builder-content .ds-program-card .ds-program-btn{align-self:flex-start;flex-shrink:0;margin-top:auto;display:inline-block;background:var(--fl-global-button);color:var(--fl-global-white);padding:10px 22px;border-radius:6px;font-weight:700;font-size:.82rem;letter-spacing:1px;text-transform:uppercase;text-decoration:none;transition:background .2s ease;position:relative;z-index:2;}
 .fl-builder-content .ds-program-card .ds-program-btn:hover,.fl-builder-content .ds-program-card:hover .ds-program-btn{background:var(--fl-global-accent);color:var(--fl-global-white);}
 
 /* ── Tournament cards (events): center-center image + overlapping details card ── */


### PR DESCRIPTION
Live diagnosis on dslaunchpad6.wpenginepowered.com: the bento text cell is a fixed-height flex column, and flex-shrink compressed the button below its content height (26px box / 44px content, measured via computed styles). Previously invisible; the Button Shape's `overflow:hidden` made it clip the label. `flex-shrink:0` on the bento button + the Program card button (same flex-column pattern).