### PR TITLE
fix: updater offers updates only when the release asset exists (1.9.44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.44] - 2026-07-22
+### Fixed
+- **Updater can no longer destroy the plugin during the release window.** Right after a release is published there is a window where the tag exists but the built ds-toolkit.zip asset isn't attached yet; the updater fell back to GitHub's raw zipball, whose owner-repo-hash folder name breaks the plugin path -- and a failed unpack after the upgrader deletes the old folder left the plugin GONE from a live site (manakoavbc, restored). The updater now offers an update ONLY when the real asset exists; otherwise it waits for the next check.
+
 ## [1.9.43] - 2026-07-22
 ### Fixed
 - **Drill drawer: parent and leaf rows now share the same font.** Parent rows are <button>s, so BB's global button typography (a display font on some sites, e.g. Manakoa) painted them differently from the anchor leaf rows. Rows and labels now hard-inherit font family/size, with the base size on the panel; the module's Mobile Overlay typography fields hook the panel, so they still restyle the whole drawer.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.43
+ * Version:           1.9.44
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.43' );
+define( 'DS_TOOLKIT_VERSION', '1.9.44' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/class-ds-toolkit-updater.php
+++ b/includes/class-ds-toolkit-updater.php
@@ -75,13 +75,22 @@ class DS_Toolkit_Updater {
         $current_version = DS_TOOLKIT_VERSION;
         $plugin_file     = $this->plugin_file();
 
-        if ( $this->is_newer_version( $latest_version, $current_version ) ) {
+        // Only offer the update once the built ds-toolkit.zip asset is attached.
+        // Right after a release is published there is a window where the tag
+        // exists but the Action hasn't uploaded the asset yet; offering the raw
+        // zipball in that window mangles the folder name and has DELETED the
+        // plugin from live sites (upgrader removes the old folder first — seen
+        // on manakoavbc 2026-07-22). No asset = pretend there's no update; the
+        // next check picks it up once the asset exists.
+        $package = $this->get_download_url( $release );
+
+        if ( '' !== $package && $this->is_newer_version( $latest_version, $current_version ) ) {
             $transient->response[ $plugin_file ] = (object) array(
                 'slug'        => $this->slug,
                 'plugin'      => $plugin_file,
                 'new_version' => $latest_version,
                 'url'         => 'https://github.com/' . $this->repo,
-                'package'     => $this->get_download_url( $release ),
+                'package'     => $package,
             );
         } else {
             // Plugin is up to date — clear any stale response entry and mark as checked.
@@ -228,8 +237,11 @@ class DS_Toolkit_Updater {
     }
 
     /**
-     * Prefer the attached release asset zip (correct folder name inside)
-     * over GitHub's raw zipball (which uses owner-repo-hash as folder name).
+     * The attached release asset zip ONLY (correct folder name inside).
+     * Never the raw zipball: its owner-repo-hash folder name breaks the
+     * active_plugins path, and a failed unpack after the upgrader deletes
+     * the old folder leaves the plugin GONE from the live site. When the
+     * asset isn't attached (yet), return '' and the caller skips the update.
      */
     private function get_download_url( $release ) {
         if ( ! empty( $release['assets'] ) ) {
@@ -239,7 +251,7 @@ class DS_Toolkit_Updater {
                 }
             }
         }
-        return $release['zipball_url'];
+        return '';
     }
 
     /**


### PR DESCRIPTION
**Incident**: manakoavbc was found running with `ds-toolkit/ds-toolkit.php` in `active_plugins` but the plugin folder GONE — every LeagueApps module dead on the live site (restored by reinstalling v1.9.43).

**Root cause**: after `gh release create` there's a window before the Action attaches `ds-toolkit.zip`. A site auto-updating in that window got the updater's **zipball fallback**: the zipball's owner-repo-hash folder name breaks the plugin path, and WP's upgrader deletes the old folder before unpacking — a failure there leaves nothing behind. Seven releases today made the window easy to hit.

**Fix**: `get_download_url()` returns the attached `ds-toolkit.zip` asset or **nothing** — never the zipball — and the update check offers a release only when the package URL exists. Sites simply wait one check cycle for the asset.
