### PR TITLE
Fix duplicate mobile Overview menu items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.50] - 2026-07-28
+### Fixed
+- **Menu: Hide Parent Overview Row also removes duplicate menu items.** Some menus contain an explicit child named "Overview" that points to the same URL as its parent. Hide now omits that duplicate from the mobile drill panel while leaving the real WordPress menu item and desktop navigation unchanged. Overview items that point elsewhere remain visible.
+
 ## [1.9.49] - 2026-07-28
 ### Added
 - **Menu: optional parent Overview row in the mobile drill drawer.** A new Responsive setting controls whether drilled panels show the parent link as an "Overview" row before their child links. It defaults to Show so existing menus remain unchanged. Hide lists only the linked child pages, and desktop navigation is unaffected.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.49
+ * Version:           1.9.50
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.49' );
+define( 'DS_TOOLKIT_VERSION', '1.9.50' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/ds-menu.php
+++ b/modules/ds-menu/ds-menu.php
@@ -404,7 +404,7 @@ FLBuilder::register_module( 'DS_Menu_Module', array(
 							'show' => __( 'Show', 'ds-toolkit' ),
 							'hide' => __( 'Hide', 'ds-toolkit' ),
 						),
-						'help'    => __( 'Show a link to the parent item above its child links in drilled panels. Hide to list child links only. Desktop is unaffected.', 'ds-toolkit' ),
+						'help'    => __( 'Show a link to the parent item above its child links in drilled panels. Hide lists child links only and also omits a duplicate Overview menu item that points back to the parent. Desktop is unaffected.', 'ds-toolkit' ),
 					),
 					'breakpoint'   => array(
 						'type'        => 'unit',

--- a/modules/ds-menu/js/frontend.js
+++ b/modules/ds-menu/js/frontend.js
@@ -100,6 +100,22 @@
 		drawer.appendChild( panelsEl );
 		var stack = [];
 
+		function normalizedUrl( value ) {
+			if ( ! value || '#' === value ) { return ''; }
+			try {
+				var parsed = new URL( value, window.location.href );
+				return parsed.origin + parsed.pathname.replace( /\/+$/, '' );
+			} catch ( error ) {
+				return value;
+			}
+		}
+
+		function isDuplicateOverview( child, parent ) {
+			return 'hide' === wrap.dataset.drillOverview
+				&& 'overview' === child.label.trim().toLowerCase()
+				&& normalizedUrl( child.url ) === normalizedUrl( parent.url );
+		}
+
 		// Persistent brand bar above the panels (site/partner logo from data attrs).
 		var brand = null;
 		if ( wrap.dataset.drillLogo ) {
@@ -161,7 +177,11 @@
 					p.appendChild( ov );
 				}
 			}
-			node.children.forEach( function ( c ) { p.appendChild( row( c, !! node.root ) ); } );
+			node.children.forEach( function ( c ) {
+				if ( ! isDuplicateOverview( c, node ) ) {
+					p.appendChild( row( c, !! node.root ) );
+				}
+			} );
 			return p;
 		}
 


### PR DESCRIPTION
## Summary

Extends the DS Menu Parent Overview Row setting for menus that already contain an explicit child named Overview pointing back to the parent. Hide now suppresses that duplicate only in the generated mobile drawer. The WordPress menu and desktop navigation remain unchanged.

Overview items pointing to a different URL remain visible.

## Verification

- PHP lint passed.
- JavaScript syntax check passed.
- Playwright DOM test confirmed Hide removes the generated row and the same-parent duplicate while preserving an Overview item with a different URL and all normal child links.
- Production target: https://risevolleyball.com/
- ClickUp task: https://app.clickup.com/t/36045567/868kg4jze

## Release

Version bumped to 1.9.50 in the final branch commit.