### PR TITLE
fix: no plugin-registered taxonomy — Tabs Source lists existing site structures only (1.9.36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.36] - 2026-07-17
+### Changed
+- **The plugin registers NO taxonomy for the tournament filter.** v1.9.35's code-registered `event_gender` taxonomy is removed: a code-registered taxonomy is invisible in the site's taxonomy tooling and unmanageable by devs. The filter's Tabs Source is purely a select of what already exists on the site (taxonomies with an admin UI + ACF choice fields), defaulting to **None**. Sites that want a Gender facet create the taxonomy with their own tooling (e.g. ACF -> Taxonomies) -- the DSLP6 blueprint now ships one exactly that way.
+
 ## [1.9.35] - 2026-07-17
 ### Changed
 - **Tournament filter tabs now come from real, partner-editable structures -- nothing invented.** A proper **Gender taxonomy** (`event_gender`) registers on the events CPT wherever it exists: partners add/rename genders under **Events -> Gender** and tick them on each event's edit screen -- no PHP, no field-group editing. The Tabs Source picker is now discovered live: every taxonomy with an admin UI (labelled with its post types) plus every ACF choice field (select/checkbox/radio/button group) on the site. Default tab source is the Gender taxonomy.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.35
+ * Version:           1.9.36
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.35' );
+define( 'DS_TOOLKIT_VERSION', '1.9.36' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-post-loop.php
+++ b/features/class-ds-post-loop.php
@@ -18,39 +18,6 @@ class DS_Post_Loop {
 
 	public function init() {
 		add_action( 'init', array( $this, 'register_module' ), 20 );
-		// After the blueprint's CPTs have registered (they use the default init
-		// priority), attach the Gender taxonomy to the events post type.
-		add_action( 'init', array( $this, 'register_event_gender_taxonomy' ), 19 );
-	}
-
-	/**
-	 * A REAL, partner-editable Gender taxonomy for the events CPT. Terms are
-	 * managed in the normal WP UI (Events → Gender) and ticked on each event's
-	 * edit screen — no code, no field-group editing. The Tournament Event Card
-	 * filter tabs (and any future facet) can then point at it like any other
-	 * taxonomy. Only registers where an `event` post type exists, and never
-	 * fights a taxonomy another plugin already registered under this name.
-	 */
-	public function register_event_gender_taxonomy() {
-		if ( ! post_type_exists( 'event' ) || taxonomy_exists( 'event_gender' ) ) {
-			return;
-		}
-		register_taxonomy( 'event_gender', array( 'event' ), array(
-			'labels'            => array(
-				'name'          => __( 'Genders', 'ds-toolkit' ),
-				'singular_name' => __( 'Gender', 'ds-toolkit' ),
-				'menu_name'     => __( 'Gender', 'ds-toolkit' ),
-				'add_new_item'  => __( 'Add New Gender', 'ds-toolkit' ),
-			),
-			'public'            => true,
-			'publicly_queryable' => false,
-			'show_ui'           => true,
-			'show_in_menu'      => true,
-			'show_in_rest'      => true,
-			'show_admin_column' => true,
-			'hierarchical'      => true, // checkbox metabox on the event edit screen
-			'rewrite'           => false,
-		) );
 	}
 
 	public function register_module() {

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -827,7 +827,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 
 		// Enriched rows (the Event Card style + filter bar read tabs/division/state).
 		// The tab facet is developer-chosen: a taxonomy, a meta field, or none.
-		$tabsrc = (string) ( $s->tn_filter_tabs ?? 'tax:event_gender' );
+		$tabsrc = (string) ( $s->tn_filter_tabs ?? '' );
 		$rows = array();
 		foreach ( $items as $it ) {
 			$p = $it['p']; $pid = $p->ID;
@@ -1256,9 +1256,9 @@ $ds_pl_form = array(
 					'tn_filter_tabs'   => array(
 						'type'    => 'select',
 						'label'   => __( 'Tabs Source', 'ds-toolkit' ),
-						'default' => 'tax:event_gender',
+						'default' => '',
 						'options' => DS_Post_Loop_Module::tourn_tab_options(),
-						'help'    => __( 'What drives the tab pills (All / …): pick a taxonomy or an ACF choice field of the queried post type. Taxonomy terms are partner-editable in the normal WP admin (e.g. Events → Gender); the same values feed the row eyebrow and the card chips.', 'ds-toolkit' ),
+						'help'    => __( 'What drives the tab pills (All / …): pick any taxonomy or ACF choice field that exists on THIS site for the queried post type. The plugin registers nothing itself — if the site has no suitable taxonomy, create one (e.g. via ACF → Taxonomies) or leave tabs off. The chosen values also feed the row eyebrow and the card chips.', 'ds-toolkit' ),
 					),
 					'tn_filter_state'  => array(
 						'type'    => 'select',


### PR DESCRIPTION
Review feedback: a taxonomy registered in plugin code is still hard-coded — it doesn't appear in the site's taxonomy tooling (ACF → Taxonomies / CPT UI), so devs can't see or edit its definition, and old sites get a structure they never created.

- Removed the `event_gender` `register_taxonomy()` call added in v1.9.35.
- **Tabs Source** now defaults to **None** and only ever lists what actually exists on the site: taxonomies with an admin UI (labelled with their post types) and ACF choice fields (labelled with their field group).
- Sites wanting a Gender facet create the taxonomy with their own tooling; the DSLP6 blueprint now defines **Genders** via ACF → Taxonomies (fully visible/editable there, terms managed under Events → Genders), and the sample modules point at it.
