### PR TITLE
Fix mobile drill drawer Overview rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.49] - 2026-07-28
+### Added
+- **Menu: optional parent Overview row in the mobile drill drawer.** A new Responsive setting controls whether drilled panels show the parent link as an "Overview" row before their child links. It defaults to Show so existing menus remain unchanged. Hide lists only the linked child pages, and desktop navigation is unaffected.
+
 ## [1.9.48] - 2026-07-25
 ### Added
 - **CTA: "Style 5 -- Motion Cards" (GH #56).** Elevated image cards with a per-card Logo/Badge overlay. Card: ratio, radius, shadow depth, hover lift, transition speed. Background: default effect (blur / darken / grayscale / opacity / colour overlay with 8 blend modes) + hover behaviour (remove effect, brighten, zoom in/out). Logo overlay: position (5 spots), size/backing/padding/radius/shadow, entrance animation (12 variants, plays on scroll into view) with duration/delay/easing, and hover animation (scale, float, bounce, rotate, pulse, fade, glow). All CSS-driven, honours prefers-reduced-motion.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.48
+ * Version:           1.9.49
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.48' );
+define( 'DS_TOOLKIT_VERSION', '1.9.49' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/ds-menu.php
+++ b/modules/ds-menu/ds-menu.php
@@ -123,9 +123,10 @@ class DS_Menu_Module extends FLBuilderModule {
 				if ( $cl ) { $drill_logo = (string) wp_get_attachment_image_url( $cl, 'medium' ); }
 			}
 		}
-		$drill_attrs = '';
+		$drill_overview = ( $s->drill_overview ?? 'show' ) === 'hide' ? 'hide' : 'show';
+		$drill_attrs    = ' data-drill-overview="' . esc_attr( $drill_overview ) . '"';
 		if ( '' !== $drill_logo ) {
-			$drill_attrs  = ' data-drill-logo="' . esc_url( $drill_logo ) . '"';
+			$drill_attrs .= ' data-drill-logo="' . esc_url( $drill_logo ) . '"';
 			$drill_attrs .= ' data-drill-logo-align="' . ( ( $s->drill_logo_align ?? 'right' ) === 'left' ? 'left' : 'right' ) . '"';
 		}
 
@@ -393,6 +394,17 @@ FLBuilder::register_module( 'DS_Menu_Module', array(
 							'overlay' => __( 'Overlay with accordions (legacy)', 'ds-toolkit' ),
 						),
 						'help'    => __( 'Drill-down: submenus slide in one level at a time with a back control (Stripe-style); parents with their own URL get an "Overview" row. Desktop is unaffected. Menu content stays editable in Appearance → Menus.', 'ds-toolkit' ),
+						'toggle'  => array( 'drill' => array( 'fields' => array( 'drill_overview' ) ) ),
+					),
+					'drill_overview' => array(
+						'type'    => 'select',
+						'label'   => __( 'Parent Overview Row', 'ds-toolkit' ),
+						'default' => 'show',
+						'options' => array(
+							'show' => __( 'Show', 'ds-toolkit' ),
+							'hide' => __( 'Hide', 'ds-toolkit' ),
+						),
+						'help'    => __( 'Show a link to the parent item above its child links in drilled panels. Hide to list child links only. Desktop is unaffected.', 'ds-toolkit' ),
 					),
 					'breakpoint'   => array(
 						'type'        => 'unit',

--- a/modules/ds-menu/js/frontend.js
+++ b/modules/ds-menu/js/frontend.js
@@ -39,7 +39,7 @@
 	   Panels are built at open time from the RENDERED WP-menu markup, so the drawer
 	   always mirrors Appearance → Menus (nothing duplicated server-side). One level
 	   per panel; drilling slides the next level in from the right; back walks out;
-	   parents with a real URL get an "Overview" link row (Stripe-style). */
+	   parents with a real URL can get an optional "Overview" link row. */
 	var CHEV_R = '<svg viewBox="0 0 24 24" aria-hidden="true"><polyline points="9 6 15 12 9 18"/></svg>';
 	var CHEV_L = '<svg viewBox="0 0 24 24" aria-hidden="true"><polyline points="15 6 9 12 15 18"/></svg>';
 
@@ -148,7 +148,7 @@
 				back.appendChild( bl );
 				back.addEventListener( 'click', pop );
 				p.appendChild( back );
-				if ( node.url && '#' !== node.url ) {
+				if ( 'hide' !== wrap.dataset.drillOverview && node.url && '#' !== node.url ) {
 					var ov = document.createElement( 'a' );
 					ov.className = 'ds-drill-overview';
 					ov.href = node.url;


### PR DESCRIPTION
## Summary

Adds a per-module Parent Overview Row setting to the DS Menu mobile drill drawer. Existing modules default to Show, preserving fleet behavior. Sites that choose Hide list only the actual child pages. Desktop navigation is unchanged.

## Verification

- PHP lint passed for the plugin bootstrap and DS Menu module.
- JavaScript syntax check passed.
- Playwright DOM test confirmed Show renders one Overview row and Hide renders zero while retaining child links.
- Production target for this request: https://risevolleyball.com/
- ClickUp task: https://app.clickup.com/t/36045567/868kg4jze

## Release

Version bumped to 1.9.49 in the final branch commit.