### PR TITLE
fix: drill rows share one font family (1.9.43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.43] - 2026-07-22
+### Fixed
+- **Drill drawer: parent and leaf rows now share the same font.** Parent rows are <button>s, so BB's global button typography (a display font on some sites, e.g. Manakoa) painted them differently from the anchor leaf rows. Rows and labels now hard-inherit font family/size, with the base size on the panel; the module's Mobile Overlay typography fields hook the panel, so they still restyle the whole drawer.
+
 ## [1.9.42] - 2026-07-22
 ### Added
 - **Divider: heading + logo caps (section-header treatment).** The horizontal divider gains an optional "Heading & Logo" section: a heading on the left ({a} accent and {outline} tokens supported, tag/colour/typography controls) and/or a logo on the right (blank image = Partner Logo -> site logo), with the line flex-filling between them and a configurable gap. Both default off, so every existing divider renders unchanged.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.42
+ * Version:           1.9.43
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.42' );
+define( 'DS_TOOLKIT_VERSION', '1.9.43' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/css/frontend.css
+++ b/modules/ds-menu/css/frontend.css
@@ -88,15 +88,16 @@ body.ds-menu-locked { overflow: hidden; }
    repaint the drawer (same hardening class as the hamburger toggle). */
 .ds-drill{position:fixed;inset:0;z-index:100000;background:var(--ds-drill-bg,#0b0b0b);opacity:0;visibility:hidden;transition:opacity .25s ease;overflow:hidden;}
 .ds-menu-wrap--drill.ds-menu-open .ds-drill{opacity:1;visibility:visible;}
-.ds-drill-panel{position:absolute;inset:0;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:72px 0 40px;background:var(--ds-drill-bg,#0b0b0b);transform:translateX(100%);transition:transform .3s ease;}
+.ds-drill-panel{position:absolute;inset:0;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:72px 0 40px;background:var(--ds-drill-bg,#0b0b0b);transform:translateX(100%);transition:transform .3s ease;font-size:16px;}
 .fl-builder-content .ds-drill .ds-drill-row,
 .fl-builder-content .ds-drill .ds-drill-back,
-.fl-builder-content .ds-drill .ds-drill-overview{display:flex;align-items:center;justify-content:space-between;gap:12px;width:100%;text-align:left;background:none !important;border:0 !important;border-bottom:1px solid var(--ds-drill-hair,rgba(255,255,255,.12)) !important;padding:17px 22px;margin:0;font-family:inherit;font-size:16px;line-height:1.3;color:var(--ds-drill-text,#fff) !important;cursor:pointer;text-decoration:none;box-sizing:border-box;-webkit-appearance:none;appearance:none;border-radius:0;box-shadow:none !important;clip-path:none !important;-webkit-clip-path:none !important;text-transform:none;letter-spacing:normal;font-weight:400;}
+.fl-builder-content .ds-drill .ds-drill-overview{display:flex;align-items:center;justify-content:space-between;gap:12px;width:100%;text-align:left;background:none !important;border:0 !important;border-bottom:1px solid var(--ds-drill-hair,rgba(255,255,255,.12)) !important;padding:17px 22px;margin:0;font-family:inherit !important;font-size:inherit !important;line-height:1.3;color:var(--ds-drill-text,#fff) !important;cursor:pointer;text-decoration:none;box-sizing:border-box;-webkit-appearance:none;appearance:none;border-radius:0;box-shadow:none !important;clip-path:none !important;-webkit-clip-path:none !important;text-transform:none;letter-spacing:normal;font-weight:400;}
 .fl-builder-content .ds-drill .ds-drill-row:hover{background:var(--ds-drill-row-bg,rgba(255,255,255,.06)) !important;}
 .ds-drill-panel.is-root .ds-drill-label{text-transform:uppercase;letter-spacing:.06em;font-weight:600;}
+.fl-builder-content .ds-drill .ds-drill-label{font-family:inherit !important;font-size:inherit !important;}
 .ds-drill-chev{flex:0 0 auto;line-height:0;}
 .ds-drill-chev svg,.fl-builder-content .ds-drill .ds-drill-back svg{width:20px;height:20px;stroke:var(--ds-drill-accent,var(--fl-global-accent));stroke-width:2;fill:none;stroke-linecap:round;stroke-linejoin:round;display:block;}
-.fl-builder-content .ds-drill .ds-drill-back{justify-content:flex-start;gap:8px;color:var(--ds-drill-accent,var(--fl-global-accent)) !important;font-size:13px;letter-spacing:.08em;text-transform:uppercase;font-weight:700;}
+.fl-builder-content .ds-drill .ds-drill-back{justify-content:flex-start;gap:8px;color:var(--ds-drill-accent,var(--fl-global-accent)) !important;font-size:13px !important;letter-spacing:.08em;text-transform:uppercase;font-weight:700;}
 .fl-builder-content .ds-drill .ds-drill-back svg{width:18px;height:18px;}
 .fl-builder-content .ds-drill .ds-drill-overview{background:var(--ds-drill-row-bg,rgba(255,255,255,.06)) !important;}
 .fl-builder-content .ds-drill .ds-drill-overview small{color:var(--ds-drill-sub,#9a9a9a);font-size:12px;}

--- a/modules/ds-menu/includes/frontend.css.php
+++ b/modules/ds-menu/includes/frontend.css.php
@@ -470,7 +470,7 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 	FLBuilderCSS::typography_field_rule( array(
 		'settings'     => $settings,
 		'setting_name' => 'mobile_typography',
-		'selector'     => "$open .ds-menu > .ds-menu-item > a, $node .ds-drill-panel.is-root .ds-drill-row .ds-drill-label",
+		'selector'     => "$open .ds-menu > .ds-menu-item > a, $node .ds-drill-panel.is-root",
 	) );
 	// Mobile submenu / mega labels. Overlay-scoped selector (specificity beats the
 	// desktop dropdown_typography), so it wins inside the overlay; if left empty the
@@ -479,7 +479,7 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 	FLBuilderCSS::typography_field_rule( array(
 		'settings'     => $settings,
 		'setting_name' => 'mobile_subtypography',
-		'selector'     => "$open .ds-submenu a, $open .ds-mega a, $node .ds-drill-panel:not(.is-root) .ds-drill-row .ds-drill-label",
+		'selector'     => "$open .ds-submenu a, $open .ds-mega a, $node .ds-drill-panel:not(.is-root)",
 	) );
 }
 ?>


### PR DESCRIPTION
On manakoavbc, drill parent rows (`<button>`s) rendered in the site's display font while leaf rows (`<a>`s) used the body font — BB's global button typography painting buttons, the same bleed class as #35 but for `font-family`. Rows and labels now hard-inherit family/size; the base size lives on the panel, and the Mobile Overlay typography fields hook the panel so they still restyle the drawer through the inherit chain.
