### PR TITLE
fix: drill drawer full Style-tab parity (1.9.46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.46] - 2026-07-22
+### Fixed
+- **Drill drawer: full Style-tab parity audit.** Five Mobile Overlay settings the drawer previously ignored now apply with the same semantics as the legacy overlay: **Submenu Colour** (overlay_subtext) colours deeper-panel rows, **Submenu Hover** and **Submenu Background** apply per row, **Menu Item Hover/Active Colour** applies to root rows on hover (it already drove the accent chevrons/back), and the CTA honours **Full Width in Mobile Overlay = No** (compact pill instead of full-width). Already honored and re-verified: overlay background, item colour, item background, dividers, Menu/Submenu typography, CTA colours, drawer logo.
+
 ## [1.9.45] - 2026-07-22
 ### Fixed
 - **Drill drawer fully respects the Mobile Overlay typography fields.** v1.9.43 hardened only font family/size, so BB's global button typography still painted weight/case/letter-spacing onto parent (<button>) rows, and the Style tab's Menu/Submenu typography (e.g. uppercase submenu labels on Manakoa) didn't reach the rows. Every typography property on rows, labels, and Overview now hard-inherits from the panel, and the panels carry the module's Menu Label / Submenu typography settings -- so the Style tab wins everywhere and button rows can never diverge from link rows. The back row keeps its compact style explicitly.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.45
+ * Version:           1.9.46
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.45' );
+define( 'DS_TOOLKIT_VERSION', '1.9.46' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/includes/frontend.css.php
+++ b/modules/ds-menu/includes/frontend.css.php
@@ -398,6 +398,24 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 	<?php /* Mirror the overlay's persistent top-level item background. */ ?>
 	<?php echo $node; ?> .ds-drill .ds-drill-panel.is-root .ds-drill-row:not(.ds-drill-cta) { background: <?php echo $oitembg; ?> !important; }
 	<?php endif; ?>
+	<?php /* Full parity with the overlay's Style-tab semantics:
+	   subtext colours the deeper (submenu-equivalent) panels, the hover colours
+	   apply per level, and the CTA honours Full Width in Mobile Overlay. */ ?>
+	<?php if ( $osub && $osub !== $otext ) : ?>
+	<?php echo $node; ?> .ds-drill .ds-drill-panel:not(.is-root) .ds-drill-row:not(.ds-drill-cta) { color: <?php echo $osub; ?> !important; }
+	<?php endif; ?>
+	<?php if ( $osubbg ) : ?>
+	<?php echo $node; ?> .ds-drill .ds-drill-panel:not(.is-root) .ds-drill-row:not(.ds-drill-cta) { background: <?php echo $osubbg; ?> !important; }
+	<?php endif; ?>
+	<?php if ( $osubhov ) : ?>
+	<?php echo $node; ?> .ds-drill .ds-drill-panel:not(.is-root) .ds-drill-row:not(.ds-drill-cta):hover { color: <?php echo $osubhov; ?> !important; }
+	<?php endif; ?>
+	<?php if ( $otexthov ) : ?>
+	<?php echo $node; ?> .ds-drill .ds-drill-panel.is-root .ds-drill-row:not(.ds-drill-cta):hover { color: <?php echo $otexthov; ?> !important; }
+	<?php endif; ?>
+	<?php if ( ( $settings->button_full_mobile ?? 'yes' ) !== 'yes' ) : ?>
+	<?php echo $node; ?> .ds-drill .ds-drill-cta { display: inline-flex; width: auto; align-self: flex-start; }
+	<?php endif; ?>
 	<?php endif; ?>
 	/* Overlay items: stacked, large, full width */
 	<?php echo $open; ?> .ds-menu-item { position: static; width: 100%; border-bottom: <?php echo $md_border; ?>; }


### PR DESCRIPTION
Systematic audit of every Menu Style-tab setting against the drill drawer. Five Mobile Overlay settings were silently ignored and now apply with overlay-identical semantics:

- **Submenu Colour** (`overlay_subtext`) → rows in deeper panels
- **Submenu Hover** (`overlay_subtext_hover`) → deeper-row hover colour
- **Submenu Background** (`overlay_sub_bg`) → deeper-row background
- **Menu Item Hover/Active** (`overlay_text_hover`) → root-row hover colour (still also drives the accent chevrons/back)
- **Full Width in Mobile Overlay = No** → compact CTA pill

Verified already-honored settings while auditing: overlay background, item colour/background, dividers, Menu + Submenu typography, CTA colours (incl. hover text), drawer logo, breakpoint, hamburger fields.
