### PR TITLE
feat: issue triage #45 #46 #47 (1.9.29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.29] - 2026-07-15
+### Added
+- **Carousel: "Open in new window" for slide links (GH #45).** The slide Link field now shows Beaver Builder's native new-tab checkbox; the render already carried the target through (with `rel="noopener noreferrer"`), so ticking it just works in all styles.
+- **Post Loop: date-range filter + keyword search (GH #46).** New Query fields on every card layout (custom source): **From Date** / **To Date** (absolute `YYYY-MM-DD` or relative like `-30 days`, inclusive) and **Keyword Search** (title/content, like site search). Newest/oldest sorting already existed (Query → Order).
+- **Carousel: "Style 4 — Overlapping Images" (GH #47).** A two-image editorial composition: Primary + Secondary photos, the secondary overlapping at a chosen corner (bottom/top × left/right) with Small/Medium/Large overlap, plus border radius, an optional editorial frame border, shadow depth, and max width. Built on CSS grid with proportional widths — responsive by construction, no absolute positioning, no custom CSS needed.
+
+### Fixed
+- **Post Loop: date sorting can no longer be hijacked by the Post Types Order plugin.** Queries now pass `ignore_custom_sort` for every explicit sort except Menu Order, so "Newest first" stays newest-first even where that plugin's auto-sort is active.
+
 ## [1.9.28] - 2026-07-14
 ### Added
 - **Design Academy dashboard panel (fleet-wide).** New feature (auto-enabled on every install): a **Design Academy** widget pinned to the top of the WordPress dashboard so partners see it the moment they log in — a "Start here" pinned course (defaults to the beginner's guide to WordPress & Beaver Builder; label/URL editable in DS Toolkit → Features) plus the five newest tutorials from designacademy.leagueapps.com (public REST feed, cached 6 hours, last-good fallback if the academy is unreachable).

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.28
+ * Version:           1.9.29
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.28' );
+define( 'DS_TOOLKIT_VERSION', '1.9.29' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-carousel/css/frontend.css
+++ b/modules/ds-carousel/css/frontend.css
@@ -116,3 +116,25 @@
 @media (prefers-reduced-motion:reduce){
   .ds-carousel--style3 a.ds-reel-card,.ds-reel-play{transition:none;}
 }
+
+/* ---- Style 4: Overlapping Images ----
+   Two images share one grid cell anchored at OPPOSITE corners; the overlap is
+   simply their widths summing past 100%. No absolute positioning, no media
+   queries — the composition is proportional, so it's responsive by construction. */
+.ds-overlap{display:grid;width:100%;}
+.ds-overlap .ds-overlap-primary,
+.ds-overlap .ds-overlap-secondary{grid-area:1/1;display:block;height:auto;max-width:100%;border-radius:8px;}
+.ds-overlap .ds-overlap-secondary{position:relative;z-index:1;}
+/* Overlap amount: primary + secondary width pairs (sum − 100% = overlap). */
+.ds-overlap--sm .ds-overlap-primary{width:90%;} .ds-overlap--sm .ds-overlap-secondary{width:42%;}
+.ds-overlap--md .ds-overlap-primary{width:86%;} .ds-overlap--md .ds-overlap-secondary{width:50%;}
+.ds-overlap--lg .ds-overlap-primary{width:80%;} .ds-overlap--lg .ds-overlap-secondary{width:60%;}
+/* Corner: the secondary sits at the chosen corner; the primary anchors opposite. */
+.ds-overlap--br .ds-overlap-primary{justify-self:start;align-self:start;}
+.ds-overlap--br .ds-overlap-secondary{justify-self:end;align-self:end;}
+.ds-overlap--bl .ds-overlap-primary{justify-self:end;align-self:start;}
+.ds-overlap--bl .ds-overlap-secondary{justify-self:start;align-self:end;}
+.ds-overlap--tr .ds-overlap-primary{justify-self:start;align-self:end;}
+.ds-overlap--tr .ds-overlap-secondary{justify-self:end;align-self:start;}
+.ds-overlap--tl .ds-overlap-primary{justify-self:end;align-self:end;}
+.ds-overlap--tl .ds-overlap-secondary{justify-self:start;align-self:start;}

--- a/modules/ds-carousel/ds-carousel.php
+++ b/modules/ds-carousel/ds-carousel.php
@@ -41,7 +41,40 @@ class DS_Carousel_Module extends FLBuilderModule {
 			'style1' => __( 'Style 1 — Stacked Deck', 'ds-toolkit' ),
 			'style2' => __( 'Style 2 — Sponsors / Logos', 'ds-toolkit' ),
 			'style3' => __( 'Style 3 — Reels Strip (images / videos)', 'ds-toolkit' ),
+			'style4' => __( 'Style 4 — Overlapping Images', 'ds-toolkit' ),
 		);
+	}
+
+	/** Resolve a BB photo value to its attachment alt text ('' when unknown). */
+	private function photo_alt( $val ) {
+		$id = 0;
+		if ( is_object( $val ) )      { $id = (int) ( $val->id ?? 0 ); }
+		elseif ( is_array( $val ) )   { $id = (int) ( $val['id'] ?? 0 ); }
+		elseif ( is_numeric( $val ) ) { $id = (int) $val; }
+		return $id ? (string) get_post_meta( $id, '_wp_attachment_image_alt', true ) : '';
+	}
+
+	/** Style 4 — Overlapping Images: a static two-image editorial composition. */
+	public function render_style4() {
+		$s = $this->settings;
+
+		$primary   = ! empty( $s->ov_primary ) ? $this->photo_url( $s->ov_primary, 'large' ) : '';
+		$secondary = ! empty( $s->ov_secondary ) ? $this->photo_url( $s->ov_secondary, 'large' ) : '';
+
+		if ( '' === $primary || '' === $secondary ) {
+			if ( FLBuilderModel::is_builder_active() ) {
+				echo '<div class="ds-carousel ds-carousel--style4"><p style="padding:14px;opacity:.7">' . esc_html__( 'Pick a Primary and a Secondary image in the module settings.', 'ds-toolkit' ) . '</p></div>';
+			}
+			return;
+		}
+
+		$corner = in_array( $s->ov_corner ?? 'br', array( 'br', 'bl', 'tr', 'tl' ), true ) ? ( $s->ov_corner ?? 'br' ) : 'br';
+		$amount = in_array( $s->ov_amount ?? 'md', array( 'sm', 'md', 'lg' ), true ) ? ( $s->ov_amount ?? 'md' ) : 'md';
+
+		echo '<div class="ds-carousel ds-carousel--style4 ds-overlap ds-overlap--' . esc_attr( $corner ) . ' ds-overlap--' . esc_attr( $amount ) . '">';
+		echo '<img class="ds-overlap-primary" src="' . esc_url( $primary ) . '" alt="' . esc_attr( $this->photo_alt( $s->ov_primary ) ) . '" loading="lazy" />';
+		echo '<img class="ds-overlap-secondary" src="' . esc_url( $secondary ) . '" alt="' . esc_attr( $this->photo_alt( $s->ov_secondary ) ) . '" loading="lazy" />';
+		echo '</div>';
 	}
 
 	/** Resolve a BB photo value (id, url, or {id|url} array/object) -> URL string. */
@@ -387,8 +420,9 @@ FLBuilder::register_settings_form( 'ds_carousel_slide_form', array(
 						'link'    => array(
 							'type'        => 'link',
 							'label'       => __( 'Link', 'ds-toolkit' ),
+							'show_target' => true,
 							'connections' => array( 'url' ),
-							'help'        => __( 'Optional. The front slide becomes clickable; click a slide behind to bring it forward.', 'ds-toolkit' ),
+							'help'        => __( 'Optional. The front slide becomes clickable; click a slide behind to bring it forward. Tick "Open in new window" to launch it in a new tab.', 'ds-toolkit' ),
 						),
 					),
 				),
@@ -420,6 +454,9 @@ FLBuilder::register_module( 'DS_Carousel_Module', array(
 							'style3' => array(
 								'sections' => array( 'slides', 'reels', 'colors', 'spacing' ),
 							),
+							'style4' => array(
+								'sections' => array( 'overlap', 'overlap_style', 'spacing' ),
+							),
 						),
 					),
 				),
@@ -438,6 +475,48 @@ FLBuilder::register_module( 'DS_Carousel_Module', array(
 							array( 'caption' => 'Lorem Ipsum' ),
 							array( 'caption' => 'Dolor Sit Amet' ),
 							array( 'caption' => 'Consectetur' ),
+						),
+					),
+				),
+			),
+			// --- Style 4 only: overlapping images ---
+			'overlap' => array(
+				'title'       => __( 'Overlapping Images', 'ds-toolkit' ),
+				'description' => __( 'Two images in a layered editorial composition — the secondary image overlaps the primary at the chosen corner. Responsive by construction; no custom CSS needed.', 'ds-toolkit' ),
+				'fields'      => array(
+					'ov_primary'   => array(
+						'type'        => 'photo',
+						'label'       => __( 'Primary Image', 'ds-toolkit' ),
+						'show_remove' => true,
+						'connections' => array( 'photo' ),
+					),
+					'ov_secondary' => array(
+						'type'        => 'photo',
+						'label'       => __( 'Secondary Image', 'ds-toolkit' ),
+						'show_remove' => true,
+						'connections' => array( 'photo' ),
+						'help'        => __( 'Sits on top, partially overlapping the primary image.', 'ds-toolkit' ),
+					),
+					'ov_corner'    => array(
+						'type'    => 'select',
+						'label'   => __( 'Overlap Position', 'ds-toolkit' ),
+						'default' => 'br',
+						'options' => array(
+							'br' => __( 'Bottom Right', 'ds-toolkit' ),
+							'bl' => __( 'Bottom Left', 'ds-toolkit' ),
+							'tr' => __( 'Top Right', 'ds-toolkit' ),
+							'tl' => __( 'Top Left', 'ds-toolkit' ),
+						),
+						'help'    => __( 'The corner of the composition where the secondary image sits.', 'ds-toolkit' ),
+					),
+					'ov_amount'    => array(
+						'type'    => 'select',
+						'label'   => __( 'Overlap Amount', 'ds-toolkit' ),
+						'default' => 'md',
+						'options' => array(
+							'sm' => __( 'Small', 'ds-toolkit' ),
+							'md' => __( 'Medium', 'ds-toolkit' ),
+							'lg' => __( 'Large', 'ds-toolkit' ),
 						),
 					),
 				),
@@ -705,6 +784,28 @@ FLBuilder::register_module( 'DS_Carousel_Module', array(
 						'help'    => __( 'Grayscale gives a tidy, uniform sponsor wall that pops to colour on hover.', 'ds-toolkit' ),
 					),
 					'logo_max_height' => array( 'type' => 'unit', 'label' => __( 'Max Logo Height', 'ds-toolkit' ), 'default' => '64', 'description' => 'px', 'responsive' => true, 'slider' => array( 'min' => 24, 'max' => 160, 'step' => 2 ), 'help' => __( 'Caps how tall any single logo can get inside its tile, so a tall logo never dwarfs a wide one. Logos always keep their aspect ratio (never stretched).', 'ds-toolkit' ) ),
+				),
+			),
+			// --- Style 4 only: overlapping images ---
+			'overlap_style' => array(
+				'title'  => __( 'Overlapping Images', 'ds-toolkit' ),
+				'fields' => array(
+					'ov_max_width'    => array( 'type' => 'unit', 'label' => __( 'Max Width', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'slider' => array( 'min' => 240, 'max' => 1200, 'step' => 10 ), 'help' => __( 'Blank = fill the column. When set, the composition centres itself.', 'ds-toolkit' ) ),
+					'ov_radius'       => array( 'type' => 'unit', 'label' => __( 'Border Radius', 'ds-toolkit' ), 'default' => '8', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 40, 'step' => 1 ), 'preview' => array( 'type' => 'css', 'selector' => '.ds-overlap-primary, .ds-overlap-secondary', 'property' => 'border-radius', 'unit' => 'px' ) ),
+					'ov_border_width' => array( 'type' => 'unit', 'label' => __( 'Secondary Border', 'ds-toolkit' ), 'default' => '0', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 16, 'step' => 1 ), 'help' => __( 'A solid frame around the secondary image (the classic editorial white border). 0 = none.', 'ds-toolkit' ) ),
+					'ov_border_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Border Colour', 'ds-toolkit' ), 'default' => 'var(--fl-global-white)', 'show_reset' => true ),
+					'ov_shadow'       => array(
+						'type'    => 'select',
+						'label'   => __( 'Shadow', 'ds-toolkit' ),
+						'default' => 'soft',
+						'options' => array(
+							'none'   => __( 'None', 'ds-toolkit' ),
+							'soft'   => __( 'Soft', 'ds-toolkit' ),
+							'medium' => __( 'Medium', 'ds-toolkit' ),
+							'strong' => __( 'Strong', 'ds-toolkit' ),
+						),
+						'help'    => __( 'Depth under the secondary image so it reads as a layer.', 'ds-toolkit' ),
+					),
 				),
 			),
 			'spacing' => array(

--- a/modules/ds-carousel/includes/frontend.css.php
+++ b/modules/ds-carousel/includes/frontend.css.php
@@ -88,6 +88,31 @@ if ( 'style3' === $style ) {
 	if ( class_exists( 'FLBuilderCSS' ) && ! empty( $settings->sl_head_typography ) ) {
 		FLBuilderCSS::typography_field_rule( array( 'settings' => $settings, 'setting_name' => 'sl_head_typography', 'selector' => "$node .ds-logos-head-label" ) );
 	}
+} elseif ( 'style4' === $style ) {
+	/* ============================ Style 4: overlapping images ============================ */
+	$ovr = $u( $settings->ov_radius ?? '', 8 );
+	echo "$node .ds-overlap-primary, $node .ds-overlap-secondary { border-radius: {$ovr}px; }\n";
+
+	$obw = $u( $settings->ov_border_width ?? '', 0 );
+	if ( $obw > 0 ) {
+		$obc = DS_Module_UI::colf( $settings->ov_border_color ?? '', 'var(--fl-global-white)' );
+		echo "$node .ds-overlap-secondary { border: {$obw}px solid {$obc}; }\n";
+	}
+
+	$shadows = array(
+		'soft'   => '0 6px 18px rgba(0,0,0,.14)',
+		'medium' => '0 10px 28px rgba(0,0,0,.22)',
+		'strong' => '0 16px 44px rgba(0,0,0,.32)',
+	);
+	$osh = (string) ( $settings->ov_shadow ?? 'soft' );
+	if ( isset( $shadows[ $osh ] ) ) {
+		echo "$node .ds-overlap-secondary { box-shadow: {$shadows[ $osh ]}; }\n";
+	}
+
+	$omw = $u( $settings->ov_max_width ?? '', 0 );
+	if ( $omw > 0 ) {
+		echo "$node .ds-overlap { max-width: {$omw}px; margin-left: auto; margin-right: auto; }\n";
+	}
 } else {
 
 /* ---- Card sizing + aspect + radius ---- */

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -175,6 +175,28 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			}
 		}
 
+		// Date-range filter (GH #46). Bounds parse via strtotime, so absolute
+		// dates (2026-01-01) and relative windows (-30 days) both work; only
+		// the bounds that actually parse are applied.
+		$after  = trim( (string) ( $s->date_after ?? '' ) );
+		$before = trim( (string) ( $s->date_before ?? '' ) );
+		$dq     = array();
+		if ( '' !== $after && false !== ( $ts = strtotime( $after ) ) ) { $dq['after'] = gmdate( 'Y-m-d', $ts ); }
+		if ( '' !== $before && false !== ( $ts = strtotime( $before ) ) ) { $dq['before'] = gmdate( 'Y-m-d', $ts ); }
+		if ( ! empty( $dq ) ) {
+			$dq['inclusive']    = true;
+			$args['date_query'] = array( $dq );
+		}
+
+		// Keyword search (GH #46) — matches title/content like the site search.
+		$kw = trim( (string) ( $s->keyword ?? '' ) );
+		if ( '' !== $kw ) { $args['s'] = sanitize_text_field( $kw ); }
+
+		// The Post Types Order plugin rewrites every query's ORDER BY to
+		// menu_order unless the query opts out; honour the explicit sort chosen
+		// here (except when the user actually picked Menu Order).
+		if ( 'menu_order' !== $ob ) { $args['ignore_custom_sort'] = true; }
+
 		return new WP_Query( $args );
 	}
 
@@ -1002,7 +1024,7 @@ $ds_pl_form = array(
 			'query' => array(
 				'title'  => __( 'Posts', 'ds-toolkit' ),
 				'fields' => array(
-					'source'         => array( 'type' => 'select', 'label' => __( 'Source', 'ds-toolkit' ), 'default' => 'custom', 'options' => array( 'custom' => __( 'This query (below)', 'ds-toolkit' ), 'archive' => __( 'Current archive (main query)', 'ds-toolkit' ) ), 'help' => __( 'On an archive template choose “Current archive” to loop whatever the archive shows (team-category term, category, tag, CPT archive). Otherwise build a custom query below.', 'ds-toolkit' ), 'toggle' => array( 'custom' => array( 'fields' => array( 'post_type', 'posts_per_page', 'order_by', 'order', 'offset', 'exclude_current' ) ) ) ),
+					'source'         => array( 'type' => 'select', 'label' => __( 'Source', 'ds-toolkit' ), 'default' => 'custom', 'options' => array( 'custom' => __( 'This query (below)', 'ds-toolkit' ), 'archive' => __( 'Current archive (main query)', 'ds-toolkit' ) ), 'help' => __( 'On an archive template choose “Current archive” to loop whatever the archive shows (team-category term, category, tag, CPT archive). Otherwise build a custom query below.', 'ds-toolkit' ), 'toggle' => array( 'custom' => array( 'fields' => array( 'post_type', 'posts_per_page', 'order_by', 'order', 'offset', 'exclude_current', 'date_after', 'date_before', 'keyword' ) ) ) ),
 					'post_type'      => array( 'type' => 'select', 'label' => __( 'Post Type', 'ds-toolkit' ), 'default' => 'post', 'options' => DS_Post_Loop_Module::post_type_options() ),
 					'posts_per_page' => array( 'type' => 'unit', 'label' => __( 'Number of Posts', 'ds-toolkit' ), 'default' => '5', 'slider' => array( 'min' => 1, 'max' => 12, 'step' => 1 ), 'help' => __( 'Total posts pulled. The first one becomes the large featured card; the rest fill the loop.', 'ds-toolkit' ) ),
 					'order_by'       => array(
@@ -1032,6 +1054,9 @@ $ds_pl_form = array(
 						'options' => array( 'DESC' => __( 'Descending (newest first)', 'ds-toolkit' ), 'ASC' => __( 'Ascending (oldest first)', 'ds-toolkit' ) ),
 					),
 					'offset'         => array( 'type' => 'unit', 'label' => __( 'Offset', 'ds-toolkit' ), 'default' => '0', 'slider' => array( 'min' => 0, 'max' => 20, 'step' => 1 ), 'help' => __( 'Skip this many posts from the start of the result set.', 'ds-toolkit' ) ),
+					'date_after'     => array( 'type' => 'text', 'label' => __( 'From Date', 'ds-toolkit' ), 'default' => '', 'help' => __( 'Only posts published on/after this date. YYYY-MM-DD, or a relative window like "-30 days". Blank = no lower bound.', 'ds-toolkit' ) ),
+					'date_before'    => array( 'type' => 'text', 'label' => __( 'To Date', 'ds-toolkit' ), 'default' => '', 'help' => __( 'Only posts published on/before this date. Same formats as From Date. Blank = no upper bound.', 'ds-toolkit' ) ),
+					'keyword'        => array( 'type' => 'text', 'label' => __( 'Keyword Search', 'ds-toolkit' ), 'default' => '', 'help' => __( 'Only posts matching this keyword (searches title and content).', 'ds-toolkit' ) ),
 					'exclude_current' => array( 'type' => 'select', 'label' => __( 'Exclude Current Post', 'ds-toolkit' ), 'default' => 'no', 'options' => array( 'no' => __( 'No', 'ds-toolkit' ), 'yes' => __( 'Yes', 'ds-toolkit' ) ), 'help' => __( 'On a single post / CPT view, leave out the post being viewed — ideal for a “More News / Related” strip.', 'ds-toolkit' ) ),
 					'date_format'    => array( 'type' => 'text', 'label' => __( 'Date Format', 'ds-toolkit' ), 'default' => 'M Y', 'help' => __( 'PHP date format for the card date (e.g. M Y → Jun 2026).', 'ds-toolkit' ) ),
 				),


### PR DESCRIPTION
Actions the three open feature requests.

**#45 — Carousel: Open link in new tab.** The render already carried slide-link targets through every style (with `rel="noopener noreferrer"`); the slide Link field just never stored one. It now sets `show_target`, so Beaver Builder's native **Open in new window** checkbox appears under the Link field and works immediately.

**#46 — Post Loop: filtering + sorting.** New Query fields (custom source, every card layout including News: Card Grid): **From Date** / **To Date** — absolute `YYYY-MM-DD` or relative windows like `-30 days`, inclusive — and **Keyword Search** (title/content). Newest/oldest sorting already existed at Query → Order; while in here, queries now pass `ignore_custom_sort` for every explicit sort except Menu Order, so the Post Types Order plugin can no longer silently rewrite date sorting to menu_order (a known fleet conflict).

**#47 — Carousel: Style 4 — Overlapping Images.** Two-image editorial composition as a new carousel style: Primary + Secondary photos share one CSS-grid cell anchored at opposite corners, and the overlap is simply their widths summing past 100% — fully responsive with zero absolute positioning or custom CSS. Options: Overlap Position (4 corners), Overlap Amount (Small/Medium/Large), Border Radius (live preview), optional editorial frame border (width + colour, defaults to white), Shadow (none/soft/medium/strong), Max Width.

Closes #45, closes #46, closes #47.
