### PR TITLE
fix: drill drawer typography fully follows the Style tab (1.9.45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.45] - 2026-07-22
+### Fixed
+- **Drill drawer fully respects the Mobile Overlay typography fields.** v1.9.43 hardened only font family/size, so BB's global button typography still painted weight/case/letter-spacing onto parent (<button>) rows, and the Style tab's Menu/Submenu typography (e.g. uppercase submenu labels on Manakoa) didn't reach the rows. Every typography property on rows, labels, and Overview now hard-inherits from the panel, and the panels carry the module's Menu Label / Submenu typography settings -- so the Style tab wins everywhere and button rows can never diverge from link rows. The back row keeps its compact style explicitly.
+
 ## [1.9.44] - 2026-07-22
 ### Fixed
 - **Updater can no longer destroy the plugin during the release window.** Right after a release is published there is a window where the tag exists but the built ds-toolkit.zip asset isn't attached yet; the updater fell back to GitHub's raw zipball, whose owner-repo-hash folder name breaks the plugin path -- and a failed unpack after the upgrader deletes the old folder left the plugin GONE from a live site (manakoavbc, restored). The updater now offers an update ONLY when the real asset exists; otherwise it waits for the next check.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.44
+ * Version:           1.9.45
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.44' );
+define( 'DS_TOOLKIT_VERSION', '1.9.45' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/css/frontend.css
+++ b/modules/ds-menu/css/frontend.css
@@ -88,16 +88,18 @@ body.ds-menu-locked { overflow: hidden; }
    repaint the drawer (same hardening class as the hamburger toggle). */
 .ds-drill{position:fixed;inset:0;z-index:100000;background:var(--ds-drill-bg,#0b0b0b);opacity:0;visibility:hidden;transition:opacity .25s ease;overflow:hidden;}
 .ds-menu-wrap--drill.ds-menu-open .ds-drill{opacity:1;visibility:visible;}
-.ds-drill-panel{position:absolute;inset:0;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:72px 0 40px;background:var(--ds-drill-bg,#0b0b0b);transform:translateX(100%);transition:transform .3s ease;font-size:16px;}
+.ds-drill-panel{position:absolute;inset:0;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:72px 0 40px;background:var(--ds-drill-bg,#0b0b0b);transform:translateX(100%);transition:transform .3s ease;font-size:16px;line-height:1.3;font-weight:400;font-style:normal;text-transform:none;letter-spacing:normal;}
+.ds-drill-panel.is-root{text-transform:uppercase;letter-spacing:.06em;font-weight:600;}
 .fl-builder-content .ds-drill .ds-drill-row,
 .fl-builder-content .ds-drill .ds-drill-back,
-.fl-builder-content .ds-drill .ds-drill-overview{display:flex;align-items:center;justify-content:space-between;gap:12px;width:100%;text-align:left;background:none !important;border:0 !important;border-bottom:1px solid var(--ds-drill-hair,rgba(255,255,255,.12)) !important;padding:17px 22px;margin:0;font-family:inherit !important;font-size:inherit !important;line-height:1.3;color:var(--ds-drill-text,#fff) !important;cursor:pointer;text-decoration:none;box-sizing:border-box;-webkit-appearance:none;appearance:none;border-radius:0;box-shadow:none !important;clip-path:none !important;-webkit-clip-path:none !important;text-transform:none;letter-spacing:normal;font-weight:400;}
+.fl-builder-content .ds-drill .ds-drill-overview{display:flex;align-items:center;justify-content:space-between;gap:12px;width:100%;text-align:left;background:none !important;border:0 !important;border-bottom:1px solid var(--ds-drill-hair,rgba(255,255,255,.12)) !important;padding:17px 22px;margin:0;color:var(--ds-drill-text,#fff) !important;cursor:pointer;text-decoration:none;box-sizing:border-box;-webkit-appearance:none;appearance:none;border-radius:0;box-shadow:none !important;clip-path:none !important;-webkit-clip-path:none !important;}
 .fl-builder-content .ds-drill .ds-drill-row:hover{background:var(--ds-drill-row-bg,rgba(255,255,255,.06)) !important;}
-.ds-drill-panel.is-root .ds-drill-label{text-transform:uppercase;letter-spacing:.06em;font-weight:600;}
-.fl-builder-content .ds-drill .ds-drill-label{font-family:inherit !important;font-size:inherit !important;}
+.fl-builder-content .ds-drill .ds-drill-row,
+.fl-builder-content .ds-drill .ds-drill-overview,
+.fl-builder-content .ds-drill .ds-drill-label{font-family:inherit !important;font-size:inherit !important;font-weight:inherit !important;font-style:inherit !important;letter-spacing:inherit !important;text-transform:inherit !important;line-height:inherit !important;}
 .ds-drill-chev{flex:0 0 auto;line-height:0;}
 .ds-drill-chev svg,.fl-builder-content .ds-drill .ds-drill-back svg{width:20px;height:20px;stroke:var(--ds-drill-accent,var(--fl-global-accent));stroke-width:2;fill:none;stroke-linecap:round;stroke-linejoin:round;display:block;}
-.fl-builder-content .ds-drill .ds-drill-back{justify-content:flex-start;gap:8px;color:var(--ds-drill-accent,var(--fl-global-accent)) !important;font-size:13px !important;letter-spacing:.08em;text-transform:uppercase;font-weight:700;}
+.fl-builder-content .ds-drill .ds-drill-back{justify-content:flex-start;gap:8px;color:var(--ds-drill-accent,var(--fl-global-accent)) !important;font-family:inherit !important;font-size:13px !important;letter-spacing:.08em !important;text-transform:uppercase !important;font-weight:700 !important;line-height:1.2 !important;}
 .fl-builder-content .ds-drill .ds-drill-back svg{width:18px;height:18px;}
 .fl-builder-content .ds-drill .ds-drill-overview{background:var(--ds-drill-row-bg,rgba(255,255,255,.06)) !important;}
 .fl-builder-content .ds-drill .ds-drill-overview small{color:var(--ds-drill-sub,#9a9a9a);font-size:12px;}


### PR DESCRIPTION
On manakoavbc the Style tab's Mobile Overlay typography (submenu uppercase @16px) was ignored by the drill drawer, and parent `<button>` rows still rendered in the theme's display font — v1.9.43 hardened family/size but BB's global button typography still painted weight/case/letter-spacing. Now every typography property on rows/labels/Overview hard-inherits from the panel, and the panels carry the module's Menu Label / Submenu typography field rules — the Style tab wins everywhere, and button rows can never diverge from anchor rows. The back row pins its own compact style explicitly.
