### PR TITLE
fix: all toggle descendants inherit Icon / Label Color (#35 final, 1.9.26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.26] - 2026-07-13
+### Fixed
+- **Menu: hamburger bars truly follow "Icon / Label Color" (GH #35, final).** v1.9.25 made the label and the bar *spans* inherit, but BB's global button styles paint **every** descendant of a button (`button *`) — including the intermediate `.ds-bars` wrapper — and CSS `inherit` only reads the direct parent, so the spans inherited white from the wrapper instead of the chosen colour from the toggle (measured live). All toggle descendants now inherit the toggle colour with `!important`, so the chain can't be broken.
+
 ## [1.9.25] - 2026-07-13
 ### Fixed
 - **Menu: hamburger bars now follow "Icon / Label Color" even against workaround CSS (GH #35 follow-up).** Live testing showed the label adapting but not the bars: BB's global button styles colour spans inside buttons directly (killing inheritance), and the fleet test site carried leftover Layout-CSS workarounds (`.ds-bars span{color:black!important}`) from before the option worked. The label/bars now inherit the toggle colour with `!important` at module-node specificity, which outranks both.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.25
+ * Version:           1.9.26
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.25' );
+define( 'DS_TOOLKIT_VERSION', '1.9.26' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/includes/frontend.css.php
+++ b/modules/ds-menu/includes/frontend.css.php
@@ -333,12 +333,14 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 	   rule, and bg/border/color are written with !important so theme button styling
 	   can't leak in (the bars + label pick the colour up via currentColor/inherit). */
 	<?php echo $node; ?> .ds-menu-wrap .ds-menu-toggle { display: flex; margin-left: auto; <?php if ( $toggle_c ) { echo 'color:' . $toggle_c . ' !important;'; } ?> background: <?php echo $tbg; ?> !important; border: <?php echo $tbord; ?> !important; border-radius: <?php echo $trad; ?>px; box-shadow: none !important; padding: 6px 10px; }
-	<?php /* !important + high specificity so the option also beats BB's global
-	   button-span colour rules AND any site-level workaround CSS left over from
-	   before this option worked (seen live: `.ds-bars span{color:black!important}`
-	   in a header Layout CSS). inherit tracks the toggle, so the open-overlay
-	   state keeps following the Overlay text colour too. */ ?>
-	<?php if ( $toggle_c ) { ?><?php echo $node; ?> .ds-menu-wrap .ds-menu-toggle .ds-menu-toggle-label, <?php echo $node; ?> .ds-menu-wrap .ds-menu-toggle .ds-bars span { color: inherit !important; }<?php } ?>
+	<?php /* EVERY descendant must inherit (not just label + bar spans): BB's global
+	   button styles paint `button *` — including the intermediate .ds-bars div —
+	   and `inherit` only reads the DIRECT parent, so skipping one element in the
+	   chain reintroduces the theme colour (measured live: spans went white via
+	   .ds-bars). !important also beats site-level workaround CSS left over from
+	   before this option worked (`.ds-bars span{color:black!important}`). inherit
+	   tracks the toggle, so the open-overlay X keeps following Overlay text. */ ?>
+	<?php if ( $toggle_c ) { ?><?php echo $node; ?> .ds-menu-wrap .ds-menu-toggle * { color: inherit !important; }<?php } ?>
 	<?php echo $node; ?> .ds-bars { width: <?php echo $isz; ?>px; height: <?php echo $ih; ?>px; }
 	<?php echo $node; ?> .ds-bars span:nth-child(1) { top: 0; }
 	<?php echo $node; ?> .ds-bars span:nth-child(2) { top: <?php echo $mid; ?>px; }


### PR DESCRIPTION
Numeric re-verification after v1.9.25 showed toggle + label at the chosen colour but the bar spans at white. Root cause: BB's global button styles paint `button *` — including the intermediate `.ds-bars` wrapper — and CSS `inherit` only reads the direct parent, so the spans inherited white from the wrapper rather than the chosen colour from the toggle. All toggle descendants now inherit with `!important`, so the chain cannot be broken by any single painted element.

Refs #35.
