### PR TITLE
fix: drill drawer brand bar survives panel resets (1.9.40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.40] - 2026-07-22
+### Fixed
+- **Drawer logo actually renders.** The v1.9.39 brand bar was wiped by the drawer reset on open (openRoot cleared the whole drawer). Panels now live in their own container, so the brand bar persists across opens and drills.
+
 ## [1.9.39] - 2026-07-22
 ### Added
 - **Menu: drawer logo (drill style).** The drill-down drawer now shows the site logo in a persistent brand bar -- top right beside the close X by default, top left selectable. Settings under Style -> Mobile Overlay: show/hide, image override (blank = the Partner Logo from Partner Setting, then the site logo), position, and height (live preview).

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.39
+ * Version:           1.9.40
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.39' );
+define( 'DS_TOOLKIT_VERSION', '1.9.40' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/css/frontend.css
+++ b/modules/ds-menu/css/frontend.css
@@ -113,3 +113,4 @@ body.ds-menu-locked { overflow: hidden; }
 .ds-drill-brand--right{justify-content:flex-end;padding-right:76px;}
 .ds-drill-brand--left{justify-content:flex-start;}
 .ds-drill-brand img{height:30px;width:auto;max-width:200px;object-fit:contain;display:block;}
+.ds-drill-panels{position:absolute;inset:0;}

--- a/modules/ds-menu/js/frontend.js
+++ b/modules/ds-menu/js/frontend.js
@@ -95,6 +95,9 @@
 		var drawer = document.createElement( 'div' );
 		drawer.className = 'ds-drill';
 		wrap.appendChild( drawer );
+		var panelsEl = document.createElement( 'div' );
+		panelsEl.className = 'ds-drill-panels';
+		drawer.appendChild( panelsEl );
 		var stack = [];
 
 		// Persistent brand bar above the panels (site/partner logo from data attrs).
@@ -165,7 +168,7 @@
 			var prev = stack[ stack.length - 1 ];
 			if ( prev ) { prev.style.transform = 'translateX(-100%)'; }
 			var p = buildPanel( node );
-			drawer.appendChild( p );
+			panelsEl.appendChild( p );
 			stack.push( p );
 			requestAnimationFrame( function () { p.style.transform = 'translateX(0)'; } );
 		}
@@ -180,11 +183,11 @@
 
 		return {
 			openRoot: function () {
-				drawer.innerHTML = '';
+				panelsEl.innerHTML = '';
 				stack = [];
 				push( { root: true, label: '', url: '', isButton: false, children: drillTree( wrap ) } );
 			},
-			clear: function () { drawer.innerHTML = ''; stack = []; }
+			clear: function () { panelsEl.innerHTML = ''; stack = []; }
 		};
 	}
 


### PR DESCRIPTION
The v1.9.39 brand bar was appended to the drawer and then immediately wiped by `openRoot()`'s `drawer.innerHTML = ''` reset. Panels now live in a dedicated `.ds-drill-panels` container that the reset targets, so the logo persists across opens and drills.
