### PR TITLE
feat: marquee item images + Partner user role (#41, #42) (1.9.27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.27] - 2026-07-14
+### Added
+- **Marquee: item images (GH #41).** Every marquee item can now carry an optional image (Item → Image) — alone for a scrolling logo strip, or together with the text. New Style options: **Image Height** (responsive, live preview, default 24px) and **Grayscale Images** (uniform logo strip, colour restored on hover). Images render eagerly with `no-lazyload`/`skip-lazy` (a lazy-loaded image would measure 0 wide and scroll a blank gap), ship `width`/`height` from attachment metadata so the seamless-loop maths is correct before the file loads, and the loop re-measures whenever an image without known dimensions finishes loading.
+- **User Roles: Partner role + plugin access control (GH #42).** New blueprint-6 feature (DS Toolkit → Features → User Roles, auto-enabled on DSLP6). Registers a **Partner** role: everything an Administrator has except plugin management (`activate/install/update/delete_plugins`) and the in-admin file editors — assign it from the standard Users screen. Independently hides the Plugins menu from non-LeagueApps users (label hide only, capabilities untouched), covering legacy full-admin partner accounts. An **Allow plugin access** switch in the card restores Partner plugin capabilities and stops the menu hiding when a dev decides a partner should manage plugins on that site.
+
 ## [1.9.26] - 2026-07-13
 ### Fixed
 - **Menu: hamburger bars truly follow "Icon / Label Color" (GH #35, final).** v1.9.25 made the label and the bar *spans* inherit, but BB's global button styles paint **every** descendant of a button (`button *`) — including the intermediate `.ds-bars` wrapper — and CSS `inherit` only reads the direct parent, so the spans inherited white from the wrapper instead of the chosen colour from the toggle (measured live). All toggle descendants now inherit the toggle colour with `!important`, so the chain can't be broken.

--- a/admin/class-ds-toolkit-admin.php
+++ b/admin/class-ds-toolkit-admin.php
@@ -226,6 +226,8 @@ class DS_Toolkit_Admin {
                 $disable_comments_enabled = ! empty( $opts['disable_comments_enabled'] );
                 $theme_setting_enabled    = ! empty( $opts['theme_setting_enabled'] );
                 $admin_menu_tidy_enabled  = ! empty( $opts['admin_menu_tidy_enabled'] );
+                $user_roles_enabled       = ! empty( $opts['user_roles_enabled'] );
+                $partner_plugin_access    = ! empty( $opts['partner_plugin_access'] );
                 $ds_menu_module_enabled   = ! empty( $opts['ds_menu_module_enabled'] );
                 $image_optimization_enabled = ! empty( $opts['image_optimization_enabled'] );
                 // Per-module on/off states for the always-visible "LeagueApps Modules" section.

--- a/admin/views/page-settings.php
+++ b/admin/views/page-settings.php
@@ -167,6 +167,32 @@ if ( ! defined( 'ABSPATH' ) ) exit;
         </div>
     </div>
 
+    <!-- User Roles (blueprint generation 6+) -->
+    <div class="dst-card">
+        <div class="dst-card-row">
+            <div class="dst-card-icon"><span class="dashicons dashicons-groups"></span></div>
+            <div class="dst-card-info">
+                <strong>User Roles (Partner)</strong>
+                <span>Registers a <strong>Partner</strong> role — everything an Administrator has except plugin management and the in-admin file editors — so partner accounts get safe admin access with one pick on the Users screen. Also hides the Plugins menu from non-LeagueApps users (menu label only; capabilities untouched). Auto-enabled on DSLP6 builds.</span>
+            </div>
+            <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[user_roles_enabled]" value="0">
+                <input type="checkbox" id="user_roles_enabled" name="ds_toolkit_settings[user_roles_enabled]" value="1" <?php checked( $user_roles_enabled ); ?>>
+                <label for="user_roles_enabled"></label>
+            </div>
+        </div>
+        <div class="dst-card-row" style="padding-top:0;">
+            <div class="dst-card-icon" aria-hidden="true"></div>
+            <div class="dst-card-info">
+                <label for="partner_plugin_access" style="display:flex;align-items:center;gap:8px;cursor:pointer;">
+                    <input type="hidden" name="ds_toolkit_settings[partner_plugin_access]" value="0">
+                    <input type="checkbox" id="partner_plugin_access" name="ds_toolkit_settings[partner_plugin_access]" value="1" <?php checked( $partner_plugin_access ); ?>>
+                    <span><strong>Allow plugin access</strong> — re-enables plugin management for the Partner role and stops hiding the Plugins menu from non-LeagueApps users. Use when a dev decides a partner should manage plugins on this site.</span>
+                </label>
+            </div>
+        </div>
+    </div>
+
     <!-- Image Optimization on Upload (blueprint generation 6+) -->
     <div class="dst-card">
         <div class="dst-card-row">

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.26
+ * Version:           1.9.27
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.26' );
+define( 'DS_TOOLKIT_VERSION', '1.9.27' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-user-roles.php
+++ b/features/class-ds-user-roles.php
@@ -1,0 +1,99 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * User Roles (blueprint generation 6+).
+ *
+ * Partner-safe access control in two layers:
+ *
+ *  1. A "Partner" role — administrator-equivalent minus plugin management and
+ *     the in-admin file editors. Devs often leave partner accounts as full
+ *     Administrators because switching roles is friction; Partner makes the
+ *     safe setup a one-click choice on the standard Users screen (that's also
+ *     where admins "select the appropriate user role" — no custom UI needed).
+ *  2. The Plugins menu is hidden from non-LeagueApps users. This is a label
+ *     hide only — capabilities are untouched (same philosophy as Admin Menu
+ *     Tidy) — so a legacy full-admin partner account stops browsing plugins
+ *     without anything breaking.
+ *
+ * Both layers honour one escape hatch: DS Toolkit → Features → User Roles →
+ * "Allow plugin access". When a LeagueApps dev switches it on, the Partner
+ * role regains the plugin-management capabilities and the Plugins menu stops
+ * being hidden. The DS Toolkit settings page itself is admin + LeagueApps
+ * gated, so partners can never flip the switch themselves.
+ *
+ * Disabling the feature stops the menu hiding and the role sync, but the
+ * Partner role itself stays registered so existing users keep working.
+ */
+class DS_User_Roles {
+
+	/** Bump when the Partner capability set changes so existing installs re-sync. */
+	const ROLE_VERSION = 1;
+	const ROLE_SLUG    = 'partner';
+
+	private $settings;
+
+	public function __construct( $settings = array() ) {
+		$this->settings = $settings;
+	}
+
+	public function init() {
+		add_action( 'init', array( $this, 'sync_role' ), 5 );
+		// Very late, after every plugin has registered its menus.
+		add_action( 'admin_menu', array( $this, 'hide_plugins_menu' ), 999999 );
+	}
+
+	private function plugin_access_allowed() {
+		return ! empty( $this->settings['partner_plugin_access'] );
+	}
+
+	/** Capabilities the Partner role gives up (the hard boundary). */
+	private static function plugin_caps() {
+		return array( 'activate_plugins', 'install_plugins', 'update_plugins', 'delete_plugins' );
+	}
+
+	/** In-admin file editors — never granted to Partner, even with plugin access open. */
+	private static function editor_caps() {
+		return array( 'edit_plugins', 'edit_themes', 'edit_files' );
+	}
+
+	/**
+	 * Create/refresh the Partner role. Cheap on every load: only writes when the
+	 * stored state (cap-set version + escape-hatch position) differs from the
+	 * target, or the role is missing entirely.
+	 */
+	public function sync_role() {
+		$want = self::ROLE_VERSION . ':' . ( $this->plugin_access_allowed() ? 'open' : 'locked' );
+		if ( get_option( 'ds_partner_role_state' ) === $want && get_role( self::ROLE_SLUG ) ) {
+			return;
+		}
+		$admin = get_role( 'administrator' );
+		if ( ! $admin ) {
+			return;
+		}
+		$caps = $admin->capabilities;
+		$drop = $this->plugin_access_allowed()
+			? self::editor_caps()
+			: array_merge( self::plugin_caps(), self::editor_caps() );
+		foreach ( $drop as $cap ) {
+			unset( $caps[ $cap ] );
+		}
+		// remove + add is the only reliable way to REDUCE an existing role's caps.
+		remove_role( self::ROLE_SLUG );
+		add_role( self::ROLE_SLUG, __( 'Partner', 'ds-toolkit' ), $caps );
+		update_option( 'ds_partner_role_state', $want );
+	}
+
+	/**
+	 * Hide the Plugins menu from non-LeagueApps users (label hide; capabilities
+	 * untouched). Partner-role users already lack activate_plugins, so WordPress
+	 * hides the menu for them natively — this catches legacy full-admin partner
+	 * accounts.
+	 */
+	public function hide_plugins_menu() {
+		if ( $this->plugin_access_allowed() || DS_Toolkit::is_leagueapps_user() ) {
+			return;
+		}
+		remove_menu_page( 'plugins.php' );
+	}
+}

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -177,6 +177,11 @@ class DS_Toolkit {
             'class'         => 'DS_Admin_Bar_Links',
             'min_blueprint' => 6,
         ),
+        'user_roles_enabled' => array(
+            'file'          => 'features/class-ds-user-roles.php',
+            'class'         => 'DS_User_Roles',
+            'min_blueprint' => 6,
+        ),
     );
 
     /**
@@ -324,6 +329,8 @@ class DS_Toolkit {
             $defaults['ds_team_detail_module_enabled'] = 1;
             $defaults['ds_builder_defaults_enabled']   = 1;
             $defaults['ds_admin_bar_links_enabled']    = 1;
+            $defaults['user_roles_enabled']            = 1;
+            $defaults['partner_plugin_access']         = 0;
         }
 
         return $defaults;

--- a/modules/ds-marquee/css/frontend.css
+++ b/modules/ds-marquee/css/frontend.css
@@ -68,12 +68,25 @@
 
 /* ---- Items + separators ---- */
 .ds-marquee-item {
+  display: inline-flex;
+  align-items: center;
+  gap: .5em;
   color: var(--fl-global-body);
   font-weight: 700;
   font-size: 12px;
   letter-spacing: .12em;
   text-transform: uppercase;
   text-decoration: none;
+}
+/* Item image (optional logo). Height is node-scoped from Image Height; width
+   follows the aspect ratio, which the width/height attributes make known
+   pre-load so the seamless-loop maths measures correctly immediately. */
+.ds-marquee-img {
+  display: block;
+  height: 24px;
+  width: auto;
+  max-width: none;
+  object-fit: contain;
 }
 a.ds-marquee-item--link { transition: color .15s ease; cursor: pointer; }
 a.ds-marquee-item--link:hover { color: var(--fl-global-white); }

--- a/modules/ds-marquee/ds-marquee.php
+++ b/modules/ds-marquee/ds-marquee.php
@@ -54,23 +54,61 @@ class DS_Marquee_Module extends FLBuilderModule {
 		return array( $url, '_blank' === $target ? '_blank' : '_self' );
 	}
 
+	/**
+	 * Resolve an item photo (id | url | array | object) to array( url, w, h, alt ),
+	 * or null when it doesn't resolve. Width/height come from attachment metadata
+	 * so the browser knows the aspect ratio BEFORE the file loads — the seamless
+	 * loop measures group widths immediately, so pre-load layout must be final.
+	 */
+	private function image_bits( $val ) {
+		$id = 0;
+		if ( is_object( $val ) )     { $id = (int) ( $val->ID ?? ( $val->id ?? 0 ) ); }
+		elseif ( is_array( $val ) )  { $id = (int) ( $val['ID'] ?? ( $val['id'] ?? 0 ) ); }
+		elseif ( is_numeric( $val ) ) { $id = (int) $val; }
+		if ( $id ) {
+			$src = wp_get_attachment_image_src( $id, 'medium' );
+			if ( ! $src ) { return null; }
+			return array( $src[0], (int) $src[1], (int) $src[2], (string) get_post_meta( $id, '_wp_attachment_image_alt', true ) );
+		}
+		$url = DS_Card::photo_url( $val, 'medium' );
+		return $url ? array( $url, 0, 0, '' ) : null;
+	}
+
 	/** Render one item (linked <a> when a URL is set, otherwise a <span>). */
 	private function item_html( $item ) {
 		$item = (object) $item;
 		$text = trim( (string) ( $item->text ?? '' ) );
-		if ( '' === $text ) { return ''; }
+		$img  = ! empty( $item->image ) ? $this->image_bits( $item->image ) : null;
+		if ( '' === $text && ! $img ) { return ''; }
+
+		$img_html = '';
+		if ( $img ) {
+			list( $iu, $iw, $ihh, $ialt ) = $img;
+			// Image-only items announce the attachment alt; with text alongside the
+			// text already carries the name, so the img stays decorative (alt="").
+			$alt  = ( '' === $text ) ? $ialt : '';
+			$dims = ( $iw && $ihh ) ? ' width="' . (int) $iw . '" height="' . (int) $ihh . '"' : '';
+			// eager + no-lazyload/skip-lazy: a lazy-loaded img in the loop would
+			// measure 0 wide and scroll through blank (Smush honours no-lazyload,
+			// core/others honour skip-lazy).
+			$img_html = '<img class="ds-marquee-img no-lazyload skip-lazy" src="' . esc_url( $iu ) . '" alt="' . esc_attr( $alt ) . '"' . $dims . ' loading="eager" decoding="async" />';
+		}
+		$cls = 'ds-marquee-item' . ( $img ? ' ds-marquee-item--img' : '' );
+
 		list( $url, $target ) = $this->link_parts( $item->link ?? '' );
 		if ( '' !== $url && '#' !== $url ) {
 			$rel = '_blank' === $target ? ' rel="noopener noreferrer"' : '';
 			return sprintf(
-				'<a class="ds-marquee-item ds-marquee-item--link" href="%s" target="%s"%s>%s</a>',
+				'<a class="%s ds-marquee-item--link" href="%s" target="%s"%s>%s%s</a>',
+				esc_attr( $cls ),
 				esc_url( $url ),
 				esc_attr( $target ),
 				$rel,
+				$img_html,
 				esc_html( $text )
 			);
 		}
-		return '<span class="ds-marquee-item">' . DS_Module_UI::inline( $text ) . '</span>';
+		return '<span class="' . esc_attr( $cls ) . '">' . $img_html . ( '' !== $text ? DS_Module_UI::inline( $text ) : '' ) . '</span>';
 	}
 
 	/** Build one full group: every item followed by a separator glyph. */
@@ -102,10 +140,11 @@ class DS_Marquee_Module extends FLBuilderModule {
 		$s = $this->settings;
 
 		$items = isset( $s->items ) && is_array( $s->items ) ? $s->items : array();
-		// Drop empty rows so the seamless loop maths stays clean.
+		// Drop empty rows so the seamless loop maths stays clean (an item counts
+		// if it has text OR an image — image-only logo items are valid).
 		$items = array_values( array_filter( $items, function( $i ) {
 			$i = (object) $i;
-			return '' !== trim( (string) ( $i->text ?? '' ) );
+			return '' !== trim( (string) ( $i->text ?? '' ) ) || ! empty( $i->image );
 		} ) );
 
 		$mods = 'ds-marquee ds-marquee--style1';
@@ -156,6 +195,13 @@ FLBuilder::register_settings_form( 'ds_marquee_item_form', array(
 				'general' => array(
 					'title'  => '',
 					'fields' => array(
+						'image' => array(
+							'type'        => 'photo',
+							'label'       => __( 'Image (optional)', 'ds-toolkit' ),
+							'show_remove' => true,
+							'connections' => array( 'photo' ),
+							'help'        => __( 'Optional logo/image for this item. Use alone for a logo strip, or together with the text. Size it via Style → Layout → Image Height.', 'ds-toolkit' ),
+						),
 						'text' => array(
 							'type'        => 'text',
 							'label'       => __( 'Text', 'ds-toolkit' ),
@@ -305,6 +351,16 @@ FLBuilder::register_module( 'DS_Marquee_Module', array(
 						'description' => 'px',
 						'slider'      => array( 'min' => 4, 'max' => 48, 'step' => 1 ),
 					),
+					'img_h'     => array(
+						'type'        => 'unit',
+						'label'       => __( 'Image Height', 'ds-toolkit' ),
+						'default'     => '24',
+						'description' => 'px',
+						'responsive'  => true,
+						'slider'      => array( 'min' => 12, 'max' => 60, 'step' => 1 ),
+						'help'        => __( 'Height of item images (width scales to keep proportions). Keep it a little under the Bar Height.', 'ds-toolkit' ),
+						'preview'     => array( 'type' => 'css', 'selector' => '.ds-marquee-img', 'property' => 'height', 'unit' => 'px' ),
+					),
 					'label_pad' => array(
 						'type'        => 'unit',
 						'label'       => __( 'Label Side Padding', 'ds-toolkit' ),
@@ -344,6 +400,13 @@ FLBuilder::register_module( 'DS_Marquee_Module', array(
 					'label_bg'         => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Label Background', 'ds-toolkit' ), 'default' => 'var(--fl-global-accent)', 'show_reset' => true, 'help' => __( 'Blank falls back to the global Accent colour.', 'ds-toolkit' ) ),
 					'label_color'      => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Label Text', 'ds-toolkit' ), 'default' => 'var(--fl-global-dark-background)', 'show_reset' => true ),
 					'dot_color'        => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Status Dot', 'ds-toolkit' ), 'default' => 'var(--fl-global-dark-background)', 'show_reset' => true ),
+					'img_grayscale'    => array(
+						'type'    => 'select',
+						'label'   => __( 'Grayscale Images', 'ds-toolkit' ),
+						'default' => 'no',
+						'options' => array( 'no' => __( 'No', 'ds-toolkit' ), 'yes' => __( 'Yes (colour on hover)', 'ds-toolkit' ) ),
+						'help'    => __( 'Renders item images in grayscale for a uniform logo strip; each logo returns to full colour on hover.', 'ds-toolkit' ),
+					),
 				),
 			),
 			'typography' => array(

--- a/modules/ds-marquee/includes/frontend.css.php
+++ b/modules/ds-marquee/includes/frontend.css.php
@@ -57,6 +57,16 @@ if ( '' !== $ih ) { echo "$node a.ds-marquee-item--link:hover { color: {$ih}; }\
 $sep_size = $u( $settings->sep_size ?? '', 12 );
 echo "$node .ds-marquee-sep { color: " . $colf( $settings->sep_color ?? '', $acc ) . "; font-size: {$sep_size}px; line-height: 1; }\n";
 
+/* ---- Item images ---- */
+$imh = $u( $settings->img_h ?? '', 24 );
+echo "$node .ds-marquee-img { height: {$imh}px; }\n";
+if ( '' !== ( $settings->img_h_medium ?? '' ) )     { echo "@media (max-width:{$bpm}px){ $node .ds-marquee-img { height: " . (int) $settings->img_h_medium . "px; } }\n"; }
+if ( '' !== ( $settings->img_h_responsive ?? '' ) ) { echo "@media (max-width:{$bpr}px){ $node .ds-marquee-img { height: " . (int) $settings->img_h_responsive . "px; } }\n"; }
+if ( ( $settings->img_grayscale ?? 'no' ) === 'yes' ) {
+	echo "$node .ds-marquee-img { filter: grayscale(1); opacity: .75; transition: filter .3s ease, opacity .3s ease; }\n";
+	echo "$node .ds-marquee-item:hover .ds-marquee-img { filter: none; opacity: 1; }\n";
+}
+
 /* ---- Item spacing ---- */
 $gap = $u( $settings->item_gap ?? '', 38 );
 echo "$node .ds-marquee-group { gap: {$gap}px; padding-left: {$gap}px; }\n";

--- a/modules/ds-marquee/js/frontend.js
+++ b/modules/ds-marquee/js/frontend.js
@@ -39,7 +39,23 @@
 	}
 
 	function boot(root) {
-		(root || document).querySelectorAll('.ds-marquee--style1').forEach(fill);
+		(root || document).querySelectorAll('.ds-marquee--style1').forEach(function (marquee) {
+			fill(marquee);
+			// Item images resolve their width pre-load only when the server knew
+			// their dimensions (width/height attributes). URL-only images don't,
+			// so re-measure when any inner image finishes loading. Delegated on
+			// the marquee root (capture — load doesn't bubble), so it survives
+			// the innerHTML cloning above. Added once per marquee.
+			if (!marquee.dsImgHook) {
+				marquee.dsImgHook = true;
+				var it;
+				marquee.addEventListener('load', function (e) {
+					if (!e.target || e.target.tagName !== 'IMG') return;
+					clearTimeout(it);
+					it = setTimeout(function () { fill(marquee); }, 120);
+				}, true);
+			}
+		});
 	}
 
 	function init() {


### PR DESCRIPTION
Two feature requests in one release.

**#41 — Marquee image support.** Every marquee item gets an optional **Image** (Item → Image): use it alone for a scrolling logo strip, or together with the text (inline, vertically centred). New Style options: **Image Height** (responsive, instant live preview, default 24px) and **Grayscale Images** (uniform logo strip; each logo returns to colour on hover). Correctness details: images render `loading=eager` with `no-lazyload skip-lazy` classes (a lazy-loaded image measures 0 wide and would scroll a blank gap through the seamless loop), carry `width`/`height` from attachment metadata so the loop maths is right before the file loads, and the loop re-measures when a dimension-less (URL-only) image finishes loading.

**#42 — User Roles (Partner).** New blueprint-6 feature (auto-enabled on DSLP6): registers a **Partner** role — everything an Administrator has minus plugin management (`activate/install/update/delete_plugins`) and the in-admin file editors — assignable from the standard Users screen. Independently, the Plugins menu is hidden from non-LeagueApps users (label hide only, capabilities untouched, same philosophy as Admin Menu Tidy) to cover legacy full-admin partner accounts. The DS Toolkit → Features → User Roles card has an **Allow plugin access** switch that restores Partner plugin capabilities and stops the menu hiding when a dev decides a partner should manage plugins on that site. The role stays registered if the feature is later disabled, so existing users keep working.

Closes #41, closes #42.
