### PR TITLE
fix: drill brand bar measures the toggle to avoid overlap (1.9.41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.41] - 2026-07-22
+### Fixed
+- **Drawer logo no longer overlaps the close control.** The right-aligned brand bar now measures the pinned X + Hamburger Label at open time and pads past it (the label makes the toggle width variable, so a fixed inset could collide).
+
 ## [1.9.40] - 2026-07-22
 ### Fixed
 - **Drawer logo actually renders.** The v1.9.39 brand bar was wiped by the drawer reset on open (openRoot cleared the whole drawer). Panels now live in their own container, so the brand bar persists across opens and drills.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.40
+ * Version:           1.9.41
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.40' );
+define( 'DS_TOOLKIT_VERSION', '1.9.41' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/js/frontend.js
+++ b/modules/ds-menu/js/frontend.js
@@ -101,8 +101,9 @@
 		var stack = [];
 
 		// Persistent brand bar above the panels (site/partner logo from data attrs).
+		var brand = null;
 		if ( wrap.dataset.drillLogo ) {
-			var brand = document.createElement( 'div' );
+			brand = document.createElement( 'div' );
 			brand.className = 'ds-drill-brand ds-drill-brand--' + ( 'left' === wrap.dataset.drillLogoAlign ? 'left' : 'right' );
 			var bimg = document.createElement( 'img' );
 			bimg.src = wrap.dataset.drillLogo;
@@ -187,7 +188,8 @@
 				stack = [];
 				push( { root: true, label: '', url: '', isButton: false, children: drillTree( wrap ) } );
 			},
-			clear: function () { panelsEl.innerHTML = ''; stack = []; }
+			clear: function () { panelsEl.innerHTML = ''; stack = []; },
+			brand: brand
 		};
 	}
 
@@ -208,6 +210,14 @@
 				if ( state ) {
 					if ( ! drill ) { drill = makeDrill( wrap ); }
 					drill.openRoot();
+					// Right-aligned brand clears the pinned X + label, whose width
+					// varies with the Hamburger Label — measure, don't guess.
+					if ( drill.brand && toggle && -1 !== drill.brand.className.indexOf( 'ds-drill-brand--right' ) ) {
+						requestAnimationFrame( function () {
+							var t = toggle.getBoundingClientRect();
+							drill.brand.style.paddingRight = Math.max( 76, Math.round( window.innerWidth - t.left + 14 ) ) + 'px';
+						} );
+					}
 				} else if ( drill ) {
 					setTimeout( drill.clear, 280 ); // after the fade-out
 				}


### PR DESCRIPTION
The pinned X includes the optional Hamburger Label, so its width varies per site — the fixed 76px inset collided with it on dslaunchpad6 (measured live). The right-aligned brand bar now measures the toggle's rect at open time and pads past it.
