### PR TITLE
feat: drawer logo for the drill-down mobile menu (1.9.39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.39] - 2026-07-22
+### Added
+- **Menu: drawer logo (drill style).** The drill-down drawer now shows the site logo in a persistent brand bar -- top right beside the close X by default, top left selectable. Settings under Style -> Mobile Overlay: show/hide, image override (blank = the Partner Logo from Partner Setting, then the site logo), position, and height (live preview).
+
 ## [1.9.38] - 2026-07-17
 ### Fixed
 - **Drill drawer colours are now deterministic.** Parent rows are <button>s and leaf rows are <a>s, so BB's global button styles and theme link colours could repaint them per site (verified live). All drawer colours/backgrounds now carry !important at .fl-builder-content scope -- the same hardening as the hamburger toggle -- and the overlay's persistent top-level item background (overlay_item_bg) is mirrored onto root drill rows.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.38
+ * Version:           1.9.39
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.38' );
+define( 'DS_TOOLKIT_VERSION', '1.9.39' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/css/frontend.css
+++ b/modules/ds-menu/css/frontend.css
@@ -106,3 +106,10 @@ body.ds-menu-locked { overflow: hidden; }
 @media (prefers-reduced-motion:reduce){
   .ds-drill,.ds-drill-panel{transition:none;}
 }
+
+/* Drill drawer brand bar: persistent above the sliding panels. Right-aligned
+   variant pads past the pinned close X so they sit side by side. */
+.ds-drill-brand{position:absolute;top:0;left:0;right:0;height:64px;display:flex;align-items:center;z-index:3;padding:0 22px;pointer-events:none;}
+.ds-drill-brand--right{justify-content:flex-end;padding-right:76px;}
+.ds-drill-brand--left{justify-content:flex-start;}
+.ds-drill-brand img{height:30px;width:auto;max-width:200px;object-fit:contain;display:block;}

--- a/modules/ds-menu/ds-menu.php
+++ b/modules/ds-menu/ds-menu.php
@@ -109,7 +109,27 @@ class DS_Menu_Module extends FLBuilderModule {
 		$this->mega_use_picker = ! empty( $this->mega_map );
 
 		$mstyle = ( ( $s->mobile_menu_style ?? 'drill' ) === 'overlay' ) ? 'overlay' : 'drill';
-		echo '<nav class="ds-menu-wrap' . ( 'drill' === $mstyle ? ' ds-menu-wrap--drill' : '' ) . '" aria-label="' . esc_attr__( 'Primary', 'ds-toolkit' ) . '">';
+
+		// Drawer logo (drill style): module image → Partner Logo option → site logo.
+		$drill_logo = '';
+		if ( 'drill' === $mstyle && ( $s->drill_logo_show ?? 'show' ) === 'show' ) {
+			$drill_logo = ! empty( $s->drill_logo ) ? DS_Card::photo_url( $s->drill_logo, 'medium' ) : '';
+			if ( '' === $drill_logo && function_exists( 'get_field' ) ) {
+				$pl = get_field( 'partner_logo', 'option' );
+				if ( $pl ) { $drill_logo = DS_Card::photo_url( $pl, 'medium' ); }
+			}
+			if ( '' === $drill_logo ) {
+				$cl = (int) get_theme_mod( 'custom_logo' );
+				if ( $cl ) { $drill_logo = (string) wp_get_attachment_image_url( $cl, 'medium' ); }
+			}
+		}
+		$drill_attrs = '';
+		if ( '' !== $drill_logo ) {
+			$drill_attrs  = ' data-drill-logo="' . esc_url( $drill_logo ) . '"';
+			$drill_attrs .= ' data-drill-logo-align="' . ( ( $s->drill_logo_align ?? 'right' ) === 'left' ? 'left' : 'right' ) . '"';
+		}
+
+		echo '<nav class="ds-menu-wrap' . ( 'drill' === $mstyle ? ' ds-menu-wrap--drill' : '' ) . '"' . $drill_attrs . ' aria-label="' . esc_attr__( 'Primary', 'ds-toolkit' ) . '">';
 
 		// Hamburger toggle (animates into an X via CSS when the overlay opens).
 		echo '<button type="button" class="ds-menu-toggle" aria-expanded="false" aria-label="' . esc_attr__( 'Toggle menu', 'ds-toolkit' ) . '">';
@@ -588,6 +608,17 @@ FLBuilder::register_module( 'DS_Menu_Module', array(
 			'mob'  => array(
 				'title'  => __( 'Mobile Overlay', 'ds-toolkit' ),
 				'fields' => array(
+					'drill_logo_show'   => array(
+						'type'    => 'select',
+						'label'   => __( 'Drawer Logo', 'ds-toolkit' ),
+						'default' => 'show',
+						'options' => array( 'show' => __( 'Show', 'ds-toolkit' ), 'hide' => __( 'Hide', 'ds-toolkit' ) ),
+						'toggle'  => array( 'show' => array( 'fields' => array( 'drill_logo', 'drill_logo_align', 'drill_logo_height' ) ) ),
+						'help'    => __( 'Shows the site logo at the top of the drill-down drawer (drill style only). Blank image = the Partner Logo from Partner Setting, then the site logo.', 'ds-toolkit' ),
+					),
+					'drill_logo'        => array( 'type' => 'photo', 'label' => __( 'Drawer Logo Image', 'ds-toolkit' ), 'show_remove' => true, 'connections' => array( 'photo' ), 'help' => __( 'Override image. Blank = Partner Logo → site logo.', 'ds-toolkit' ) ),
+					'drill_logo_align'  => array( 'type' => 'select', 'label' => __( 'Drawer Logo Position', 'ds-toolkit' ), 'default' => 'right', 'options' => array( 'right' => __( 'Top Right (beside the close X)', 'ds-toolkit' ), 'left' => __( 'Top Left', 'ds-toolkit' ) ) ),
+					'drill_logo_height' => array( 'type' => 'unit', 'label' => __( 'Drawer Logo Height', 'ds-toolkit' ), 'default' => '30', 'description' => 'px', 'slider' => array( 'min' => 16, 'max' => 64, 'step' => 1 ), 'preview' => array( 'type' => 'css', 'selector' => '.ds-drill-brand img', 'property' => 'height', 'unit' => 'px' ) ),
 					'overlay_bg'           => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Overlay Background', 'ds-toolkit' ), 'default' => 'var(--fl-global-dark-background)', 'show_reset' => true, 'show_alpha' => true ),
 					// --- Menu items (top level) in the overlay ---
 					'overlay_text'          => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Menu Item Color', 'ds-toolkit' ), 'default' => 'var(--fl-global-white)', 'show_reset' => true, 'show_alpha' => true ),

--- a/modules/ds-menu/includes/frontend.css.php
+++ b/modules/ds-menu/includes/frontend.css.php
@@ -391,6 +391,8 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 		<?php if ( $oitembg ) : ?>--ds-drill-row-bg: <?php echo $oitembg; ?>;<?php endif; ?>
 	}
 	<?php echo $node; ?> .ds-drill-cta:hover { color: <?php echo $dr_mtexth; ?> !important; }
+	<?php $dlh = ( isset( $settings->drill_logo_height ) && '' !== $settings->drill_logo_height ) ? (int) $settings->drill_logo_height : 30; ?>
+	<?php echo $node; ?> .ds-drill-brand img { height: <?php echo $dlh; ?>px; }
 	<?php echo $node; ?> .ds-drill .ds-drill-row, <?php echo $node; ?> .ds-drill .ds-drill-back, <?php echo $node; ?> .ds-drill .ds-drill-overview { border-bottom: <?php echo $md_border; ?> !important; }
 	<?php if ( $oitembg ) : ?>
 	<?php /* Mirror the overlay's persistent top-level item background. */ ?>

--- a/modules/ds-menu/js/frontend.js
+++ b/modules/ds-menu/js/frontend.js
@@ -97,6 +97,17 @@
 		wrap.appendChild( drawer );
 		var stack = [];
 
+		// Persistent brand bar above the panels (site/partner logo from data attrs).
+		if ( wrap.dataset.drillLogo ) {
+			var brand = document.createElement( 'div' );
+			brand.className = 'ds-drill-brand ds-drill-brand--' + ( 'left' === wrap.dataset.drillLogoAlign ? 'left' : 'right' );
+			var bimg = document.createElement( 'img' );
+			bimg.src = wrap.dataset.drillLogo;
+			bimg.alt = '';
+			brand.appendChild( bimg );
+			drawer.appendChild( brand );
+		}
+
 		function row( node, isRoot ) {
 			var hasKids = node.children.length > 0;
 			var el = document.createElement( hasKids ? 'button' : 'a' );


### PR DESCRIPTION
V1 polish from review: the drill drawer gets a persistent **brand bar** above the sliding panels — **top right beside the close X** (default) or top left. Settings under Style → Mobile Overlay: show/hide, image override, position, height (live preview). Blank image resolves to the **Partner Logo** (Partner Setting ACF option — the fleet's canonical logo) and then the site custom logo, so it just works on every install with no configuration.
