### PR TITLE
feat: hide Tools + Settings menus from non-LeagueApps users (1.9.30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.30] - 2026-07-15
+### Changed
+- **User Roles: Tools and Settings menus now hidden from non-LeagueApps users.** Alongside the existing Plugins hide — menu labels only, capabilities untouched. The "Allow plugin access" switch still restores Plugins; Tools/Settings stay hidden for partners regardless (they hold host/SEO/security surfaces). Note: on DSLP6 installs Admin Menu Tidy relocates Defender / Yoast / Media Library Organizer under Tools, so those entries disappear for partners too.
+
 ## [1.9.29] - 2026-07-15
 ### Added
 - **Carousel: "Open in new window" for slide links (GH #45).** The slide Link field now shows Beaver Builder's native new-tab checkbox; the render already carried the target through (with `rel="noopener noreferrer"`), so ticking it just works in all styles.

--- a/admin/views/page-settings.php
+++ b/admin/views/page-settings.php
@@ -76,7 +76,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
             <div class="dst-card-icon"><span class="dashicons dashicons-groups"></span></div>
             <div class="dst-card-info">
                 <strong>User Roles (Partner)</strong>
-                <span>Registers a <strong>Partner</strong> role — everything an Administrator has except plugin management and the in-admin file editors — so partner accounts get safe admin access with one pick on the Users screen. Also hides the Plugins menu from non-LeagueApps users (menu label only; capabilities untouched). Auto-enabled on every install.</span>
+                <span>Registers a <strong>Partner</strong> role — everything an Administrator has except plugin management and the in-admin file editors — so partner accounts get safe admin access with one pick on the Users screen. Also hides the <strong>Plugins</strong>, <strong>Tools</strong>, and <strong>Settings</strong> menus from non-LeagueApps users (menu labels only; capabilities untouched). Auto-enabled on every install.</span>
             </div>
             <div class="dst-toggle">
                 <input type="hidden" name="ds_toolkit_settings[user_roles_enabled]" value="0">

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.29
+ * Version:           1.9.30
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.29' );
+define( 'DS_TOOLKIT_VERSION', '1.9.30' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-user-roles.php
+++ b/features/class-ds-user-roles.php
@@ -11,15 +11,19 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  *     Administrators because switching roles is friction; Partner makes the
  *     safe setup a one-click choice on the standard Users screen (that's also
  *     where admins "select the appropriate user role" — no custom UI needed).
- *  2. The Plugins menu is hidden from non-LeagueApps users. This is a label
- *     hide only — capabilities are untouched (same philosophy as Admin Menu
- *     Tidy) — so a legacy full-admin partner account stops browsing plugins
- *     without anything breaking.
+ *  2. The Plugins, Tools, and Settings menus are hidden from non-LeagueApps
+ *     users. This is a label hide only — capabilities are untouched (same
+ *     philosophy as Admin Menu Tidy) — so a legacy full-admin partner account
+ *     stops browsing those screens without anything breaking. Note that on
+ *     DSLP6 installs Admin Menu Tidy relocates Defender / Yoast / Media
+ *     Library Organizer under Tools, so those relocated entries disappear
+ *     for partners too.
  *
- * Both layers honour one escape hatch: DS Toolkit → Features → User Roles →
- * "Allow plugin access". When a LeagueApps dev switches it on, the Partner
- * role regains the plugin-management capabilities and the Plugins menu stops
- * being hidden. The DS Toolkit settings page itself is admin + LeagueApps
+ * The plugin layers honour one escape hatch: DS Toolkit → Features → User
+ * Roles → "Allow plugin access". When a LeagueApps dev switches it on, the
+ * Partner role regains the plugin-management capabilities and the Plugins
+ * menu stops being hidden (Tools/Settings stay hidden — they're not plugin
+ * management). The DS Toolkit settings page itself is admin + LeagueApps
  * gated, so partners can never flip the switch themselves.
  *
  * Disabling the feature stops the menu hiding and the role sync, but the
@@ -40,7 +44,7 @@ class DS_User_Roles {
 	public function init() {
 		add_action( 'init', array( $this, 'sync_role' ), 5 );
 		// Very late, after every plugin has registered its menus.
-		add_action( 'admin_menu', array( $this, 'hide_plugins_menu' ), 999999 );
+		add_action( 'admin_menu', array( $this, 'hide_admin_menus' ), 999999 );
 	}
 
 	private function plugin_access_allowed() {
@@ -85,15 +89,21 @@ class DS_User_Roles {
 	}
 
 	/**
-	 * Hide the Plugins menu from non-LeagueApps users (label hide; capabilities
-	 * untouched). Partner-role users already lack activate_plugins, so WordPress
-	 * hides the menu for them natively — this catches legacy full-admin partner
-	 * accounts.
+	 * Hide admin menus from non-LeagueApps users (label hide; capabilities
+	 * untouched). Plugins honours the "Allow plugin access" escape hatch;
+	 * Tools and Settings are always hidden for partners — those screens hold
+	 * host/SEO/security surfaces partners shouldn't wander into. Partner-role
+	 * users already lack activate_plugins, so WordPress hides Plugins for them
+	 * natively — the explicit remove catches legacy full-admin partner accounts.
 	 */
-	public function hide_plugins_menu() {
-		if ( $this->plugin_access_allowed() || DS_Toolkit::is_leagueapps_user() ) {
+	public function hide_admin_menus() {
+		if ( DS_Toolkit::is_leagueapps_user() ) {
 			return;
 		}
-		remove_menu_page( 'plugins.php' );
+		if ( ! $this->plugin_access_allowed() ) {
+			remove_menu_page( 'plugins.php' );
+		}
+		remove_menu_page( 'tools.php' );
+		remove_menu_page( 'options-general.php' );
 	}
 }


### PR DESCRIPTION
Extends the User Roles feature's partner-safe menu hiding beyond Plugins: the **Tools** and **Settings** admin menus are now hidden for non-LeagueApps emails too. Label hide only — capabilities untouched, direct URLs still resolve — matching the Admin Menu Tidy philosophy.

- The **Allow plugin access** switch keeps governing Plugins only; Tools/Settings stay hidden for partners regardless (host/SEO/security surfaces).
- Heads-up: on DSLP6 installs, Admin Menu Tidy relocates Defender / Yoast / Media Library Organizer under Tools, so those entries disappear for partners as well.
