### PR TITLE
feat: tournament Event Card List display (1.9.33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.33] - 2026-07-17
+### Added
+- **Post Loop: Tournament Event Card "List" display.** New Display option (Grid / List) on the Event Card style. List renders each event as a full-width row -- accent date tile (month + day), logo thumbnail, gender eyebrow, uppercase title, location + date meta, outlined division chips, and a "Register ->" button (theme-synced). The filter bar (gender tabs, state dropdown, search, live count) works identically in both displays. Rows collapse gracefully on mobile.
+
 ## [1.9.32] - 2026-07-16
 ### Fixed
 - **Tournament cards: date ranges with ordinal suffixes no longer drop future events.** The range normaliser only matched bare digits before the dash, so `March 20th-21st, 2027` slipped through unnormalised and PHP's strtotime mis-parsed it into March 2026 -- a "past" date, silently hiding the event. Suffixed ranges (`18th-20th`) now normalise like bare ones (`18-20`), which also makes range sorting land on the actual start day.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.32
+ * Version:           1.9.33
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.32' );
+define( 'DS_TOOLKIT_VERSION', '1.9.33' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-post-loop/css/frontend.css
+++ b/modules/ds-post-loop/css/frontend.css
@@ -232,3 +232,24 @@
   .ds-tourn-search{margin-left:0;width:100%;}
   .ds-tourn-search input{flex:1 1 auto;}
 }
+
+/* ---- Tournament: Event Card LIST display (rows) ---- */
+.ds-tourn--list .ds-tourn-card--row{flex-direction:row;align-items:center;gap:18px;padding:16px 20px;}
+.ds-tourn-when{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:1px;width:64px;height:64px;flex:0 0 auto;border-radius:12px;background:color-mix(in srgb, var(--fl-global-accent) 10%, transparent);}
+.ds-tourn-when-m{font-size:.58rem;font-weight:800;letter-spacing:.08em;text-transform:uppercase;color:var(--fl-global-accent);line-height:1;}
+.ds-tourn-when-d{font-size:1.35rem;font-weight:800;color:var(--fl-global-headings);line-height:1;}
+.ds-tourn-thumb{width:64px;height:64px;flex:0 0 auto;border:1px solid rgba(0,0,0,.08);border-radius:12px;background:var(--fl-global-white);overflow:hidden;display:flex;align-items:center;justify-content:center;}
+.ds-tourn-thumb img{width:100%;height:100%;object-fit:contain;padding:5px;box-sizing:border-box;display:block;}
+.ds-tourn-rowmain{display:flex;flex-direction:column;gap:4px;min-width:0;flex:1 1 auto;}
+.ds-tourn-eyebrow{color:var(--fl-global-accent);font-size:.66rem;font-weight:800;letter-spacing:.1em;text-transform:uppercase;line-height:1.2;}
+.ds-tourn--list .ds-tourn-title{font-size:1.25rem;text-transform:uppercase;line-height:1.15;}
+.ds-tourn-rowmeta{display:flex;align-items:center;gap:16px;flex-wrap:wrap;}
+.ds-tourn-rowside{display:flex;align-items:center;gap:14px;flex:0 0 auto;margin-left:auto;}
+.ds-tourn-chip--outline{background:transparent;border:1px solid rgba(0,0,0,.18);text-transform:uppercase;letter-spacing:.04em;}
+.ds-tourn-btn--row{display:inline-flex;align-items:center;gap:8px;width:auto;white-space:nowrap;}
+.ds-tourn-btn--row svg{width:14px;height:14px;flex:0 0 auto;}
+@media(max-width:860px){
+  .ds-tourn--list .ds-tourn-card--row{flex-wrap:wrap;}
+  .ds-tourn-rowmain{flex-basis:calc(100% - 170px);}
+  .ds-tourn-rowside{margin-left:0;width:100%;justify-content:space-between;flex-wrap:wrap;gap:10px;}
+}

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -758,9 +758,10 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		$items = array_slice( $items, 0, $limit );
 
 		$style     = ( ( $s->tn_style ?? 'overlap' ) === 'event' ) ? 'event' : 'overlap';
+		$list      = 'event' === $style && ( $s->tn_display ?? 'grid' ) === 'list';
 		$filter_on = 'event' === $style && ( $s->tn_filter ?? 'disable' ) === 'enable' && ! empty( $items );
 
-		$root = 'ds-news ds-tourn' . ( 'event' === $style ? ' ds-tourn--event' : '' ) . ( $filter_on ? ' ds-tourn--filter' : '' );
+		$root = 'ds-news ds-tourn' . ( 'event' === $style ? ' ds-tourn--event' : '' ) . ( $list ? ' ds-tourn--list' : '' ) . ( $filter_on ? ' ds-tourn--filter' : '' );
 		echo '<section class="' . esc_attr( $root ) . '"><div class="ds-news-wrap">';
 		$this->render_head();
 		if ( empty( $items ) ) {
@@ -780,6 +781,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 				'url'      => get_permalink( $pid ),
 				'title'    => get_the_title( $pid ),
 				'date'     => $it['raw'],
+				'ts'       => $it['ts'],
 				'feat'     => $feat,
 				'logo'     => $this->acf_image_url( ( function_exists( 'get_field' ) ? get_field( 'event_image', $pid ) : '' ) ?: '' ),
 				'loc'      => $loc,
@@ -795,8 +797,9 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		$pin    = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 21s-7-6.2-7-11a7 7 0 0 1 14 0c0 4.8-7 11-7 11z"/><circle cx="12" cy="10" r="2.5"/></svg>';
 		$person = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M4 21c0-4 3.6-6.5 8-6.5s8 2.5 8 6.5"/></svg>';
 		$tag    = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M20.6 13.4 12 22l-8.6-8.6a2 2 0 0 1-.6-1.4V4a2 2 0 0 1 2-2h8a2 2 0 0 1 1.4.6l8.4 8.4a2 2 0 0 1 0 2.8z" transform="scale(.9) translate(1 1)"/><circle cx="7.5" cy="7.5" r="1.5"/></svg>';
+		$arrow  = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>';
 		$btn    = trim( (string) ( $s->tourn_btn ?? '' ) );
-		if ( '' === $btn ) { $btn = 'event' === $style ? __( 'View Event Details', 'ds-toolkit' ) : __( 'View More', 'ds-toolkit' ); }
+		if ( '' === $btn ) { $btn = $list ? __( 'Register', 'ds-toolkit' ) : ( 'event' === $style ? __( 'View Event Details', 'ds-toolkit' ) : __( 'View More', 'ds-toolkit' ) ); }
 		$badge  = 'event' === $style ? trim( (string) ( $s->tn_badge ?? __( 'Tournament', 'ds-toolkit' ) ) ) : '';
 
 		$this->loop_open( 'ds-tourn-grid' );
@@ -808,6 +811,33 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 				$data .= ' data-state="' . esc_attr( $r['state'] ) . '"';
 				$data .= ' data-q="' . esc_attr( $q ) . '"';
 			}
+
+			if ( $list ) {
+				// List row: date tile · logo thumb · gender eyebrow + title + meta · chips + button.
+				echo '<a class="ds-tourn-card ds-tourn-card--row" href="' . esc_url( $r['url'] ) . '"' . $data . '>';
+				if ( $r['ts'] && PHP_INT_MAX !== $r['ts'] ) {
+					echo '<span class="ds-tourn-when" aria-hidden="true"><span class="ds-tourn-when-m">' . esc_html( date_i18n( 'F', $r['ts'] ) ) . '</span><span class="ds-tourn-when-d">' . esc_html( date_i18n( 'd', $r['ts'] ) ) . '</span></span>';
+				}
+				$thumb = $r['logo'] ?: $r['feat'];
+				if ( '' !== $thumb ) { echo '<span class="ds-tourn-thumb"><img src="' . esc_url( $thumb ) . '" alt="" loading="lazy" /></span>'; }
+				echo '<span class="ds-tourn-rowmain">';
+				if ( ! empty( $r['gender'] ) ) { echo '<span class="ds-tourn-eyebrow">' . esc_html( implode( ' & ', $r['gender'] ) ) . '</span>'; }
+				echo '<h3 class="ds-tourn-title">' . DS_Module_UI::inline( $r['title'] ) . '</h3>';
+				echo '<span class="ds-tourn-rowmeta">';
+				if ( '' !== $r['loc'] )  { echo '<span class="ds-tourn-loc">' . $pin . '<span>' . esc_html( $r['loc'] ) . '</span></span>'; }
+				if ( '' !== $r['date'] ) { echo '<span class="ds-tourn-date">' . $cal . '<span>' . esc_html( $r['date'] ) . '</span></span>'; }
+				echo '</span></span>';
+				echo '<span class="ds-tourn-rowside">';
+				if ( ! empty( $r['division'] ) ) {
+					echo '<span class="ds-tourn-chips">';
+					foreach ( $r['division'] as $d ) { echo '<span class="ds-tourn-chip ds-tourn-chip--outline">' . esc_html( $d ) . '</span>'; }
+					echo '</span>';
+				}
+				echo '<span class="ds-tourn-btn ds-tourn-btn--row">' . esc_html( $btn ) . $arrow . '</span>';
+				echo '</span></a>';
+				continue;
+			}
+
 			echo '<a class="ds-tourn-card' . ( 'event' === $style ? ' ds-tourn-card--event' : '' ) . '" href="' . esc_url( $r['url'] ) . '"' . $data . '>';
 			echo '<div class="ds-tourn-img"' . ( $r['feat'] ? ' style="background-image:url(' . esc_url( $r['feat'] ) . ')"' : '' ) . '>';
 			if ( 'event' === $style && '' !== $badge ) { echo '<span class="ds-tourn-badge">' . esc_html( $badge ) . '</span>'; }
@@ -1354,9 +1384,17 @@ $ds_pl_form = array(
 						),
 						'toggle'  => array(
 							'overlap' => array( 'fields' => array( 'tn_overlap', 'tn_inset', 'tn_align', 'tn_logo_shape' ) ),
-							'event'   => array( 'fields' => array( 'tn_badge', 'tn_filter' ) ),
+							'event'   => array( 'fields' => array( 'tn_display', 'tn_badge', 'tn_filter' ) ),
 						),
 						'help'    => __( 'Event Card: flat card with a badge pill on the image, left-aligned date/location plus gender & division chips, and a full-width button. Supports the filter bar.', 'ds-toolkit' ),
+					),
+					'tn_display'     => array(
+						'type'    => 'select',
+						'label'   => __( 'Display', 'ds-toolkit' ),
+						'default' => 'grid',
+						'options' => array( 'grid' => __( 'Grid (cards)', 'ds-toolkit' ), 'list' => __( 'List (rows)', 'ds-toolkit' ) ),
+						'toggle'  => array( 'grid' => array( 'fields' => array( 'tn_badge', 'tn_cols', 'tn_img_ratio' ) ) ),
+						'help'    => __( 'List renders each event as a full-width row: date tile, logo, gender + title + location, division chips, and a Register button.', 'ds-toolkit' ),
 					),
 					'tn_badge'       => array( 'type' => 'text', 'label' => __( 'Badge Text', 'ds-toolkit' ), 'default' => 'Tournament', 'help' => __( 'The pill shown at the top of the image. Blank = no badge.', 'ds-toolkit' ) ),
 					'tn_filter'      => array(

--- a/modules/ds-post-loop/includes/frontend.css.php
+++ b/modules/ds-post-loop/includes/frontend.css.php
@@ -206,11 +206,17 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 
 // ---- Tournament cards (events) ----
 if ( ( $settings->card_layout ?? '' ) === 'tournament' ) {
-	$tc = max( 1, (int) ( $settings->tn_cols ?? 3 ) );
 	$tg = $u( $settings->tn_gap ?? '', 28 );
-	echo "$node .ds-tourn-grid{grid-template-columns:repeat({$tc},1fr);gap:{$tg}px;}\n";
-	echo "@media(max-width:1024px){ $node .ds-tourn-grid{grid-template-columns:repeat(2,1fr);} }\n";
-	echo "@media(max-width:600px){ $node .ds-tourn-grid{grid-template-columns:1fr;} }\n";
+	$is_list = ( ( $settings->tn_style ?? 'overlap' ) === 'event' ) && ( ( $settings->tn_display ?? 'grid' ) === 'list' );
+	if ( $is_list ) {
+		// List display is always a single column of rows.
+		echo "$node .ds-tourn-grid{grid-template-columns:1fr;gap:" . min( $tg, 18 ) . "px;}\n";
+	} else {
+		$tc = max( 1, (int) ( $settings->tn_cols ?? 3 ) );
+		echo "$node .ds-tourn-grid{grid-template-columns:repeat({$tc},1fr);gap:{$tg}px;}\n";
+		echo "@media(max-width:1024px){ $node .ds-tourn-grid{grid-template-columns:repeat(2,1fr);} }\n";
+		echo "@media(max-width:600px){ $node .ds-tourn-grid{grid-template-columns:1fr;} }\n";
+	}
 	$ar = preg_replace( '#[^0-9/ ]#', '', (string) ( $settings->tn_img_ratio ?? '16 / 10' ) ); if ( '' === trim( $ar ) ) { $ar = '16 / 10'; }
 	echo "$node .ds-tourn-img{aspect-ratio:$ar;}\n";
 	$ls = $u( $settings->tn_logo_size ?? '', 96 );


### PR DESCRIPTION
Second display mode for the Event Card tournament style, matching the mylacrossetournaments.com home listing: **Tournament Cards → Display → List** renders each event as a full-width row — accent **date tile** (month + day), **logo thumbnail**, gender **eyebrow**, uppercase title, location + date meta, **outlined division chips**, and a theme-synced **Register →** button. The filter bar works identically in both displays (rows share the card hooks + data attributes); the dynamic CSS forces a single column for List. Mobile rows wrap gracefully.
