### PR TITLE
feat: drill-down mobile drawer for the Menu module (1.9.37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.37] - 2026-07-17
+### Added
+- **Menu: drill-down mobile drawer -- the new default mobile style.** New Style -> Responsive -> **Mobile Menu Style**: "Drill-down drawer" (default) renders the mobile menu Stripe-style -- one level per sliding panel, a back row showing the parent's label, and an "Overview" link row for parents with their own URL. Panels are built live from the rendered WP menu, so content stays fully editable in Appearance -> Menus (any depth; mega panels flatten into drill levels; the CTA item keeps its button styling). All existing Mobile Overlay settings drive the drawer (background, text, hover/accent, dividers, typography, CTA colours). Desktop menus are unchanged; "Overlay with accordions (legacy)" remains selectable per module. NOTE: this default deliberately applies fleet-wide -- existing mobile menus switch to drill-down on update; pick Overlay on any module that should keep the old behaviour.
+
 ## [1.9.36] - 2026-07-17
 ### Changed
 - **The plugin registers NO taxonomy for the tournament filter.** v1.9.35's code-registered `event_gender` taxonomy is removed: a code-registered taxonomy is invisible in the site's taxonomy tooling and unmanageable by devs. The filter's Tabs Source is purely a select of what already exists on the site (taxonomies with an admin UI + ACF choice fields), defaulting to **None**. Sites that want a Gender facet create the taxonomy with their own tooling (e.g. ACF -> Taxonomies) -- the DSLP6 blueprint now ships one exactly that way.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.36
+ * Version:           1.9.37
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.36' );
+define( 'DS_TOOLKIT_VERSION', '1.9.37' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/css/frontend.css
+++ b/modules/ds-menu/css/frontend.css
@@ -79,3 +79,25 @@
 
 /* Lock page scroll while the mobile overlay is open */
 body.ds-menu-locked { overflow: hidden; }
+
+/* ---- Drill-down mobile drawer (Mobile Menu Style = drill) ----
+   Colours arrive as custom props (--ds-drill-*) emitted node-scoped from the
+   module's existing Mobile Overlay settings; sensible dark defaults here. */
+.ds-drill{position:fixed;inset:0;z-index:100000;background:var(--ds-drill-bg,#0b0b0b);opacity:0;visibility:hidden;transition:opacity .25s ease;overflow:hidden;}
+.ds-menu-wrap--drill.ds-menu-open .ds-drill{opacity:1;visibility:visible;}
+.ds-drill-panel{position:absolute;inset:0;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:72px 0 40px;background:var(--ds-drill-bg,#0b0b0b);transform:translateX(100%);transition:transform .3s ease;}
+.ds-drill-row,.ds-drill-back,.ds-drill-overview{display:flex;align-items:center;justify-content:space-between;gap:12px;width:100%;text-align:left;background:none;border:0;border-bottom:1px solid var(--ds-drill-hair,rgba(255,255,255,.12));padding:17px 22px;margin:0;font-family:inherit;font-size:16px;line-height:1.3;color:var(--ds-drill-text,#fff);cursor:pointer;text-decoration:none;box-sizing:border-box;-webkit-appearance:none;appearance:none;border-radius:0;}
+.ds-drill-row:hover{background:var(--ds-drill-row-bg,rgba(255,255,255,.05));}
+.ds-drill-panel.is-root .ds-drill-label{text-transform:uppercase;letter-spacing:.06em;font-weight:600;}
+.ds-drill-chev{flex:0 0 auto;line-height:0;}
+.ds-drill-chev svg,.ds-drill-back svg{width:20px;height:20px;stroke:var(--ds-drill-accent,var(--fl-global-accent));stroke-width:2;fill:none;stroke-linecap:round;stroke-linejoin:round;display:block;}
+.ds-drill-back{justify-content:flex-start;gap:8px;color:var(--ds-drill-accent,var(--fl-global-accent));font-size:13px;letter-spacing:.08em;text-transform:uppercase;font-weight:700;}
+.ds-drill-back svg{width:18px;height:18px;}
+.ds-drill-overview{background:var(--ds-drill-row-bg,rgba(255,255,255,.05));}
+.ds-drill-overview small{color:var(--ds-drill-sub,#9a9a9a);font-size:12px;}
+.ds-drill-row:focus-visible,.ds-drill-back:focus-visible,.ds-drill-overview:focus-visible{outline:2px solid var(--ds-drill-accent,var(--fl-global-accent));outline-offset:-2px;}
+.ds-drill-cta{background:var(--ds-drill-cta-bg,var(--fl-global-button));color:var(--ds-drill-cta-text,var(--fl-global-white));margin:14px 22px 0;width:auto;border-radius:8px;justify-content:center;font-weight:700;text-transform:uppercase;letter-spacing:.06em;border-bottom:0;}
+.ds-drill-cta:hover{background:var(--ds-drill-cta-bg-hover,var(--fl-global-accent));}
+@media (prefers-reduced-motion:reduce){
+  .ds-drill,.ds-drill-panel{transition:none;}
+}

--- a/modules/ds-menu/ds-menu.php
+++ b/modules/ds-menu/ds-menu.php
@@ -108,7 +108,8 @@ class DS_Menu_Module extends FLBuilderModule {
 		}
 		$this->mega_use_picker = ! empty( $this->mega_map );
 
-		echo '<nav class="ds-menu-wrap" aria-label="' . esc_attr__( 'Primary', 'ds-toolkit' ) . '">';
+		$mstyle = ( ( $s->mobile_menu_style ?? 'drill' ) === 'overlay' ) ? 'overlay' : 'drill';
+		echo '<nav class="ds-menu-wrap' . ( 'drill' === $mstyle ? ' ds-menu-wrap--drill' : '' ) . '" aria-label="' . esc_attr__( 'Primary', 'ds-toolkit' ) . '">';
 
 		// Hamburger toggle (animates into an X via CSS when the overlay opens).
 		echo '<button type="button" class="ds-menu-toggle" aria-expanded="false" aria-label="' . esc_attr__( 'Toggle menu', 'ds-toolkit' ) . '">';
@@ -363,12 +364,22 @@ FLBuilder::register_module( 'DS_Menu_Module', array(
 			'resp'   => array(
 				'title'  => __( 'Responsive', 'ds-toolkit' ),
 				'fields' => array(
+					'mobile_menu_style' => array(
+						'type'    => 'select',
+						'label'   => __( 'Mobile Menu Style', 'ds-toolkit' ),
+						'default' => 'drill',
+						'options' => array(
+							'drill'   => __( 'Drill-down drawer (one level per panel)', 'ds-toolkit' ),
+							'overlay' => __( 'Overlay with accordions (legacy)', 'ds-toolkit' ),
+						),
+						'help'    => __( 'Drill-down: submenus slide in one level at a time with a back control (Stripe-style); parents with their own URL get an "Overview" row. Desktop is unaffected. Menu content stays editable in Appearance → Menus.', 'ds-toolkit' ),
+					),
 					'breakpoint'   => array(
 						'type'        => 'unit',
 						'label'       => __( 'Mobile Breakpoint', 'ds-toolkit' ),
 						'default'     => '1000',
 						'description' => 'px',
-						'help'        => __( 'At or below this width the menu collapses to a full-screen hamburger overlay.', 'ds-toolkit' ),
+						'help'        => __( 'At or below this width the menu collapses to the hamburger menu.', 'ds-toolkit' ),
 					),
 					'toggle_label' => array(
 						'type'    => 'text',

--- a/modules/ds-menu/includes/frontend.css.php
+++ b/modules/ds-menu/includes/frontend.css.php
@@ -369,6 +369,30 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 		$md_border = '0';
 	}
 	?>
+	<?php if ( ( $settings->mobile_menu_style ?? 'drill' ) !== 'overlay' ) : ?>
+	<?php
+	/* Drill-down drawer (default mobile style). The legacy overlay panel is hidden;
+	   the drawer inherits ALL the module's Mobile Overlay settings as custom props,
+	   so nothing is hard-coded — colours, dividers, and the CTA follow the fields. */
+	$dr_mbg    = $col( $settings->button_mobile_bg ?? '' ) ?: $otext;
+	$dr_mtext  = $col( $settings->button_mobile_text ?? '' ) ?: ( $obg ?: 'var(--fl-global-dark-background)' );
+	$dr_mbgh   = $col( $settings->button_mobile_bg_hover ?? '' ) ?: $dr_mbg;
+	$dr_mtexth = $col( $settings->button_mobile_text_hover ?? '' ) ?: $dr_mtext;
+	?>
+	<?php echo $open; ?> .ds-menu { display: none !important; }
+	<?php echo $node; ?> .ds-drill {
+		--ds-drill-bg: <?php echo $obg ?: 'var(--fl-global-dark-background)'; ?>;
+		--ds-drill-text: <?php echo $otext; ?>;
+		--ds-drill-sub: <?php echo $osub; ?>;
+		--ds-drill-accent: <?php echo $otexthov ?: 'var(--fl-global-accent)'; ?>;
+		--ds-drill-cta-bg: <?php echo $dr_mbg; ?>;
+		--ds-drill-cta-text: <?php echo $dr_mtext; ?>;
+		--ds-drill-cta-bg-hover: <?php echo $dr_mbgh; ?>;
+		<?php if ( $oitembg ) : ?>--ds-drill-row-bg: <?php echo $oitembg; ?>;<?php endif; ?>
+	}
+	<?php echo $node; ?> .ds-drill-cta:hover { color: <?php echo $dr_mtexth; ?>; }
+	<?php echo $node; ?> .ds-drill-row, <?php echo $node; ?> .ds-drill-back, <?php echo $node; ?> .ds-drill-overview { border-bottom: <?php echo $md_border; ?>; }
+	<?php endif; ?>
 	/* Overlay items: stacked, large, full width */
 	<?php echo $open; ?> .ds-menu-item { position: static; width: 100%; border-bottom: <?php echo $md_border; ?>; }
 	<?php echo $open; ?> .ds-menu-item > a { padding: 14px 4px; color: <?php echo $otext; ?>; flex: 1; }
@@ -436,18 +460,20 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
  * so it overrides the 20px default set above.
  */
 if ( class_exists( 'FLBuilderCSS' ) ) {
+	// Top-level labels: overlay rows AND the drill drawer's root-panel rows.
 	FLBuilderCSS::typography_field_rule( array(
 		'settings'     => $settings,
 		'setting_name' => 'mobile_typography',
-		'selector'     => "$open .ds-menu > .ds-menu-item > a",
+		'selector'     => "$open .ds-menu > .ds-menu-item > a, $node .ds-drill-panel.is-root .ds-drill-row .ds-drill-label",
 	) );
 	// Mobile submenu / mega labels. Overlay-scoped selector (specificity beats the
 	// desktop dropdown_typography), so it wins inside the overlay; if left empty the
-	// desktop "Submenu Label Typography" carries through as the fallback.
+	// desktop "Submenu Label Typography" carries through as the fallback. Also
+	// covers the drill drawer's deeper-panel rows.
 	FLBuilderCSS::typography_field_rule( array(
 		'settings'     => $settings,
 		'setting_name' => 'mobile_subtypography',
-		'selector'     => "$open .ds-submenu a, $open .ds-mega a",
+		'selector'     => "$open .ds-submenu a, $open .ds-mega a, $node .ds-drill-panel:not(.is-root) .ds-drill-row .ds-drill-label",
 	) );
 }
 ?>

--- a/modules/ds-menu/js/frontend.js
+++ b/modules/ds-menu/js/frontend.js
@@ -35,17 +35,170 @@
 		slide( panelOf( li ), willOpen );
 	}
 
+	/* ---------------- Drill-down drawer (Mobile Menu Style = drill) ----------------
+	   Panels are built at open time from the RENDERED WP-menu markup, so the drawer
+	   always mirrors Appearance → Menus (nothing duplicated server-side). One level
+	   per panel; drilling slides the next level in from the right; back walks out;
+	   parents with a real URL get an "Overview" link row (Stripe-style). */
+	var CHEV_R = '<svg viewBox="0 0 24 24" aria-hidden="true"><polyline points="9 6 15 12 9 18"/></svg>';
+	var CHEV_L = '<svg viewBox="0 0 24 24" aria-hidden="true"><polyline points="15 6 9 12 15 18"/></svg>';
+
+	// Data tree from the rendered menu. Mega panels flatten into drill levels:
+	// each mega column heading becomes a drillable row over its column links.
+	function drillTree( wrap ) {
+		function walkList( ul ) {
+			var out = [];
+			if ( ! ul ) { return out; }
+			for ( var i = 0; i < ul.children.length; i++ ) {
+				var li = ul.children[ i ];
+				if ( ! li.classList || ! li.classList.contains( 'ds-menu-item' ) ) { continue; }
+				var a = li.querySelector( ':scope > a' );
+				if ( ! a ) { continue; }
+				var labelEl = a.querySelector( 'span' );
+				var node = {
+					label: ( labelEl ? labelEl.textContent : a.textContent ).trim(),
+					url: a.getAttribute( 'href' ) || '',
+					target: a.getAttribute( 'target' ) || '',
+					isButton: li.classList.contains( 'is-button' ),
+					children: []
+				};
+				var mega = null;
+				for ( var j = 0; j < li.children.length; j++ ) {
+					if ( li.children[ j ].classList && li.children[ j ].classList.contains( 'ds-mega' ) ) { mega = li.children[ j ]; break; }
+				}
+				if ( mega ) {
+					mega.querySelectorAll( '.ds-mega-col' ).forEach( function ( col ) {
+						var head  = col.querySelector( '.ds-mega-head a' ) || col.querySelector( '.ds-mega-head' );
+						var colNode = {
+							label: head ? head.textContent.trim() : '',
+							url: ( head && head.getAttribute ) ? ( head.getAttribute( 'href' ) || '' ) : '',
+							target: '', isButton: false,
+							children: walkList( col.querySelector( '.ds-submenu' ) )
+						};
+						if ( colNode.label ) { node.children.push( colNode ); }
+					} );
+				} else {
+					var sub = null;
+					for ( var k = 0; k < li.children.length; k++ ) {
+						if ( li.children[ k ].classList && li.children[ k ].classList.contains( 'ds-submenu' ) ) { sub = li.children[ k ]; break; }
+					}
+					node.children = walkList( sub );
+				}
+				out.push( node );
+			}
+			return out;
+		}
+		return walkList( wrap.querySelector( '.ds-menu' ) );
+	}
+
+	function makeDrill( wrap ) {
+		var drawer = document.createElement( 'div' );
+		drawer.className = 'ds-drill';
+		wrap.appendChild( drawer );
+		var stack = [];
+
+		function row( node, isRoot ) {
+			var hasKids = node.children.length > 0;
+			var el = document.createElement( hasKids ? 'button' : 'a' );
+			el.className = 'ds-drill-row' + ( node.isButton ? ' ds-drill-cta' : '' );
+			if ( hasKids ) { el.type = 'button'; } else {
+				el.href = node.url || '#';
+				if ( node.target ) { el.target = node.target; el.rel = 'noopener'; }
+			}
+			var label = document.createElement( 'span' );
+			label.className = 'ds-drill-label';
+			label.textContent = node.label;
+			el.appendChild( label );
+			if ( hasKids ) {
+				var chev = document.createElement( 'span' );
+				chev.className = 'ds-drill-chev';
+				chev.setAttribute( 'aria-hidden', 'true' );
+				chev.innerHTML = CHEV_R;
+				el.appendChild( chev );
+				el.addEventListener( 'click', function () { push( node ); } );
+			}
+			return el;
+		}
+
+		function buildPanel( node ) {
+			var p = document.createElement( 'div' );
+			p.className = 'ds-drill-panel' + ( node.root ? ' is-root' : '' );
+			if ( ! node.root ) {
+				var back = document.createElement( 'button' );
+				back.type = 'button';
+				back.className = 'ds-drill-back';
+				back.innerHTML = CHEV_L;
+				var bl = document.createElement( 'span' );
+				bl.textContent = node.label;
+				back.appendChild( bl );
+				back.addEventListener( 'click', pop );
+				p.appendChild( back );
+				if ( node.url && '#' !== node.url ) {
+					var ov = document.createElement( 'a' );
+					ov.className = 'ds-drill-overview';
+					ov.href = node.url;
+					var os = document.createElement( 'span' );
+					os.textContent = 'Overview';
+					var oh = document.createElement( 'small' );
+					oh.textContent = node.label;
+					ov.appendChild( os );
+					ov.appendChild( oh );
+					p.appendChild( ov );
+				}
+			}
+			node.children.forEach( function ( c ) { p.appendChild( row( c, !! node.root ) ); } );
+			return p;
+		}
+
+		function push( node ) {
+			var prev = stack[ stack.length - 1 ];
+			if ( prev ) { prev.style.transform = 'translateX(-100%)'; }
+			var p = buildPanel( node );
+			drawer.appendChild( p );
+			stack.push( p );
+			requestAnimationFrame( function () { p.style.transform = 'translateX(0)'; } );
+		}
+
+		function pop() {
+			if ( stack.length < 2 ) { return; }
+			var top = stack.pop();
+			top.style.transform = 'translateX(100%)';
+			setTimeout( function () { top.remove(); }, 320 );
+			stack[ stack.length - 1 ].style.transform = 'translateX(0)';
+		}
+
+		return {
+			openRoot: function () {
+				drawer.innerHTML = '';
+				stack = [];
+				push( { root: true, label: '', url: '', isButton: false, children: drillTree( wrap ) } );
+			},
+			clear: function () { drawer.innerHTML = ''; stack = []; }
+		};
+	}
+
 	function init( wrap ) {
 		if ( wrap.dsMenuInit ) { return; }
 		wrap.dsMenuInit = true;
 
-		var toggle = wrap.querySelector( '.ds-menu-toggle' );
-		var close  = wrap.querySelector( '.ds-menu-close' );
+		var toggle  = wrap.querySelector( '.ds-menu-toggle' );
+		var close   = wrap.querySelector( '.ds-menu-close' );
+		var isDrill = wrap.classList.contains( 'ds-menu-wrap--drill' );
+		var drill   = null;
 
 		function open( state ) {
 			wrap.classList.toggle( 'ds-menu-open', state );
 			if ( toggle ) { toggle.setAttribute( 'aria-expanded', state ? 'true' : 'false' ); }
 			document.body.classList.toggle( 'ds-menu-locked', state );
+			if ( isDrill ) {
+				if ( state ) {
+					if ( ! drill ) { drill = makeDrill( wrap ); }
+					drill.openRoot();
+				} else if ( drill ) {
+					setTimeout( drill.clear, 280 ); // after the fade-out
+				}
+				return;
+			}
 			if ( ! state ) {
 				// Reset every expanded accordion + clear inline heights so it reopens clean.
 				wrap.querySelectorAll( '.ds-menu-item.ds-open' ).forEach( function ( li ) {
@@ -60,27 +213,29 @@
 		if ( toggle ) { toggle.addEventListener( 'click', function () { open( ! wrap.classList.contains( 'ds-menu-open' ) ); } ); }
 		if ( close ) { close.addEventListener( 'click', function () { open( false ); } ); }
 
-		// The +/- icon toggles its submenu.
-		wrap.querySelectorAll( '.ds-sub-toggle' ).forEach( function ( btn ) {
-			btn.addEventListener( 'click', function ( e ) {
-				e.preventDefault();
-				var li = btn.closest( '.ds-menu-item' );
-				if ( li ) { toggleItem( li ); }
+		if ( ! isDrill ) {
+			// The +/- icon toggles its submenu.
+			wrap.querySelectorAll( '.ds-sub-toggle' ).forEach( function ( btn ) {
+				btn.addEventListener( 'click', function ( e ) {
+					e.preventDefault();
+					var li = btn.closest( '.ds-menu-item' );
+					if ( li ) { toggleItem( li ); }
+				} );
 			} );
-		} );
 
-		// In the overlay, tapping ANYWHERE on a parent row (the whole line, not just
-		// the icon) opens/closes its submenu instead of navigating. Leaf links and the
-		// desktop bar are untouched — navigation still works when the overlay is closed.
-		wrap.querySelectorAll( '.ds-menu-item.has-children > a' ).forEach( function ( a ) {
-			a.addEventListener( 'click', function ( e ) {
-				if ( ! wrap.classList.contains( 'ds-menu-open' ) ) { return; }
-				var li = a.closest( '.ds-menu-item' );
-				if ( ! li ) { return; }
-				e.preventDefault();
-				toggleItem( li );
+			// In the overlay, tapping ANYWHERE on a parent row (the whole line, not just
+			// the icon) opens/closes its submenu instead of navigating. Leaf links and the
+			// desktop bar are untouched — navigation still works when the overlay is closed.
+			wrap.querySelectorAll( '.ds-menu-item.has-children > a' ).forEach( function ( a ) {
+				a.addEventListener( 'click', function ( e ) {
+					if ( ! wrap.classList.contains( 'ds-menu-open' ) ) { return; }
+					var li = a.closest( '.ds-menu-item' );
+					if ( ! li ) { return; }
+					e.preventDefault();
+					toggleItem( li );
+				} );
 			} );
-		} );
+		}
 
 		document.addEventListener( 'keydown', function ( e ) {
 			if ( 'Escape' === e.key && wrap.classList.contains( 'ds-menu-open' ) ) { open( false ); }


### PR DESCRIPTION
Integrates the STA mobile-menu prototype as the Menu module's new default mobile style.

**Mobile Menu Style** (Style → Responsive): **Drill-down drawer** (default) or **Overlay with accordions (legacy)**. Mobile only — desktop menus are untouched.

- One level per panel; panels slide horizontally; a back row shows the parent's label; parents with a real URL get an **Overview** link row (Stripe pattern).
- Panels are built at open time from the rendered WP menu markup — content stays 100% editable in Appearance → Menus; unlimited depth; mega panels flatten into drill levels (column heading → column links); the CTA last-item keeps its button styling and mobile colours.
- Styling comes entirely from the existing Mobile Overlay fields (background, text, hover→accent, item bg, dividers, mobile typography, CTA colours) via node-scoped custom props — nothing hard-coded.
- Escape/X close, body scroll lock, aria-expanded, focus-visible rings, prefers-reduced-motion honoured.
- ⚠️ Deliberate fleet default change (per review direction): existing mobile menus switch to drill-down on update; any module can select Overlay to keep the legacy behaviour.
