### PR TITLE
feat: real Gender taxonomy + discovered Tabs Source options (1.9.35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.35] - 2026-07-17
+### Changed
+- **Tournament filter tabs now come from real, partner-editable structures -- nothing invented.** A proper **Gender taxonomy** (`event_gender`) registers on the events CPT wherever it exists: partners add/rename genders under **Events -> Gender** and tick them on each event's edit screen -- no PHP, no field-group editing. The Tabs Source picker is now discovered live: every taxonomy with an admin UI (labelled with its post types) plus every ACF choice field (select/checkbox/radio/button group) on the site. Default tab source is the Gender taxonomy.
+
 ## [1.9.34] - 2026-07-17
 ### Changed
 - **Tournament filter bar is now fully developer-configurable (nothing hard-coded).** New "Filter Bar (Event Card)" section on the Query tab: **Tabs Source** picks what drives the tab pills -- any public taxonomy, the event_gender field, or none (the same values feed the row eyebrow and card chips); **State Dropdown** (from event_state / the ", XX" address tail) can be shown or hidden; **Search Box** and **Event Count** each get their own show/hide. Defaults keep the previous behaviour, so existing modules render unchanged.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.34
+ * Version:           1.9.35
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.34' );
+define( 'DS_TOOLKIT_VERSION', '1.9.35' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-post-loop.php
+++ b/features/class-ds-post-loop.php
@@ -18,6 +18,39 @@ class DS_Post_Loop {
 
 	public function init() {
 		add_action( 'init', array( $this, 'register_module' ), 20 );
+		// After the blueprint's CPTs have registered (they use the default init
+		// priority), attach the Gender taxonomy to the events post type.
+		add_action( 'init', array( $this, 'register_event_gender_taxonomy' ), 19 );
+	}
+
+	/**
+	 * A REAL, partner-editable Gender taxonomy for the events CPT. Terms are
+	 * managed in the normal WP UI (Events → Gender) and ticked on each event's
+	 * edit screen — no code, no field-group editing. The Tournament Event Card
+	 * filter tabs (and any future facet) can then point at it like any other
+	 * taxonomy. Only registers where an `event` post type exists, and never
+	 * fights a taxonomy another plugin already registered under this name.
+	 */
+	public function register_event_gender_taxonomy() {
+		if ( ! post_type_exists( 'event' ) || taxonomy_exists( 'event_gender' ) ) {
+			return;
+		}
+		register_taxonomy( 'event_gender', array( 'event' ), array(
+			'labels'            => array(
+				'name'          => __( 'Genders', 'ds-toolkit' ),
+				'singular_name' => __( 'Gender', 'ds-toolkit' ),
+				'menu_name'     => __( 'Gender', 'ds-toolkit' ),
+				'add_new_item'  => __( 'Add New Gender', 'ds-toolkit' ),
+			),
+			'public'            => true,
+			'publicly_queryable' => false,
+			'show_ui'           => true,
+			'show_in_menu'      => true,
+			'show_in_rest'      => true,
+			'show_admin_column' => true,
+			'hierarchical'      => true, // checkbox metabox on the event edit screen
+			'rewrite'           => false,
+		) );
 	}
 
 	public function register_module() {

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -699,15 +699,30 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 	}
 
 	/** Tournament Cards — upcoming events (by the event_date ACF field), image with an overlapping details card. */
-	/** Options for the Event Card filter Tabs Source: none, the event_gender field, or any public taxonomy. */
+	/**
+	 * Options for the Event Card filter Tabs Source. Nothing is invented here:
+	 * the list is discovered live from (a) every taxonomy with an admin UI —
+	 * whose TERMS partners edit in the normal WP screens — and (b) every ACF
+	 * choice field (select / checkbox / radio / button group) registered on the
+	 * site. Labelled with the post types they belong to so devs pick the right
+	 * facet for the queried post type.
+	 */
 	public static function tourn_tab_options() {
-		$opts = array(
-			''                  => __( 'None (hide tabs)', 'ds-toolkit' ),
-			'meta:event_gender' => __( 'Gender field (event_gender)', 'ds-toolkit' ),
-		);
-		foreach ( get_taxonomies( array( 'public' => true ), 'objects' ) as $tax ) {
-			if ( 'post_format' === $tax->name ) { continue; }
-			$opts[ 'tax:' . $tax->name ] = sprintf( __( 'Taxonomy: %s (%s)', 'ds-toolkit' ), $tax->label, $tax->name );
+		$opts = array( '' => __( 'None (hide tabs)', 'ds-toolkit' ) );
+		$skip = array( 'post_format', 'nav_menu', 'link_category', 'wp_theme', 'wp_template_part_area', 'fl-builder-template-category', 'fl-builder-template-type' );
+		foreach ( get_taxonomies( array( 'show_ui' => true ), 'objects' ) as $tax ) {
+			if ( in_array( $tax->name, $skip, true ) ) { continue; }
+			$types = implode( ', ', (array) $tax->object_type );
+			$opts[ 'tax:' . $tax->name ] = sprintf( __( 'Taxonomy: %1$s — on: %2$s', 'ds-toolkit' ), $tax->label, $types );
+		}
+		if ( function_exists( 'acf_get_field_groups' ) && function_exists( 'acf_get_fields' ) ) {
+			foreach ( acf_get_field_groups() as $group ) {
+				foreach ( (array) acf_get_fields( $group ) as $field ) {
+					if ( in_array( $field['type'], array( 'select', 'checkbox', 'radio', 'button_group' ), true ) ) {
+						$opts[ 'meta:' . $field['name'] ] = sprintf( __( 'ACF field: %1$s (%2$s)', 'ds-toolkit' ), $field['label'], $group['title'] );
+					}
+				}
+			}
 		}
 		return $opts;
 	}
@@ -812,7 +827,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 
 		// Enriched rows (the Event Card style + filter bar read tabs/division/state).
 		// The tab facet is developer-chosen: a taxonomy, a meta field, or none.
-		$tabsrc = (string) ( $s->tn_filter_tabs ?? 'meta:event_gender' );
+		$tabsrc = (string) ( $s->tn_filter_tabs ?? 'tax:event_gender' );
 		$rows = array();
 		foreach ( $items as $it ) {
 			$p = $it['p']; $pid = $p->ID;
@@ -1241,9 +1256,9 @@ $ds_pl_form = array(
 					'tn_filter_tabs'   => array(
 						'type'    => 'select',
 						'label'   => __( 'Tabs Source', 'ds-toolkit' ),
-						'default' => 'meta:event_gender',
+						'default' => 'tax:event_gender',
 						'options' => DS_Post_Loop_Module::tourn_tab_options(),
-						'help'    => __( 'What drives the tab pills (All / …): any public taxonomy of the queried post type, the event_gender field, or none. The same values feed the row eyebrow and the card chips.', 'ds-toolkit' ),
+						'help'    => __( 'What drives the tab pills (All / …): pick a taxonomy or an ACF choice field of the queried post type. Taxonomy terms are partner-editable in the normal WP admin (e.g. Events → Gender); the same values feed the row eyebrow and the card chips.', 'ds-toolkit' ),
 					),
 					'tn_filter_state'  => array(
 						'type'    => 'select',


### PR DESCRIPTION
Review feedback: the gender facet must not be an invented/hidden structure — partners need to edit the value list in the UI ("what if there are more genders?").

- **Real `event_gender` taxonomy** registered on the events CPT (wherever it exists; never fights an existing registration): terms are managed under **Events → Gender** like categories, ticked per event via the standard checkbox metabox, with an admin column and REST support. Adding a gender is a normal term add — zero code.
- **Tabs Source picker is discovered, not hardcoded**: every taxonomy with an admin UI (labelled with the post types it's on) + every ACF choice field (select/checkbox/radio/button group, labelled with its field group). Devs pick the facet; partners edit its values in the UI.
- Default tab source is now the Gender taxonomy.
