### PR TITLE
fix: ordinal-suffixed event date ranges parsed correctly (1.9.32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.32] - 2026-07-16
+### Fixed
+- **Tournament cards: date ranges with ordinal suffixes no longer drop future events.** The range normaliser only matched bare digits before the dash, so `March 20th-21st, 2027` slipped through unnormalised and PHP's strtotime mis-parsed it into March 2026 -- a "past" date, silently hiding the event. Suffixed ranges (`18th-20th`) now normalise like bare ones (`18-20`), which also makes range sorting land on the actual start day.
+
 ## [1.9.31] - 2026-07-16
 ### Added
 - **Post Loop: Tournament "Event Card" style + filter bar.** The Tournament layout gains a second Card Style (Tournament Cards -> Card Style): a flat event card with a badge pill on the image ("Tournament", editable), the event image centred plain over the featured photo, a left-aligned details list (date, location, gender chips, division chips), and a full-width theme-synced button ("View Event Details"). An optional **Filter Bar** (enable/disable) renders gender tabs (All + genders found), a state dropdown, a search box, and a live "N events" count -- all client-side, no reloads. Genders come from a new `event_gender` field; states from `event_state` or the ", XX" tail of the Location. Existing modules keep the Classic overlapping style untouched.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.31
+ * Version:           1.9.32
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.31' );
+define( 'DS_TOOLKIT_VERSION', '1.9.32' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -690,7 +690,10 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 	private function parse_event_date( $str ) {
 		$str = trim( (string) $str );
 		if ( '' === $str ) { return 0; }
-		$norm = preg_replace( '/(\d{1,2})\s*[\x{2013}\x{2014}-]\s*\d{1,2}/u', '$1', $str ); // "18-20" -> "18"
+		// "18-20" / "18th-20th" -> "18". Ordinal suffixes must be part of the match:
+		// strtotime mis-parses an unnormalised "March 20th-21st, 2027" into MARCH 2026,
+		// which silently dropped future events as "past" (seen on the fleet blueprint).
+		$norm = preg_replace( '/(\d{1,2})(?:st|nd|rd|th)?\s*[\x{2013}\x{2014}-]\s*\d{1,2}(?:st|nd|rd|th)?/iu', '$1', $str );
 		$ts = strtotime( $norm );
 		return $ts ? (int) $ts : 0;
 	}


### PR DESCRIPTION
Found while verifying the new Event Card page: the tournament layout's date-range normaliser (`18-20` → `18`) only matched bare digits before the dash, so `March 20th-21st, 2027` passed through unnormalised and `strtotime` mis-parsed it into **March 2026** — a past date, silently hiding the future event from the loop. Ordinal suffixes (`18th-20th`) are now part of the range match, which also makes range sorting land on the actual start day instead of a strtotime guess.
