### PR TITLE
feat: tournament Event Card style + filter bar (1.9.31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.31] - 2026-07-16
+### Added
+- **Post Loop: Tournament "Event Card" style + filter bar.** The Tournament layout gains a second Card Style (Tournament Cards -> Card Style): a flat event card with a badge pill on the image ("Tournament", editable), the event image centred plain over the featured photo, a left-aligned details list (date, location, gender chips, division chips), and a full-width theme-synced button ("View Event Details"). An optional **Filter Bar** (enable/disable) renders gender tabs (All + genders found), a state dropdown, a search box, and a live "N events" count -- all client-side, no reloads. Genders come from a new `event_gender` field; states from `event_state` or the ", XX" tail of the Location. Existing modules keep the Classic overlapping style untouched.
+
 ## [1.9.30] - 2026-07-15
 ### Changed
 - **User Roles: Tools and Settings menus now hidden from non-LeagueApps users.** Alongside the existing Plugins hide — menu labels only, capabilities untouched. The "Allow plugin access" switch still restores Plugins; Tools/Settings stay hidden for partners regardless (they hold host/SEO/security surfaces). Note: on DSLP6 installs Admin Menu Tidy relocates Defender / Yoast / Media Library Organizer under Tools, so those entries disappear for partners too.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.30
+ * Version:           1.9.31
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.30' );
+define( 'DS_TOOLKIT_VERSION', '1.9.31' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-post-loop/css/frontend.css
+++ b/modules/ds-post-loop/css/frontend.css
@@ -201,3 +201,34 @@
 /* WYSIWYG sponsor description paragraphs. */
 .ds-sponsor-desc p{margin:0 0 .5em;}
 .ds-sponsor-desc p:last-child{margin-bottom:0;}
+
+/* ---- Tournament: Event Card style (badge + details list + filter bar) ---- */
+.ds-tourn--event .ds-tourn-card{background:var(--fl-global-white);overflow:hidden;box-shadow:0 12px 32px -20px rgba(10,30,60,.35);}
+.ds-tourn--event .ds-tourn-body{flex:1 1 auto;box-shadow:none;gap:12px;}
+.ds-tourn--event .ds-tourn-title{font-size:1.1rem;text-transform:uppercase;letter-spacing:.01em;}
+.ds-tourn--event .ds-tourn-meta{align-items:flex-start;gap:9px;width:100%;}
+.ds-tourn--event .ds-tourn-logo{background:transparent;box-shadow:none;padding:0;overflow:visible;filter:drop-shadow(0 8px 22px rgba(0,0,0,.35));}
+.ds-tourn-badge{position:absolute;top:14px;left:50%;transform:translateX(-50%);z-index:2;background:var(--fl-global-button);color:var(--fl-global-white);font-size:.68rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase;line-height:1;padding:6px 14px;border-radius:999px;white-space:nowrap;}
+.ds-tourn-row{display:inline-flex;align-items:flex-start;gap:7px;font-size:.85rem;color:var(--fl-global-body);line-height:1.3;}
+.ds-tourn-row svg{width:15px;height:15px;flex:0 0 auto;color:var(--fl-global-accent);margin-top:1px;}
+.ds-tourn-chips{display:flex;flex-wrap:wrap;gap:6px;}
+.ds-tourn-chip{background:color-mix(in srgb, var(--fl-global-body) 10%, transparent);color:var(--fl-global-headings);border-radius:999px;padding:3px 10px;font-size:.72rem;font-weight:700;line-height:1.3;}
+.ds-tourn-btn--full{display:block;width:100%;text-align:center;margin-top:auto;box-sizing:border-box;}
+
+/* ---- Tournament: filter bar ---- */
+.ds-tourn-filter{display:flex;align-items:center;gap:14px;flex-wrap:wrap;background:var(--fl-global-white);border:1px solid rgba(0,0,0,.08);border-radius:var(--ds-radius);padding:10px 14px;margin-bottom:24px;}
+.ds-tourn-tabs{display:inline-flex;background:color-mix(in srgb, var(--fl-global-body) 8%, transparent);border-radius:8px;padding:3px;gap:2px;}
+.fl-builder-content .ds-tourn-tab{appearance:none;-webkit-appearance:none;border:0 !important;background:transparent !important;box-shadow:none;padding:7px 16px;border-radius:6px;font-size:.85rem;font-weight:700;line-height:1.2;cursor:pointer;color:var(--fl-global-body) !important;clip-path:none;-webkit-clip-path:none;}
+.fl-builder-content .ds-tourn-tab.is-active{background:var(--fl-global-white) !important;color:var(--fl-global-headings) !important;box-shadow:0 1px 4px rgba(0,0,0,.16);}
+.ds-tourn-state{display:inline-flex;align-items:center;gap:8px;border:1px solid rgba(0,0,0,.12);border-radius:8px;padding:7px 12px;cursor:pointer;}
+.ds-tourn-state svg{width:15px;height:15px;color:var(--fl-global-headings);flex:0 0 auto;}
+.ds-tourn-state select{border:0;background:transparent;font-weight:700;font-size:.85rem;color:var(--fl-global-headings);outline:none;cursor:pointer;}
+.ds-tourn-search{display:inline-flex;align-items:center;gap:8px;border:1px solid rgba(0,0,0,.12);border-radius:8px;padding:7px 12px;margin-left:auto;background:var(--fl-global-white);}
+.ds-tourn-search svg{width:15px;height:15px;color:var(--fl-global-body);flex:0 0 auto;}
+.ds-tourn-search input{border:0;background:transparent;outline:none;font-size:.85rem;min-width:150px;color:var(--fl-global-headings);}
+.ds-tourn-count{font-size:.85rem;font-weight:600;color:var(--fl-global-body);white-space:nowrap;}
+.ds-tourn-none{padding:18px;text-align:center;opacity:.75;}
+@media(max-width:600px){
+  .ds-tourn-search{margin-left:0;width:100%;}
+  .ds-tourn-search input{flex:1 1 auto;}
+}

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -696,6 +696,47 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 	}
 
 	/** Tournament Cards — upcoming events (by the event_date ACF field), image with an overlapping details card. */
+	/** Read an event meta value as a trimmed list (ACF checkbox array or comma text). */
+	private function tourn_list( $pid, $key ) {
+		$v = function_exists( 'get_field' ) ? get_field( $key, $pid ) : get_post_meta( $pid, $key, true );
+		if ( is_array( $v ) ) { $v = implode( ',', $v ); }
+		return array_values( array_filter( array_map( 'trim', explode( ',', (string) $v ) ) ) );
+	}
+
+	/** Event state: explicit event_state field, else the ", XX" tail of the location. */
+	private function tourn_state( $pid, $loc ) {
+		$st = function_exists( 'get_field' ) ? trim( (string) get_field( 'event_state', $pid ) ) : trim( (string) get_post_meta( $pid, 'event_state', true ) );
+		if ( '' === $st && preg_match( '/,\s*([A-Za-z]{2})\.?\s*$/', $loc, $m ) ) { $st = $m[1]; }
+		return strtoupper( $st );
+	}
+
+	/** The Event Card filter bar: gender tabs + state dropdown + search + live count. */
+	private function tourn_filter_bar( $rows ) {
+		$genders = array(); $states = array();
+		foreach ( $rows as $r ) {
+			foreach ( $r['gender'] as $g ) { $genders[ strtolower( $g ) ] = $g; }
+			if ( '' !== $r['state'] ) { $states[ $r['state'] ] = $r['state'] ; }
+		}
+		ksort( $genders ); ksort( $states );
+		$pin  = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 21s-7-6.2-7-11a7 7 0 0 1 14 0c0 4.8-7 11-7 11z"/><circle cx="12" cy="10" r="2.5"/></svg>';
+		$mag  = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>';
+		echo '<div class="ds-tourn-filter">';
+		echo '<div class="ds-tourn-tabs" role="group" aria-label="' . esc_attr__( 'Filter by gender', 'ds-toolkit' ) . '">';
+		echo '<button type="button" class="ds-tourn-tab is-active" data-gender="">' . esc_html__( 'All', 'ds-toolkit' ) . '</button>';
+		foreach ( $genders as $key => $label ) {
+			echo '<button type="button" class="ds-tourn-tab" data-gender="' . esc_attr( $key ) . '">' . esc_html( $label ) . '</button>';
+		}
+		echo '</div>';
+		if ( ! empty( $states ) ) {
+			echo '<label class="ds-tourn-state">' . $pin . '<select aria-label="' . esc_attr__( 'Filter by state', 'ds-toolkit' ) . '"><option value="">' . esc_html__( 'All states', 'ds-toolkit' ) . '</option>';
+			foreach ( $states as $st ) { echo '<option value="' . esc_attr( $st ) . '">' . esc_html( $st ) . '</option>'; }
+			echo '</select></label>';
+		}
+		echo '<div class="ds-tourn-search">' . $mag . '<input type="search" placeholder="' . esc_attr__( 'Search events…', 'ds-toolkit' ) . '" aria-label="' . esc_attr__( 'Search events', 'ds-toolkit' ) . '"></div>';
+		echo '<span class="ds-tourn-count">' . count( $rows ) . ' ' . esc_html( 1 === count( $rows ) ? __( 'event', 'ds-toolkit' ) : __( 'events', 'ds-toolkit' ) ) . '</span>';
+		echo '</div>';
+	}
+
 	public function render_tournament() {
 		$s     = $this->settings;
 		$ptype = preg_replace( '/[^a-z0-9_-]/', '', (string) ( $s->post_type ?? 'event' ) );
@@ -713,38 +754,81 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		usort( $items, function ( $a, $b ) { return $a['ts'] <=> $b['ts']; } ); // upcoming first (event_date ascending)
 		$items = array_slice( $items, 0, $limit );
 
-		echo '<section class="ds-news ds-tourn"><div class="ds-news-wrap">';
+		$style     = ( ( $s->tn_style ?? 'overlap' ) === 'event' ) ? 'event' : 'overlap';
+		$filter_on = 'event' === $style && ( $s->tn_filter ?? 'disable' ) === 'enable' && ! empty( $items );
+
+		$root = 'ds-news ds-tourn' . ( 'event' === $style ? ' ds-tourn--event' : '' ) . ( $filter_on ? ' ds-tourn--filter' : '' );
+		echo '<section class="' . esc_attr( $root ) . '"><div class="ds-news-wrap">';
 		$this->render_head();
 		if ( empty( $items ) ) {
 			if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No upcoming events. Publish events with a future Event Date.', 'ds-toolkit' ) . '</p>'; }
 			echo '</div></section>'; return;
 		}
-		$cal = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="4" width="18" height="17" rx="2"/><path d="M3 9h18M8 2v4M16 2v4"/></svg>';
-		$pin = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 21s-7-6.2-7-11a7 7 0 0 1 14 0c0 4.8-7 11-7 11z"/><circle cx="12" cy="10" r="2.5"/></svg>';
-		$btn = trim( (string) ( $s->tourn_btn ?? '' ) ); if ( '' === $btn ) { $btn = __( 'View More', 'ds-toolkit' ); }
-		$this->loop_open( 'ds-tourn-grid' );
+
+		// Enriched rows (the Event Card style + filter bar read gender/division/state).
+		$rows = array();
 		foreach ( $items as $it ) {
 			$p = $it['p']; $pid = $p->ID;
-			$url = get_permalink( $pid ); $title = get_the_title( $pid );
-			// Main (back) banner = the Featured image; the Event Image sits small & centered, overlapping it.
 			$feat = has_post_thumbnail( $pid ) ? (string) get_the_post_thumbnail_url( $pid, 'large' ) : '';
 			if ( '' === $feat ) { $feat = self::placeholder_image(); }
-			$evt  = $this->acf_image_url( ( function_exists( 'get_field' ) ? get_field( 'event_image', $pid ) : '' ) ?: '' );
-			$loc = function_exists( 'get_field' ) ? trim( (string) get_field( 'event_location', $pid ) ) : '';
-			echo '<a class="ds-tourn-card" href="' . esc_url( $url ) . '">';
-			echo '<div class="ds-tourn-img"' . ( $feat ? ' style="background-image:url(' . esc_url( $feat ) . ')"' : '' ) . '>';
-			if ( '' !== $evt ) { echo '<span class="ds-tourn-logo"><img src="' . esc_url( $evt ) . '" alt="" loading="lazy" /></span>'; }
+			$loc  = function_exists( 'get_field' ) ? trim( (string) get_field( 'event_location', $pid ) ) : '';
+			$rows[] = array(
+				'pid'      => $pid,
+				'url'      => get_permalink( $pid ),
+				'title'    => get_the_title( $pid ),
+				'date'     => $it['raw'],
+				'feat'     => $feat,
+				'logo'     => $this->acf_image_url( ( function_exists( 'get_field' ) ? get_field( 'event_image', $pid ) : '' ) ?: '' ),
+				'loc'      => $loc,
+				'gender'   => $this->tourn_list( $pid, 'event_gender' ),
+				'division' => $this->tourn_list( $pid, 'event_division' ),
+				'state'    => $this->tourn_state( $pid, $loc ),
+			);
+		}
+
+		if ( $filter_on ) { $this->tourn_filter_bar( $rows ); }
+
+		$cal    = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="4" width="18" height="17" rx="2"/><path d="M3 9h18M8 2v4M16 2v4"/></svg>';
+		$pin    = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 21s-7-6.2-7-11a7 7 0 0 1 14 0c0 4.8-7 11-7 11z"/><circle cx="12" cy="10" r="2.5"/></svg>';
+		$person = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 3.6-6.5 8-6.5s8 2.5 8 6.5"/></svg>';
+		$tag    = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M20.6 13.4 12 22l-8.6-8.6a2 2 0 0 1-.6-1.4V4a2 2 0 0 1 2-2h8a2 2 0 0 1 1.4.6l8.4 8.4a2 2 0 0 1 0 2.8z" transform="scale(.9) translate(1 1)"/><circle cx="7.5" cy="7.5" r="1.5"/></svg>';
+		$btn    = trim( (string) ( $s->tourn_btn ?? '' ) );
+		if ( '' === $btn ) { $btn = 'event' === $style ? __( 'View Event Details', 'ds-toolkit' ) : __( 'View More', 'ds-toolkit' ); }
+		$badge  = 'event' === $style ? trim( (string) ( $s->tn_badge ?? __( 'Tournament', 'ds-toolkit' ) ) ) : '';
+
+		$this->loop_open( 'ds-tourn-grid' );
+		foreach ( $rows as $r ) {
+			$data = '';
+			if ( $filter_on ) {
+				$q     = strtolower( $r['title'] . ' ' . $r['loc'] . ' ' . implode( ' ', $r['division'] ) . ' ' . implode( ' ', $r['gender'] ) );
+				$data  = ' data-gender="' . esc_attr( strtolower( implode( ' ', $r['gender'] ) ) ) . '"';
+				$data .= ' data-state="' . esc_attr( $r['state'] ) . '"';
+				$data .= ' data-q="' . esc_attr( $q ) . '"';
+			}
+			echo '<a class="ds-tourn-card' . ( 'event' === $style ? ' ds-tourn-card--event' : '' ) . '" href="' . esc_url( $r['url'] ) . '"' . $data . '>';
+			echo '<div class="ds-tourn-img"' . ( $r['feat'] ? ' style="background-image:url(' . esc_url( $r['feat'] ) . ')"' : '' ) . '>';
+			if ( 'event' === $style && '' !== $badge ) { echo '<span class="ds-tourn-badge">' . esc_html( $badge ) . '</span>'; }
+			if ( '' !== $r['logo'] ) { echo '<span class="ds-tourn-logo"><img src="' . esc_url( $r['logo'] ) . '" alt="" loading="lazy" /></span>'; }
 			echo '</div>';
 			echo '<div class="ds-tourn-body">';
-			echo '<h3 class="ds-tourn-title">' . DS_Module_UI::inline( $title ) . '</h3>';
+			echo '<h3 class="ds-tourn-title">' . DS_Module_UI::inline( $r['title'] ) . '</h3>';
 			echo '<div class="ds-tourn-meta">';
-			if ( '' !== $it['raw'] ) { echo '<span class="ds-tourn-date">' . $cal . '<span>' . esc_html( $it['raw'] ) . '</span></span>'; }
-			if ( '' !== $loc )       { echo '<span class="ds-tourn-loc">' . $pin . '<span>' . esc_html( $loc ) . '</span></span>'; }
+			if ( '' !== $r['date'] ) { echo '<span class="ds-tourn-date">' . $cal . '<span>' . esc_html( $r['date'] ) . '</span></span>'; }
+			if ( '' !== $r['loc'] )  { echo '<span class="ds-tourn-loc">' . $pin . '<span>' . esc_html( $r['loc'] ) . '</span></span>'; }
+			if ( 'event' === $style && ! empty( $r['gender'] ) ) {
+				echo '<span class="ds-tourn-row">' . $person . '<span class="ds-tourn-chips"><span class="ds-tourn-chip">' . esc_html( implode( ', ', $r['gender'] ) ) . '</span></span></span>';
+			}
+			if ( 'event' === $style && ! empty( $r['division'] ) ) {
+				echo '<span class="ds-tourn-row">' . $tag . '<span class="ds-tourn-chips">';
+				foreach ( $r['division'] as $d ) { echo '<span class="ds-tourn-chip">' . esc_html( $d ) . '</span>'; }
+				echo '</span></span>';
+			}
 			echo '</div>';
-			echo '<span class="ds-tourn-btn">' . esc_html( $btn ) . '</span>';
+			echo '<span class="ds-tourn-btn' . ( 'event' === $style ? ' ds-tourn-btn--full' : '' ) . '">' . esc_html( $btn ) . '</span>';
 			echo '</div></a>';
 		}
 		$this->loop_close();
+		if ( $filter_on ) { echo '<p class="ds-tourn-none" hidden>' . esc_html__( 'No events match your filters.', 'ds-toolkit' ) . '</p>'; }
 		echo '</div></section>';
 	}
 
@@ -1257,6 +1341,28 @@ $ds_pl_form = array(
 				'title'       => __( 'Tournament Cards', 'ds-toolkit' ),
 				'description' => __( 'Ordering is automatic: upcoming events first, sorted by the Event Date field, with past events hidden. (The Query tab\'s Order By / Order do not apply to this layout.)', 'ds-toolkit' ),
 				'fields' => array(
+					'tn_style'       => array(
+						'type'    => 'select',
+						'label'   => __( 'Card Style', 'ds-toolkit' ),
+						'default' => 'overlap',
+						'options' => array(
+							'overlap' => __( 'Classic — overlapping details card', 'ds-toolkit' ),
+							'event'   => __( 'Event Card — badge, details list, filter-ready', 'ds-toolkit' ),
+						),
+						'toggle'  => array(
+							'overlap' => array( 'fields' => array( 'tn_overlap', 'tn_inset', 'tn_align', 'tn_logo_shape' ) ),
+							'event'   => array( 'fields' => array( 'tn_badge', 'tn_filter' ) ),
+						),
+						'help'    => __( 'Event Card: flat card with a badge pill on the image, left-aligned date/location plus gender & division chips, and a full-width button. Supports the filter bar.', 'ds-toolkit' ),
+					),
+					'tn_badge'       => array( 'type' => 'text', 'label' => __( 'Badge Text', 'ds-toolkit' ), 'default' => 'Tournament', 'help' => __( 'The pill shown at the top of the image. Blank = no badge.', 'ds-toolkit' ) ),
+					'tn_filter'      => array(
+						'type'    => 'select',
+						'label'   => __( 'Filter Bar', 'ds-toolkit' ),
+						'default' => 'disable',
+						'options' => array( 'disable' => __( 'Disable', 'ds-toolkit' ), 'enable' => __( 'Enable', 'ds-toolkit' ) ),
+						'help'    => __( 'Adds gender tabs, a state dropdown, a search box, and a live event count above the grid. Genders come from the event_gender field; states from event_state or the ", XX" tail of the Location.', 'ds-toolkit' ),
+					),
 					'tn_cols'        => array( 'type' => 'unit', 'label' => __( 'Columns', 'ds-toolkit' ), 'default' => '3', 'slider' => array( 'min' => 1, 'max' => 5, 'step' => 1 ) ),
 					'tn_gap'         => array( 'type' => 'unit', 'label' => __( 'Gap', 'ds-toolkit' ), 'default' => '28', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 60, 'step' => 1 ) ),
 					'tn_img_ratio'   => array( 'type' => 'select', 'label' => __( 'Image Ratio', 'ds-toolkit' ), 'default' => '16 / 10', 'options' => array( '16 / 9' => '16:9', '16 / 10' => '16:10', '4 / 3' => '4:3', '3 / 2' => '3:2', '1 / 1' => '1:1' ) ),

--- a/modules/ds-post-loop/includes/frontend.css.php
+++ b/modules/ds-post-loop/includes/frontend.css.php
@@ -214,13 +214,22 @@ if ( ( $settings->card_layout ?? '' ) === 'tournament' ) {
 	$ar = preg_replace( '#[^0-9/ ]#', '', (string) ( $settings->tn_img_ratio ?? '16 / 10' ) ); if ( '' === trim( $ar ) ) { $ar = '16 / 10'; }
 	echo "$node .ds-tourn-img{aspect-ratio:$ar;}\n";
 	$ls = $u( $settings->tn_logo_size ?? '', 96 );
-	$lsh = ( ( $settings->tn_logo_shape ?? 'circle' ) === 'square' ) ? '14px' : '50%';
-	echo "$node .ds-tourn-logo{width:{$ls}px;height:{$ls}px;border-radius:{$lsh};}\n";
 	$trad = ( isset( $settings->tn_radius ) && '' !== $settings->tn_radius ) ? ( (int) $settings->tn_radius ) . 'px' : 'var(--ds-radius)';
-	echo "$node .ds-tourn-img,$node .ds-tourn-body{border-radius:{$trad};}\n";
-	$ov = $u( $settings->tn_overlap ?? '', 48 ); $ins = $u( $settings->tn_inset ?? '', 18 ); $tpad = $u( $settings->tn_pad ?? '', 24 );
-	$tal = ( ( $settings->tn_align ?? 'center' ) === 'left' ) ? 'left' : 'center'; $tai = ( 'left' === $tal ) ? 'flex-start' : 'center';
-	echo "$node .ds-tourn-body{margin:-{$ov}px {$ins}px 0;padding:{$tpad}px;text-align:{$tal};align-items:{$tai};}\n";
+	$tpad = $u( $settings->tn_pad ?? '', 24 );
+	if ( ( $settings->tn_style ?? 'overlap' ) === 'event' ) {
+		// Event Card: flat white card (radius on the card, image square inside),
+		// left-aligned details, plain centred logo (no white circle chrome).
+		echo "$node .ds-tourn-card{border-radius:{$trad};}\n";
+		echo "$node .ds-tourn-logo{width:{$ls}px;height:{$ls}px;border-radius:0;}\n";
+		echo "$node .ds-tourn-body{margin:0;padding:{$tpad}px;text-align:left;align-items:stretch;}\n";
+	} else {
+		$lsh = ( ( $settings->tn_logo_shape ?? 'circle' ) === 'square' ) ? '14px' : '50%';
+		echo "$node .ds-tourn-logo{width:{$ls}px;height:{$ls}px;border-radius:{$lsh};}\n";
+		echo "$node .ds-tourn-img,$node .ds-tourn-body{border-radius:{$trad};}\n";
+		$ov = $u( $settings->tn_overlap ?? '', 48 ); $ins = $u( $settings->tn_inset ?? '', 18 );
+		$tal = ( ( $settings->tn_align ?? 'center' ) === 'left' ) ? 'left' : 'center'; $tai = ( 'left' === $tal ) ? 'flex-start' : 'center';
+		echo "$node .ds-tourn-body{margin:-{$ov}px {$ins}px 0;padding:{$tpad}px;text-align:{$tal};align-items:{$tai};}\n";
+	}
 	$c = $col( $settings->tn_card_bg ?? '' );    if ( $c ) { echo "$node .ds-tourn-body{background:{$c};}\n"; }
 	$c = $col( $settings->tn_title_color ?? '' ); if ( $c ) { echo "$node .ds-tourn-title{color:{$c};}\n"; }
 	$c = $col( $settings->tn_meta_color ?? '' );  if ( $c ) { echo "$node .ds-tourn-date,$node .ds-tourn-loc{color:{$c};}\n"; }

--- a/modules/ds-post-loop/js/frontend.js
+++ b/modules/ds-post-loop/js/frontend.js
@@ -143,9 +143,59 @@
 		}
 	}
 
+	/* ------------------------------------------------- Tournament filter bar */
+	function initTournFilter(root) {
+		if (root.dsTournInit) return;
+		var bar  = root.querySelector('.ds-tourn-filter');
+		var grid = root.querySelector('.ds-tourn-grid');
+		if (!bar || !grid) return;
+		root.dsTournInit = true;
+
+		var cards = [].slice.call(grid.querySelectorAll('.ds-tourn-card'));
+		var tabs  = [].slice.call(bar.querySelectorAll('.ds-tourn-tab'));
+		var sel   = bar.querySelector('.ds-tourn-state select');
+		var inp   = bar.querySelector('.ds-tourn-search input');
+		var count = bar.querySelector('.ds-tourn-count');
+		var none  = root.querySelector('.ds-tourn-none');
+		var gender = '', state = '', q = '';
+
+		function apply() {
+			var shown = 0;
+			cards.forEach(function (c) {
+				var ok = true;
+				if (gender && (' ' + (c.dataset.gender || '') + ' ').indexOf(' ' + gender + ' ') === -1) ok = false;
+				if (ok && state && (c.dataset.state || '') !== state) ok = false;
+				if (ok && q && (c.dataset.q || '').indexOf(q) === -1) ok = false;
+				c.style.display = ok ? '' : 'none';
+				if (ok) shown++;
+			});
+			if (count) count.textContent = shown + ' ' + (shown === 1 ? 'event' : 'events');
+			if (none) none.hidden = shown !== 0;
+		}
+
+		tabs.forEach(function (t) {
+			t.addEventListener('click', function () {
+				tabs.forEach(function (x) { x.classList.remove('is-active'); });
+				t.classList.add('is-active');
+				gender = t.dataset.gender || '';
+				apply();
+			});
+		});
+		if (sel) sel.addEventListener('change', function () { state = sel.value; apply(); });
+		if (inp) {
+			var deb;
+			inp.addEventListener('input', function () {
+				clearTimeout(deb);
+				deb = setTimeout(function () { q = inp.value.trim().toLowerCase(); apply(); }, 150);
+			});
+		}
+		apply();
+	}
+
 	function boot(rt) {
 		(rt || document).querySelectorAll('.ds-loopcar').forEach(initCarousel);
 		(rt || document).querySelectorAll('.ds-looppage').forEach(initPagination);
+		(rt || document).querySelectorAll('.ds-tourn--filter').forEach(initTournFilter);
 	}
 	if (document.readyState !== 'loading') boot();
 	else document.addEventListener('DOMContentLoaded', function () { boot(); });


### PR DESCRIPTION
Modernises the Tournament layout to match the mylacrossetournaments.com event-card reference.

**Event Card style** (Tournament Cards → Card Style → Event Card; existing modules keep Classic):
- Badge pill over the featured image (text editable, default "Tournament").
- Event image overlays the photo centred, plain (no white circle chrome).
- Left-aligned details list: 📅 date, 📍 location, 👤 gender chips, 🏷 division chips.
- Full-width theme-synced button, bottom-aligned across the row (default "View Event Details").

**Filter bar** (Event Card only, enable/disable, default off):
- Gender tabs (All + each gender found in the loop), state dropdown (from `event_state` or the ", XX" tail of Location), search box, live "N events" count, and a no-results message. Pure client-side via per-card data attributes — no reloads.
