### PR TITLE
fix: hamburger bars follow Icon / Label Color reliably (#35 follow-up, 1.9.25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.25] - 2026-07-13
+### Fixed
+- **Menu: hamburger bars now follow "Icon / Label Color" even against workaround CSS (GH #35 follow-up).** Live testing showed the label adapting but not the bars: BB's global button styles colour spans inside buttons directly (killing inheritance), and the fleet test site carried leftover Layout-CSS workarounds (`.ds-bars span{color:black!important}`) from before the option worked. The label/bars now inherit the toggle colour with `!important` at module-node specificity, which outranks both.
+
 ## [1.9.24] - 2026-07-13
 ### Fixed
 - **Menu: Hamburger "Icon / Label Color" now always wins (GH #35).** The option (Style → Hamburger Button → Icon / Label Color) colours the bars and the label, but it was emitted without `!important` while a theme's own `header button` colour rule could outrank it. It now ships with `!important` like the toggle's background/border already did, and the label/bars explicitly inherit it. The open-overlay X keeps following the Overlay text colour.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.24
+ * Version:           1.9.25
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.24' );
+define( 'DS_TOOLKIT_VERSION', '1.9.25' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/includes/frontend.css.php
+++ b/modules/ds-menu/includes/frontend.css.php
@@ -333,7 +333,12 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 	   rule, and bg/border/color are written with !important so theme button styling
 	   can't leak in (the bars + label pick the colour up via currentColor/inherit). */
 	<?php echo $node; ?> .ds-menu-wrap .ds-menu-toggle { display: flex; margin-left: auto; <?php if ( $toggle_c ) { echo 'color:' . $toggle_c . ' !important;'; } ?> background: <?php echo $tbg; ?> !important; border: <?php echo $tbord; ?> !important; border-radius: <?php echo $trad; ?>px; box-shadow: none !important; padding: 6px 10px; }
-	<?php if ( $toggle_c ) { ?><?php echo $node; ?> .ds-menu-wrap .ds-menu-toggle .ds-menu-toggle-label, <?php echo $node; ?> .ds-menu-wrap .ds-menu-toggle .ds-bars span { color: inherit; }<?php } ?>
+	<?php /* !important + high specificity so the option also beats BB's global
+	   button-span colour rules AND any site-level workaround CSS left over from
+	   before this option worked (seen live: `.ds-bars span{color:black!important}`
+	   in a header Layout CSS). inherit tracks the toggle, so the open-overlay
+	   state keeps following the Overlay text colour too. */ ?>
+	<?php if ( $toggle_c ) { ?><?php echo $node; ?> .ds-menu-wrap .ds-menu-toggle .ds-menu-toggle-label, <?php echo $node; ?> .ds-menu-wrap .ds-menu-toggle .ds-bars span { color: inherit !important; }<?php } ?>
 	<?php echo $node; ?> .ds-bars { width: <?php echo $isz; ?>px; height: <?php echo $ih; ?>px; }
 	<?php echo $node; ?> .ds-bars span:nth-child(1) { top: 0; }
 	<?php echo $node; ?> .ds-bars span:nth-child(2) { top: <?php echo $mid; ?>px; }


### PR DESCRIPTION
Live re-test after v1.9.24 showed the label adapting but not the bars. CSSOM inspection on the fleet test site found two culprits stacking on the spans inside the toggle:

1. Beaver Builder's global button styles colour spans inside buttons directly, which kills inheritance from the toggle.
2. The site carries leftover Layout-CSS workarounds from before the option worked: `.ds-bars span{color:black!important}` / `.ds-menu-toggle-label{color:black!important}` in the header themer layout.

The label/bars now inherit the toggle colour with `!important` at module-node specificity (only emitted when Icon / Label Color is set), which outranks both. `inherit` tracks the toggle's computed colour, so the open-overlay X keeps following the Overlay text colour.

Refs #35.
