### PR TITLE
feat: Teams Cards layout + blueprint-aware fallback image (1.9.47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.47] - 2026-07-22
+### Added
+- **Post Loop: "Teams: Cards" layout.** A photo grid of teams: featured image (ratio option), team name, and an arrow -- external icon when the card links to the team's External Link (new tab), arrow when it links to the team page. Options: columns, gap, photo ratio, card/name/icon colours, name typography (live preview).
+
+### Changed
+- **Blueprint-aware fallback image for entries without a featured photo** (used by Teams/Staff/Sponsor/Tournament layouts): Launchpad 6 uses the Theme Setting Social Card; Launchpad 5 (or any site without the Theme Setting card) uses the stock LA social card shipped in the DSLP5 media library (/wp-content/uploads/2024/11/lasocialcard1.png).
+
 ## [1.9.46] - 2026-07-22
 ### Fixed
 - **Drill drawer: full Style-tab parity audit.** Five Mobile Overlay settings the drawer previously ignored now apply with the same semantics as the legacy overlay: **Submenu Colour** (overlay_subtext) colours deeper-panel rows, **Submenu Hover** and **Submenu Background** apply per row, **Menu Item Hover/Active Colour** applies to root rows on hover (it already drove the accent chevrons/back), and the CTA honours **Full Width in Mobile Overlay = No** (compact pill instead of full-width). Already honored and re-verified: overlay background, item colour, item background, dividers, Menu/Submenu typography, CTA colours, drawer logo.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.46
+ * Version:           1.9.47
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.46' );
+define( 'DS_TOOLKIT_VERSION', '1.9.47' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-post-loop/css/frontend.css
+++ b/modules/ds-post-loop/css/frontend.css
@@ -253,3 +253,16 @@
   .ds-tourn-rowmain{flex-basis:calc(100% - 170px);}
   .ds-tourn-rowside{margin-left:0;width:100%;justify-content:space-between;flex-wrap:wrap;gap:10px;}
 }
+
+/* ---- Teams: Cards (photo grid) ---- */
+.ds-teamcard-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:24px;}
+.ds-teamcard{display:flex;flex-direction:column;text-decoration:none;color:inherit;background:var(--fl-global-white);border-radius:var(--ds-radius);overflow:hidden;box-shadow:0 12px 30px -20px rgba(10,30,60,.3);transition:transform .2s ease,box-shadow .2s ease;}
+.ds-teamcard:hover{transform:translateY(-3px);box-shadow:0 18px 40px -20px rgba(10,30,60,.4);}
+.ds-teamcard-photo{display:block;width:100%;aspect-ratio:16 / 10;background:#ececec center center/cover no-repeat;}
+.ds-teamcard-body{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:16px 18px;}
+.ds-teamcard-name{color:var(--fl-global-headings);font-weight:700;font-size:1.05rem;line-height:1.2;}
+.ds-teamcard-ico{flex:0 0 auto;line-height:0;color:var(--fl-global-accent);transition:transform .2s ease;}
+.ds-teamcard-ico svg{width:18px;height:18px;display:block;}
+.ds-teamcard:hover .ds-teamcard-ico{transform:translateX(3px);}
+@media(max-width:1024px){.ds-teamcard-grid{grid-template-columns:repeat(2,1fr);}}
+@media(max-width:600px){.ds-teamcard-grid{grid-template-columns:1fr;}}

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -66,6 +66,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			'athlete_logo'   => __( 'Athletes: Logo Row (dark)', 'ds-toolkit' ),
 			'athlete_action' => __( 'Athletes: Action Cards', 'ds-toolkit' ),
 			'team_list'      => __( 'Teams: List', 'ds-toolkit' ),
+			'team_card'      => __( 'Teams: Cards (photo grid)', 'ds-toolkit' ),
 			'sponsor'        => __( 'Sponsors: Grid (manual list)', 'ds-toolkit' ),
 			'program'        => __( 'Custom Program Card (manual list)', 'ds-toolkit' ),
 			'tournament'     => __( 'Tournament Cards (events, upcoming)', 'ds-toolkit' ),
@@ -87,8 +88,18 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 	 * Fallback image for a post with no featured image: the Theme Setting
 	 * Social Card (so empty cards still show a branded image, not a blank box).
 	 */
+	/**
+	 * Fallback image for entries without a featured image.
+	 * Launchpad 6: the Theme Setting Social Card. Launchpad 5 (or any site
+	 * without the Theme Setting card): the stock social card that every DSLP5
+	 * build ships in its media library.
+	 */
 	private static function placeholder_image() {
-		return DS_Card::placeholder_image();
+		if ( class_exists( 'DS_Toolkit' ) && DS_Toolkit::blueprint_version() >= 6 ) {
+			$url = DS_Card::placeholder_image(); // Theme Setting → Social Card
+			if ( '' !== $url ) { return $url; }
+		}
+		return home_url( '/wp-content/uploads/2024/11/lasocialcard1.png' );
 	}
 
 	/** Heading markup: escape, {a}..{/a} -> accent span, newlines -> <br>. */
@@ -253,6 +264,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			'athlete_logo'   => 'render_athlete_logo',
 			'athlete_action' => 'render_athlete_action',
 			'team_list'      => 'render_team_list',
+			'team_card'      => 'render_team_card',
 			'sponsor'        => 'render_sponsor',
 			'program'        => 'render_program',
 			'tournament'     => 'render_tournament',
@@ -430,6 +442,45 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			echo '</a>';
 		}
 		$this->loop_close(); echo '</div></section>';
+		wp_reset_postdata();
+	}
+
+	/** Teams: Cards — photo grid; external LeagueApps link preferred, permalink fallback. */
+	public function render_team_card() {
+		$s  = $this->settings;
+		$ph = self::placeholder_image();
+		$q  = $this->run_query();
+
+		echo '<section class="ds-news ds-teamcards"><div class="ds-news-wrap">';
+		$this->render_head();
+		if ( ! $q->have_posts() ) {
+			if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No Teams published yet.', 'ds-toolkit' ) . '</p>'; }
+			echo '</div></section>';
+			return;
+		}
+
+		$arrow = DS_Card::icon( 'arrow' );
+		$ext   = DS_Card::icon( 'external' );
+		$this->loop_open( 'ds-teamcard-grid' );
+		while ( $q->have_posts() ) {
+			$q->the_post();
+			$id      = get_the_ID();
+			$name    = get_the_title( $id );
+			$img     = get_the_post_thumbnail_url( $id, 'large' ) ?: $ph;
+			$extlink = trim( (string) $this->acf( 'team_external_link', $id ) );
+			$is_ext  = '' !== $extlink;
+			$url     = $is_ext ? $extlink : get_permalink( $id );
+			$tgt     = $is_ext ? ' target="_blank" rel="noopener noreferrer"' : '';
+
+			echo '<a class="ds-teamcard" href="' . esc_url( $url ) . '"' . $tgt . '>';
+			echo '<span class="ds-teamcard-photo"' . ( $img ? ' style="background-image:url(' . esc_url( $img ) . ')"' : '' ) . '></span>';
+			echo '<span class="ds-teamcard-body">';
+			echo '<span class="ds-teamcard-name">' . DS_Module_UI::inline( $name ) . '</span>';
+			echo '<span class="ds-teamcard-ico" aria-hidden="true">' . ( $is_ext ? $ext : $arrow ) . '</span>';
+			echo '</span></a>';
+		}
+		$this->loop_close();
+		echo '</div></section>';
 		wp_reset_postdata();
 	}
 
@@ -1061,6 +1112,7 @@ $ds_pl_form = array(
 							'athlete_logo'   => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 							'athlete_action' => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 							'team_list'      => array( 'sections' => array( 'header', 'query', 'query_filter', 'team_list_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders' ), 'tabs' => array( 'query' ) ),
+							'team_card'      => array( 'sections' => array( 'header', 'query', 'query_filter', 'team_card_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 							'custom'         => array( 'sections' => array( 'header', 'query', 'query_filter', 'loopcard', 'header_style', 'typography', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 							'sponsor'        => array( 'sections' => array( 'header', 'sponsors_sec', 'sponsor_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ) ),
 							'program'        => array( 'sections' => array( 'header', 'programs_sec', 'program_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ) ),
@@ -1392,6 +1444,19 @@ $ds_pl_form = array(
 				),
 			),
 			// --- Team list options ---
+			'team_card_opts' => array(
+				'title'       => __( 'Team Cards', 'ds-toolkit' ),
+				'description' => __( 'Photo grid of teams. Cards link to the team\'s External Link (new tab) when set, else the team page. Teams without a featured image use the Social Card (Theme Setting on Launchpad 6; the stock LA social card on Launchpad 5).', 'ds-toolkit' ),
+				'fields'      => array(
+					'tc_cols'       => array( 'type' => 'unit', 'label' => __( 'Columns', 'ds-toolkit' ), 'default' => '3', 'slider' => array( 'min' => 1, 'max' => 5, 'step' => 1 ) ),
+					'tc_gap'        => array( 'type' => 'unit', 'label' => __( 'Gap', 'ds-toolkit' ), 'default' => '24', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 60, 'step' => 1 ) ),
+					'tc_ratio'      => array( 'type' => 'select', 'label' => __( 'Photo Ratio', 'ds-toolkit' ), 'default' => '16 / 10', 'options' => array( '16 / 9' => '16:9', '16 / 10' => '16:10', '4 / 3' => '4:3', '3 / 2' => '3:2', '1 / 1' => '1:1' ) ),
+					'tc_card_bg'    => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Card Background', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+					'tc_name_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Team Name Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+					'tc_ico_color'  => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Arrow Icon Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Blank = the global Accent colour.', 'ds-toolkit' ) ),
+					'tc_name_typo'  => array( 'type' => 'typography', 'label' => __( 'Team Name Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-teamcard-name' ) ),
+				),
+			),
 			'team_list_opts' => array(
 				'title'  => __( 'Team List', 'ds-toolkit' ),
 				'fields' => array(

--- a/modules/ds-post-loop/includes/frontend.css.php
+++ b/modules/ds-post-loop/includes/frontend.css.php
@@ -204,6 +204,23 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 	) );
 }
 
+// ---- Teams: Cards (photo grid) ----
+if ( ( $settings->card_layout ?? '' ) === 'team_card' ) {
+	$tcc = max( 1, (int) ( $settings->tc_cols ?? 3 ) );
+	$tcg = $u( $settings->tc_gap ?? '', 24 );
+	echo "$node .ds-teamcard-grid{grid-template-columns:repeat({$tcc},1fr);gap:{$tcg}px;}\n";
+	echo "@media(max-width:1024px){ $node .ds-teamcard-grid{grid-template-columns:repeat(" . min( $tcc, 2 ) . ",1fr);} }\n";
+	echo "@media(max-width:600px){ $node .ds-teamcard-grid{grid-template-columns:1fr;} }\n";
+	$tcr = preg_replace( '#[^0-9/ ]#', '', (string) ( $settings->tc_ratio ?? '16 / 10' ) ); if ( '' === trim( $tcr ) ) { $tcr = '16 / 10'; }
+	echo "$node .ds-teamcard-photo{aspect-ratio:{$tcr};}\n";
+	$c = $col( $settings->tc_card_bg ?? '' );    if ( $c ) { echo "$node .ds-teamcard{background:{$c};}\n"; }
+	$c = $col( $settings->tc_name_color ?? '' ); if ( $c ) { echo "$node .ds-teamcard-name{color:{$c};}\n"; }
+	$c = $col( $settings->tc_ico_color ?? '' );  if ( $c ) { echo "$node .ds-teamcard-ico{color:{$c};}\n"; }
+	if ( class_exists( 'FLBuilderCSS' ) && ! empty( $settings->tc_name_typo ) ) {
+		FLBuilderCSS::typography_field_rule( array( 'settings' => $settings, 'setting_name' => 'tc_name_typo', 'selector' => "$node .ds-teamcard-name" ) );
+	}
+}
+
 // ---- Tournament cards (events) ----
 if ( ( $settings->card_layout ?? '' ) === 'tournament' ) {
 	$tg = $u( $settings->tn_gap ?? '', 28 );


### PR DESCRIPTION
**Teams: Cards** — a photo grid layout for the Post Loop: featured image (ratio option), team name, and an arrow (external-link icon + new tab when the team's External Link is set, else the team page — identical link rule to Teams: List). Options: columns, gap, photo ratio, card/name/icon colours, name typography with live preview.

**Blueprint-aware fallback image**: entries without a featured photo now fall back to the **Theme Setting Social Card on Launchpad 6**, and to the stock **/wp-content/uploads/2024/11/lasocialcard1.png** on Launchpad 5 (which ships it in the media library). This also gives Staff/Sponsor/Tournament layouts a sane placeholder on DSLP5 where they previously had none.
