### PR TITLE
fix: drill drawer colour hardening (1.9.38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.38] - 2026-07-17
+### Fixed
+- **Drill drawer colours are now deterministic.** Parent rows are <button>s and leaf rows are <a>s, so BB's global button styles and theme link colours could repaint them per site (verified live). All drawer colours/backgrounds now carry !important at .fl-builder-content scope -- the same hardening as the hamburger toggle -- and the overlay's persistent top-level item background (overlay_item_bg) is mirrored onto root drill rows.
+
 ## [1.9.37] - 2026-07-17
 ### Added
 - **Menu: drill-down mobile drawer -- the new default mobile style.** New Style -> Responsive -> **Mobile Menu Style**: "Drill-down drawer" (default) renders the mobile menu Stripe-style -- one level per sliding panel, a back row showing the parent's label, and an "Overview" link row for parents with their own URL. Panels are built live from the rendered WP menu, so content stays fully editable in Appearance -> Menus (any depth; mega panels flatten into drill levels; the CTA item keeps its button styling). All existing Mobile Overlay settings drive the drawer (background, text, hover/accent, dividers, typography, CTA colours). Desktop menus are unchanged; "Overlay with accordions (legacy)" remains selectable per module. NOTE: this default deliberately applies fleet-wide -- existing mobile menus switch to drill-down on update; pick Overlay on any module that should keep the old behaviour.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.37
+ * Version:           1.9.38
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.37' );
+define( 'DS_TOOLKIT_VERSION', '1.9.38' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/css/frontend.css
+++ b/modules/ds-menu/css/frontend.css
@@ -82,22 +82,27 @@ body.ds-menu-locked { overflow: hidden; }
 
 /* ---- Drill-down mobile drawer (Mobile Menu Style = drill) ----
    Colours arrive as custom props (--ds-drill-*) emitted node-scoped from the
-   module's existing Mobile Overlay settings; sensible dark defaults here. */
+   module's existing Mobile Overlay settings; sensible dark defaults here.
+   Row colours/backgrounds carry !important at .fl-builder-content scope so
+   BB global button styles (`button *`) and theme link colours can never
+   repaint the drawer (same hardening class as the hamburger toggle). */
 .ds-drill{position:fixed;inset:0;z-index:100000;background:var(--ds-drill-bg,#0b0b0b);opacity:0;visibility:hidden;transition:opacity .25s ease;overflow:hidden;}
 .ds-menu-wrap--drill.ds-menu-open .ds-drill{opacity:1;visibility:visible;}
 .ds-drill-panel{position:absolute;inset:0;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:72px 0 40px;background:var(--ds-drill-bg,#0b0b0b);transform:translateX(100%);transition:transform .3s ease;}
-.ds-drill-row,.ds-drill-back,.ds-drill-overview{display:flex;align-items:center;justify-content:space-between;gap:12px;width:100%;text-align:left;background:none;border:0;border-bottom:1px solid var(--ds-drill-hair,rgba(255,255,255,.12));padding:17px 22px;margin:0;font-family:inherit;font-size:16px;line-height:1.3;color:var(--ds-drill-text,#fff);cursor:pointer;text-decoration:none;box-sizing:border-box;-webkit-appearance:none;appearance:none;border-radius:0;}
-.ds-drill-row:hover{background:var(--ds-drill-row-bg,rgba(255,255,255,.05));}
+.fl-builder-content .ds-drill .ds-drill-row,
+.fl-builder-content .ds-drill .ds-drill-back,
+.fl-builder-content .ds-drill .ds-drill-overview{display:flex;align-items:center;justify-content:space-between;gap:12px;width:100%;text-align:left;background:none !important;border:0 !important;border-bottom:1px solid var(--ds-drill-hair,rgba(255,255,255,.12)) !important;padding:17px 22px;margin:0;font-family:inherit;font-size:16px;line-height:1.3;color:var(--ds-drill-text,#fff) !important;cursor:pointer;text-decoration:none;box-sizing:border-box;-webkit-appearance:none;appearance:none;border-radius:0;box-shadow:none !important;clip-path:none !important;-webkit-clip-path:none !important;text-transform:none;letter-spacing:normal;font-weight:400;}
+.fl-builder-content .ds-drill .ds-drill-row:hover{background:var(--ds-drill-row-bg,rgba(255,255,255,.06)) !important;}
 .ds-drill-panel.is-root .ds-drill-label{text-transform:uppercase;letter-spacing:.06em;font-weight:600;}
 .ds-drill-chev{flex:0 0 auto;line-height:0;}
-.ds-drill-chev svg,.ds-drill-back svg{width:20px;height:20px;stroke:var(--ds-drill-accent,var(--fl-global-accent));stroke-width:2;fill:none;stroke-linecap:round;stroke-linejoin:round;display:block;}
-.ds-drill-back{justify-content:flex-start;gap:8px;color:var(--ds-drill-accent,var(--fl-global-accent));font-size:13px;letter-spacing:.08em;text-transform:uppercase;font-weight:700;}
-.ds-drill-back svg{width:18px;height:18px;}
-.ds-drill-overview{background:var(--ds-drill-row-bg,rgba(255,255,255,.05));}
-.ds-drill-overview small{color:var(--ds-drill-sub,#9a9a9a);font-size:12px;}
+.ds-drill-chev svg,.fl-builder-content .ds-drill .ds-drill-back svg{width:20px;height:20px;stroke:var(--ds-drill-accent,var(--fl-global-accent));stroke-width:2;fill:none;stroke-linecap:round;stroke-linejoin:round;display:block;}
+.fl-builder-content .ds-drill .ds-drill-back{justify-content:flex-start;gap:8px;color:var(--ds-drill-accent,var(--fl-global-accent)) !important;font-size:13px;letter-spacing:.08em;text-transform:uppercase;font-weight:700;}
+.fl-builder-content .ds-drill .ds-drill-back svg{width:18px;height:18px;}
+.fl-builder-content .ds-drill .ds-drill-overview{background:var(--ds-drill-row-bg,rgba(255,255,255,.06)) !important;}
+.fl-builder-content .ds-drill .ds-drill-overview small{color:var(--ds-drill-sub,#9a9a9a);font-size:12px;}
 .ds-drill-row:focus-visible,.ds-drill-back:focus-visible,.ds-drill-overview:focus-visible{outline:2px solid var(--ds-drill-accent,var(--fl-global-accent));outline-offset:-2px;}
-.ds-drill-cta{background:var(--ds-drill-cta-bg,var(--fl-global-button));color:var(--ds-drill-cta-text,var(--fl-global-white));margin:14px 22px 0;width:auto;border-radius:8px;justify-content:center;font-weight:700;text-transform:uppercase;letter-spacing:.06em;border-bottom:0;}
-.ds-drill-cta:hover{background:var(--ds-drill-cta-bg-hover,var(--fl-global-accent));}
+.fl-builder-content .ds-drill .ds-drill-cta{background:var(--ds-drill-cta-bg,var(--fl-global-button)) !important;color:var(--ds-drill-cta-text,var(--fl-global-white)) !important;margin:14px 22px 0;width:auto;border-radius:8px;justify-content:center;font-weight:700;text-transform:uppercase;letter-spacing:.06em;border-bottom:0 !important;}
+.fl-builder-content .ds-drill .ds-drill-cta:hover{background:var(--ds-drill-cta-bg-hover,var(--fl-global-accent)) !important;}
 @media (prefers-reduced-motion:reduce){
   .ds-drill,.ds-drill-panel{transition:none;}
 }

--- a/modules/ds-menu/includes/frontend.css.php
+++ b/modules/ds-menu/includes/frontend.css.php
@@ -390,8 +390,12 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 		--ds-drill-cta-bg-hover: <?php echo $dr_mbgh; ?>;
 		<?php if ( $oitembg ) : ?>--ds-drill-row-bg: <?php echo $oitembg; ?>;<?php endif; ?>
 	}
-	<?php echo $node; ?> .ds-drill-cta:hover { color: <?php echo $dr_mtexth; ?>; }
-	<?php echo $node; ?> .ds-drill-row, <?php echo $node; ?> .ds-drill-back, <?php echo $node; ?> .ds-drill-overview { border-bottom: <?php echo $md_border; ?>; }
+	<?php echo $node; ?> .ds-drill-cta:hover { color: <?php echo $dr_mtexth; ?> !important; }
+	<?php echo $node; ?> .ds-drill .ds-drill-row, <?php echo $node; ?> .ds-drill .ds-drill-back, <?php echo $node; ?> .ds-drill .ds-drill-overview { border-bottom: <?php echo $md_border; ?> !important; }
+	<?php if ( $oitembg ) : ?>
+	<?php /* Mirror the overlay's persistent top-level item background. */ ?>
+	<?php echo $node; ?> .ds-drill .ds-drill-panel.is-root .ds-drill-row:not(.ds-drill-cta) { background: <?php echo $oitembg; ?> !important; }
+	<?php endif; ?>
 	<?php endif; ?>
 	/* Overlay items: stacked, large, full width */
 	<?php echo $open; ?> .ds-menu-item { position: static; width: 100%; border-bottom: <?php echo $md_border; ?>; }


### PR DESCRIPTION
Live verification showed BB's global button styles painting drill parent rows (they're `<button>`s) and theme link colours painting leaf rows (`<a>`s) — nondeterministic per site. Drawer colours/backgrounds now carry `!important` at `.fl-builder-content` scope (same hardening as the hamburger toggle, #35), and `overlay_item_bg` mirrors onto root rows like the legacy overlay did.
