### PR TITLE
feat: Design Academy dashboard panel + User Roles fleet-wide (1.9.28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.28] - 2026-07-14
+### Added
+- **Design Academy dashboard panel (fleet-wide).** New feature (auto-enabled on every install): a **Design Academy** widget pinned to the top of the WordPress dashboard so partners see it the moment they log in — a "Start here" pinned course (defaults to the beginner's guide to WordPress & Beaver Builder; label/URL editable in DS Toolkit → Features) plus the five newest tutorials from designacademy.leagueapps.com (public REST feed, cached 6 hours, last-good fallback if the academy is unreachable).
+
+### Changed
+- **User Roles is now fleet-wide.** The Partner role + Plugins-menu hiding (v1.9.27, GH #42) no longer requires blueprint 6 — it defaults ON for every install, so the whole fleet gets the Partner role and the partner-safe Plugins hiding on this update. The "Allow plugin access" escape hatch is unchanged.
+
 ## [1.9.27] - 2026-07-14
 ### Added
 - **Marquee: item images (GH #41).** Every marquee item can now carry an optional image (Item → Image) — alone for a scrolling logo strip, or together with the text. New Style options: **Image Height** (responsive, live preview, default 24px) and **Grayscale Images** (uniform logo strip, colour restored on hover). Images render eagerly with `no-lazyload`/`skip-lazy` (a lazy-loaded image would measure 0 wide and scroll a blank gap), ship `width`/`height` from attachment metadata so the seamless-loop maths is correct before the file loads, and the loop re-measures whenever an image without known dimensions finishes loading.

--- a/admin/class-ds-toolkit-admin.php
+++ b/admin/class-ds-toolkit-admin.php
@@ -228,6 +228,9 @@ class DS_Toolkit_Admin {
                 $admin_menu_tidy_enabled  = ! empty( $opts['admin_menu_tidy_enabled'] );
                 $user_roles_enabled       = ! empty( $opts['user_roles_enabled'] );
                 $partner_plugin_access    = ! empty( $opts['partner_plugin_access'] );
+                $design_academy_enabled   = ! empty( $opts['design_academy_enabled'] );
+                $academy_pinned_url       = ! empty( $opts['academy_pinned_url'] ) ? $opts['academy_pinned_url'] : 'https://designacademy.leagueapps.com/course/how-to-edit-your-website-a-beginners-guide-to-wordpress-beaverbuilder/';
+                $academy_pinned_label     = ! empty( $opts['academy_pinned_label'] ) ? $opts['academy_pinned_label'] : "How to Edit Your Website: A Beginner's Guide to WordPress & Beaver Builder";
                 $ds_menu_module_enabled   = ! empty( $opts['ds_menu_module_enabled'] );
                 $image_optimization_enabled = ! empty( $opts['image_optimization_enabled'] );
                 // Per-module on/off states for the always-visible "LeagueApps Modules" section.

--- a/admin/views/page-settings.php
+++ b/admin/views/page-settings.php
@@ -70,6 +70,57 @@ if ( ! defined( 'ABSPATH' ) ) exit;
         </div>
     </div>
 
+    <!-- User Roles (fleet-wide) -->
+    <div class="dst-card">
+        <div class="dst-card-row">
+            <div class="dst-card-icon"><span class="dashicons dashicons-groups"></span></div>
+            <div class="dst-card-info">
+                <strong>User Roles (Partner)</strong>
+                <span>Registers a <strong>Partner</strong> role — everything an Administrator has except plugin management and the in-admin file editors — so partner accounts get safe admin access with one pick on the Users screen. Also hides the Plugins menu from non-LeagueApps users (menu label only; capabilities untouched). Auto-enabled on every install.</span>
+            </div>
+            <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[user_roles_enabled]" value="0">
+                <input type="checkbox" id="user_roles_enabled" name="ds_toolkit_settings[user_roles_enabled]" value="1" <?php checked( $user_roles_enabled ); ?>>
+                <label for="user_roles_enabled"></label>
+            </div>
+        </div>
+        <div class="dst-card-row" style="padding-top:0;">
+            <div class="dst-card-icon" aria-hidden="true"></div>
+            <div class="dst-card-info">
+                <label for="partner_plugin_access" style="display:flex;align-items:center;gap:8px;cursor:pointer;">
+                    <input type="hidden" name="ds_toolkit_settings[partner_plugin_access]" value="0">
+                    <input type="checkbox" id="partner_plugin_access" name="ds_toolkit_settings[partner_plugin_access]" value="1" <?php checked( $partner_plugin_access ); ?>>
+                    <span><strong>Allow plugin access</strong> — re-enables plugin management for the Partner role and stops hiding the Plugins menu from non-LeagueApps users. Use when a dev decides a partner should manage plugins on this site.</span>
+                </label>
+            </div>
+        </div>
+    </div>
+
+    <!-- Design Academy dashboard panel (fleet-wide) -->
+    <div class="dst-card">
+        <div class="dst-card-row">
+            <div class="dst-card-icon"><span class="dashicons dashicons-welcome-learn-more"></span></div>
+            <div class="dst-card-info">
+                <strong>Design Academy Dashboard</strong>
+                <span>Puts a <strong>Design Academy</strong> panel at the top of the WordPress dashboard: a pinned getting-started course plus the five newest tutorials from <a href="https://designacademy.leagueapps.com/" target="_blank" rel="noopener">designacademy.leagueapps.com</a> (cached 6 hours; falls back to the last good list if the academy is unreachable). Auto-enabled on every install.</span>
+            </div>
+            <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[design_academy_enabled]" value="0">
+                <input type="checkbox" id="design_academy_enabled" name="ds_toolkit_settings[design_academy_enabled]" value="1" <?php checked( $design_academy_enabled ); ?>>
+                <label for="design_academy_enabled"></label>
+            </div>
+        </div>
+        <div class="dst-card-row" style="padding-top:0;">
+            <div class="dst-card-icon" aria-hidden="true"></div>
+            <div class="dst-card-info" style="width:100%;">
+                <strong>Pinned course</strong>
+                <span>The "Start here" item at the top of the panel.</span>
+                <input type="text" name="ds_toolkit_settings[academy_pinned_label]" value="<?php echo esc_attr( $academy_pinned_label ); ?>" placeholder="Pinned label" style="width:100%;margin-top:6px;">
+                <input type="url" name="ds_toolkit_settings[academy_pinned_url]" value="<?php echo esc_attr( $academy_pinned_url ); ?>" placeholder="https://designacademy.leagueapps.com/…" style="width:100%;margin-top:6px;">
+            </div>
+        </div>
+    </div>
+
     <!-- LeagueApps modules (Beaver Builder blocks) — opt-in on ANY blueprint, off by default below gen 6 -->
     <p class="dst-section-title">LeagueApps Modules (Beaver Builder blocks)</p>
     <div class="dst-card">
@@ -167,31 +218,6 @@ if ( ! defined( 'ABSPATH' ) ) exit;
         </div>
     </div>
 
-    <!-- User Roles (blueprint generation 6+) -->
-    <div class="dst-card">
-        <div class="dst-card-row">
-            <div class="dst-card-icon"><span class="dashicons dashicons-groups"></span></div>
-            <div class="dst-card-info">
-                <strong>User Roles (Partner)</strong>
-                <span>Registers a <strong>Partner</strong> role — everything an Administrator has except plugin management and the in-admin file editors — so partner accounts get safe admin access with one pick on the Users screen. Also hides the Plugins menu from non-LeagueApps users (menu label only; capabilities untouched). Auto-enabled on DSLP6 builds.</span>
-            </div>
-            <div class="dst-toggle">
-                <input type="hidden" name="ds_toolkit_settings[user_roles_enabled]" value="0">
-                <input type="checkbox" id="user_roles_enabled" name="ds_toolkit_settings[user_roles_enabled]" value="1" <?php checked( $user_roles_enabled ); ?>>
-                <label for="user_roles_enabled"></label>
-            </div>
-        </div>
-        <div class="dst-card-row" style="padding-top:0;">
-            <div class="dst-card-icon" aria-hidden="true"></div>
-            <div class="dst-card-info">
-                <label for="partner_plugin_access" style="display:flex;align-items:center;gap:8px;cursor:pointer;">
-                    <input type="hidden" name="ds_toolkit_settings[partner_plugin_access]" value="0">
-                    <input type="checkbox" id="partner_plugin_access" name="ds_toolkit_settings[partner_plugin_access]" value="1" <?php checked( $partner_plugin_access ); ?>>
-                    <span><strong>Allow plugin access</strong> — re-enables plugin management for the Partner role and stops hiding the Plugins menu from non-LeagueApps users. Use when a dev decides a partner should manage plugins on this site.</span>
-                </label>
-            </div>
-        </div>
-    </div>
 
     <!-- Image Optimization on Upload (blueprint generation 6+) -->
     <div class="dst-card">

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.27
+ * Version:           1.9.28
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.27' );
+define( 'DS_TOOLKIT_VERSION', '1.9.28' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-design-academy.php
+++ b/features/class-ds-design-academy.php
@@ -1,0 +1,129 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Design Academy dashboard panel (fleet-wide — every install).
+ *
+ * Puts the LeagueApps Design Academy (designacademy.leagueapps.com) in front
+ * of partners the moment they log in: a widget pinned to the TOP of the
+ * WordPress dashboard with
+ *
+ *  - a pinned "start here" course (defaults to the beginner's guide to
+ *    WordPress & Beaver Builder; both URL and label editable in DS Toolkit →
+ *    Features), and
+ *  - the five newest tutorials, pulled from the academy's public REST API
+ *    (`/wp-json/wp/v2/tutorial`) and cached for six hours. If the academy is
+ *    unreachable the last good list is served from a backup option, so the
+ *    dashboard never waits on or breaks over a remote fetch.
+ *
+ * Everyone who can see the dashboard sees the panel — it's aimed at partner
+ * editors, but the links are just as useful to LeagueApps staff.
+ */
+class DS_Design_Academy {
+
+	const SITE      = 'https://designacademy.leagueapps.com';
+	const CACHE_KEY = 'ds_academy_tutorials';
+
+	private $settings;
+
+	public function __construct( $settings = array() ) {
+		$this->settings = $settings;
+	}
+
+	public function init() {
+		add_action( 'wp_dashboard_setup', array( $this, 'register_widget' ) );
+	}
+
+	public function register_widget() {
+		wp_add_dashboard_widget( 'ds_design_academy', __( 'Design Academy', 'ds-toolkit' ), array( $this, 'render_widget' ) );
+
+		// Move the widget to the FIRST slot of the main column so it's the
+		// first thing a partner sees on login (WP appends new widgets last).
+		global $wp_meta_boxes;
+		$core = $wp_meta_boxes['dashboard']['normal']['core'] ?? array();
+		if ( isset( $core['ds_design_academy'] ) ) {
+			$ours = array( 'ds_design_academy' => $core['ds_design_academy'] );
+			unset( $core['ds_design_academy'] );
+			$wp_meta_boxes['dashboard']['normal']['core'] = $ours + $core;
+		}
+	}
+
+	/**
+	 * Latest tutorials from the academy REST API. Cached 6h in a transient;
+	 * the last successful fetch is also kept in a no-autoload option so a
+	 * temporary outage degrades to slightly stale links, never an empty box.
+	 */
+	private function tutorials() {
+		$cached = get_transient( self::CACHE_KEY );
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+		$res = wp_remote_get(
+			self::SITE . '/wp-json/wp/v2/tutorial?per_page=5&orderby=date&order=desc&_fields=title,link,date',
+			array( 'timeout' => 8 )
+		);
+		if ( is_wp_error( $res ) || 200 !== wp_remote_retrieve_response_code( $res ) ) {
+			// Short negative cache so a down academy isn't re-tried on every load.
+			set_transient( self::CACHE_KEY, get_option( self::CACHE_KEY . '_backup', array() ), 15 * MINUTE_IN_SECONDS );
+			return get_option( self::CACHE_KEY . '_backup', array() );
+		}
+		$rows = json_decode( wp_remote_retrieve_body( $res ), true );
+		$list = array();
+		foreach ( ( is_array( $rows ) ? $rows : array() ) as $row ) {
+			$title = isset( $row['title']['rendered'] ) ? wp_strip_all_tags( (string) $row['title']['rendered'] ) : '';
+			$link  = isset( $row['link'] ) ? esc_url_raw( (string) $row['link'] ) : '';
+			if ( '' === $title || '' === $link ) {
+				continue;
+			}
+			$list[] = array(
+				'title' => html_entity_decode( $title, ENT_QUOTES ),
+				'link'  => $link,
+				'date'  => substr( (string) ( $row['date'] ?? '' ), 0, 10 ),
+			);
+		}
+		set_transient( self::CACHE_KEY, $list, 6 * HOUR_IN_SECONDS );
+		update_option( self::CACHE_KEY . '_backup', $list, false );
+		return $list;
+	}
+
+	public function render_widget() {
+		$pin_url   = ! empty( $this->settings['academy_pinned_url'] )
+			? esc_url( $this->settings['academy_pinned_url'] )
+			: self::SITE . '/course/how-to-edit-your-website-a-beginners-guide-to-wordpress-beaverbuilder/';
+		$pin_label = ! empty( $this->settings['academy_pinned_label'] )
+			? $this->settings['academy_pinned_label']
+			: __( "How to Edit Your Website: A Beginner's Guide to WordPress & Beaver Builder", 'ds-toolkit' );
+
+		// Pinned "start here" course.
+		echo '<div style="border:1px solid #c3c4c7;border-left:4px solid #2271b1;background:#f6f7f7;border-radius:2px;padding:10px 12px;margin:2px 0 12px;">';
+		echo '<span class="dashicons dashicons-sticky" aria-hidden="true" style="color:#2271b1;margin-right:4px;"></span>';
+		echo '<strong>' . esc_html__( 'Start here:', 'ds-toolkit' ) . '</strong> ';
+		echo '<a href="' . esc_url( $pin_url ) . '" target="_blank" rel="noopener">' . esc_html( $pin_label ) . '</a>';
+		echo '</div>';
+
+		// Latest tutorials.
+		$tutorials = $this->tutorials();
+		if ( ! empty( $tutorials ) ) {
+			echo '<p style="margin:0 0 4px;"><strong>' . esc_html__( 'Latest tutorials', 'ds-toolkit' ) . '</strong></p>';
+			echo '<ul style="margin:0 0 12px;">';
+			foreach ( $tutorials as $t ) {
+				echo '<li style="margin-bottom:6px;">';
+				echo '<a href="' . esc_url( $t['link'] ) . '" target="_blank" rel="noopener">' . esc_html( $t['title'] ) . '</a>';
+				if ( ! empty( $t['date'] ) ) {
+					echo ' <span style="color:#787c82;font-size:11px;">' . esc_html( date_i18n( get_option( 'date_format' ), strtotime( $t['date'] ) ) ) . '</span>';
+				}
+				echo '</li>';
+			}
+			echo '</ul>';
+		}
+
+		// Footer links.
+		echo '<p style="margin:0;border-top:1px solid #f0f0f1;padding-top:8px;">';
+		echo '<a href="' . esc_url( self::SITE . '/all-tutorials/' ) . '" target="_blank" rel="noopener">' . esc_html__( 'Browse all tutorials', 'ds-toolkit' ) . ' &rarr;</a>';
+		echo ' &nbsp;|&nbsp; ';
+		echo '<a href="' . esc_url( self::SITE . '/courses/' ) . '" target="_blank" rel="noopener">' . esc_html__( 'Courses', 'ds-toolkit' ) . '</a>';
+		echo ' &nbsp;|&nbsp; ';
+		echo '<a href="' . esc_url( self::SITE ) . '" target="_blank" rel="noopener">' . esc_html__( 'Visit the Design Academy', 'ds-toolkit' ) . '</a>';
+		echo '</p>';
+	}
+}

--- a/features/class-ds-user-roles.php
+++ b/features/class-ds-user-roles.php
@@ -2,7 +2,7 @@
 if ( ! defined( 'ABSPATH' ) ) exit;
 
 /**
- * User Roles (blueprint generation 6+).
+ * User Roles (fleet-wide — every install, any blueprint generation).
  *
  * Partner-safe access control in two layers:
  *

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -177,10 +177,15 @@ class DS_Toolkit {
             'class'         => 'DS_Admin_Bar_Links',
             'min_blueprint' => 6,
         ),
+        // Fleet-wide (no blueprint gate): partner-safe access control and the
+        // Design Academy dashboard panel apply to every install, not just DSLP6.
         'user_roles_enabled' => array(
-            'file'          => 'features/class-ds-user-roles.php',
-            'class'         => 'DS_User_Roles',
-            'min_blueprint' => 6,
+            'file'  => 'features/class-ds-user-roles.php',
+            'class' => 'DS_User_Roles',
+        ),
+        'design_academy_enabled' => array(
+            'file'  => 'features/class-ds-design-academy.php',
+            'class' => 'DS_Design_Academy',
         ),
     );
 
@@ -285,6 +290,13 @@ class DS_Toolkit {
             // Compat patch — only does anything when UABB Advanced Posts fires its
             // hooks, so it's safe to default on. Sites without UABB are unaffected.
             'uabb_post_loop_fix_enabled'         => 1,
+            // Partner-safe access control + the Design Academy dashboard panel:
+            // on for the whole fleet regardless of blueprint generation.
+            'user_roles_enabled'                 => 1,
+            'partner_plugin_access'              => 0,
+            'design_academy_enabled'             => 1,
+            'academy_pinned_url'                 => 'https://designacademy.leagueapps.com/course/how-to-edit-your-website-a-beginners-guide-to-wordpress-beaverbuilder/',
+            'academy_pinned_label'               => 'How to Edit Your Website: A Beginner\'s Guide to WordPress & Beaver Builder',
             // MCP tool group access controls — off by default
             'mcp_posts_pages_enabled'            => 0,
             'mcp_cpt_enabled'                    => 0,
@@ -329,8 +341,6 @@ class DS_Toolkit {
             $defaults['ds_team_detail_module_enabled'] = 1;
             $defaults['ds_builder_defaults_enabled']   = 1;
             $defaults['ds_admin_bar_links_enabled']    = 1;
-            $defaults['user_roles_enabled']            = 1;
-            $defaults['partner_plugin_access']         = 0;
         }
 
         return $defaults;


### PR DESCRIPTION
Follow-ups to #42 from review feedback, plus the Design Academy integration.

**User Roles goes fleet-wide.** The Partner role + Plugins-menu hiding shipped in v1.9.27 behind the blueprint-6 gate; per review it should apply everywhere. The feature now defaults ON for every install (any blueprint generation). The **Allow plugin access** escape hatch is unchanged.

**Design Academy dashboard panel.** New fleet-wide feature (auto-enabled): a **Design Academy** widget pinned to the FIRST slot of the wp-admin dashboard so partners see it on login:
- 📌 **Start here** — pinned course, defaulting to *How to Edit Your Website: A Beginner's Guide to WordPress & Beaver Builder*; label and URL editable in DS Toolkit → Features → Design Academy Dashboard.
- **Latest tutorials** — the five newest posts from the academy's public `tutorial` REST endpoint, cached 6 hours in a transient with a last-good backup option (an academy outage degrades to stale links, never a broken/slow dashboard).
- Footer links to All Tutorials, Courses, and the academy home.
