### PR TITLE
Improve mobile drill drawer UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.51] - 2026-07-28
+### Changed
+- **Menu: more usable and accessible mobile drill drawer.** The open control now says Close, drilled panels show a clear Back cue and current section title, and focus moves with navigation, stays inside the drawer, returns to the parent row on Back, and returns to the menu control on Escape. The drawer now exposes dialog and panel semantics, honors device safe areas and reduced motion, wraps long labels, retains 44px or larger touch targets, and compacts short landscape screens so the CTA remains visible. Rapid close and reopen actions no longer clear the fresh panel.
+
 ## [1.9.50] - 2026-07-28
 ### Fixed
 - **Menu: Hide Parent Overview Row also removes duplicate menu items.** Some menus contain an explicit child named "Overview" that points to the same URL as its parent. Hide now omits that duplicate from the mobile drill panel while leaving the real WordPress menu item and desktop navigation unchanged. Overview items that point elsewhere remain visible.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.50
+ * Version:           1.9.51
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.50' );
+define( 'DS_TOOLKIT_VERSION', '1.9.51' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/css/frontend.css
+++ b/modules/ds-menu/css/frontend.css
@@ -78,7 +78,7 @@
 .ds-menu-item.ds-open > .ds-sub-toggle::after { transform: translate(-50%,-50%) rotate(0); }
 
 /* Lock page scroll while the mobile overlay is open */
-body.ds-menu-locked { overflow: hidden; }
+body.ds-menu-locked { overflow: hidden; overscroll-behavior: none; }
 
 /* ---- Drill-down mobile drawer (Mobile Menu Style = drill) ----
    Colours arrive as custom props (--ds-drill-*) emitted node-scoped from the
@@ -86,34 +86,51 @@ body.ds-menu-locked { overflow: hidden; }
    Row colours/backgrounds carry !important at .fl-builder-content scope so
    BB global button styles (`button *`) and theme link colours can never
    repaint the drawer (same hardening class as the hamburger toggle). */
-.ds-drill{position:fixed;inset:0;z-index:100000;background:var(--ds-drill-bg,#0b0b0b);opacity:0;visibility:hidden;transition:opacity .25s ease;overflow:hidden;}
+.ds-drill{position:fixed;inset:0;height:100vh;height:100dvh;z-index:100000;background:var(--ds-drill-bg,#0b0b0b);opacity:0;visibility:hidden;transition:opacity .25s ease;overflow:hidden;overscroll-behavior:contain;}
 .ds-menu-wrap--drill.ds-menu-open .ds-drill{opacity:1;visibility:visible;}
-.ds-drill-panel{position:absolute;inset:0;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:72px 0 40px;background:var(--ds-drill-bg,#0b0b0b);transform:translateX(100%);transition:transform .3s ease;font-size:16px;line-height:1.3;font-weight:400;font-style:normal;text-transform:none;letter-spacing:normal;}
+.ds-drill-panel{position:absolute;inset:0;overflow-y:auto;-webkit-overflow-scrolling:touch;overscroll-behavior:contain;padding:calc(72px + env(safe-area-inset-top)) 0 calc(40px + env(safe-area-inset-bottom));background:var(--ds-drill-bg,#0b0b0b);transform:translateX(100%);transition:transform .3s ease;font-size:16px;line-height:1.3;font-weight:400;font-style:normal;text-transform:none;letter-spacing:normal;}
+.ds-drill-panel[aria-hidden="true"]{pointer-events:none;}
+.ds-drill-panel:focus{outline:none;}
 .ds-drill-panel.is-root{text-transform:uppercase;letter-spacing:.06em;font-weight:600;}
 .fl-builder-content .ds-drill .ds-drill-row,
 .fl-builder-content .ds-drill .ds-drill-back,
-.fl-builder-content .ds-drill .ds-drill-overview{display:flex;align-items:center;justify-content:space-between;gap:12px;width:100%;text-align:left;background:none !important;border:0 !important;border-bottom:1px solid var(--ds-drill-hair,rgba(255,255,255,.12)) !important;padding:17px 22px;margin:0;color:var(--ds-drill-text,#fff) !important;cursor:pointer;text-decoration:none;box-sizing:border-box;-webkit-appearance:none;appearance:none;border-radius:0;box-shadow:none !important;clip-path:none !important;-webkit-clip-path:none !important;}
+.fl-builder-content .ds-drill .ds-drill-overview{display:flex;align-items:center;justify-content:space-between;gap:12px;width:100%;min-height:48px;text-align:left;background:none !important;border:0 !important;border-bottom:1px solid var(--ds-drill-hair,rgba(255,255,255,.12)) !important;padding:17px 22px;margin:0;color:var(--ds-drill-text,#fff) !important;cursor:pointer;touch-action:manipulation;-webkit-tap-highlight-color:transparent;text-decoration:none;box-sizing:border-box;-webkit-appearance:none;appearance:none;border-radius:0;box-shadow:none !important;clip-path:none !important;-webkit-clip-path:none !important;}
 .fl-builder-content .ds-drill .ds-drill-row:hover{background:var(--ds-drill-row-bg,rgba(255,255,255,.06)) !important;}
+.fl-builder-content .ds-drill .ds-drill-row:active{background:var(--ds-drill-row-bg,rgba(255,255,255,.1)) !important;}
 .fl-builder-content .ds-drill .ds-drill-row,
 .fl-builder-content .ds-drill .ds-drill-overview,
 .fl-builder-content .ds-drill .ds-drill-label{font-family:inherit !important;font-size:inherit !important;font-weight:inherit !important;font-style:inherit !important;letter-spacing:inherit !important;text-transform:inherit !important;line-height:inherit !important;}
+.ds-drill-label{min-width:0;overflow-wrap:anywhere;}
 .ds-drill-chev{flex:0 0 auto;line-height:0;}
 .ds-drill-chev svg,.fl-builder-content .ds-drill .ds-drill-back svg{width:20px;height:20px;stroke:var(--ds-drill-accent,var(--fl-global-accent));stroke-width:2;fill:none;stroke-linecap:round;stroke-linejoin:round;display:block;}
-.fl-builder-content .ds-drill .ds-drill-back{justify-content:flex-start;gap:8px;color:var(--ds-drill-accent,var(--fl-global-accent)) !important;font-family:inherit !important;font-size:13px !important;letter-spacing:.08em !important;text-transform:uppercase !important;font-weight:700 !important;line-height:1.2 !important;}
+.fl-builder-content .ds-drill .ds-drill-back{justify-content:flex-start;gap:12px;color:var(--ds-drill-accent,var(--fl-global-accent)) !important;font-family:inherit !important;font-size:inherit !important;letter-spacing:inherit !important;text-transform:inherit !important;font-weight:inherit !important;line-height:inherit !important;}
 .fl-builder-content .ds-drill .ds-drill-back svg{width:18px;height:18px;}
+.ds-drill-back-copy{display:flex;flex-direction:column;gap:2px;min-width:0;}
+.fl-builder-content .ds-drill .ds-drill-back-cue{color:var(--ds-drill-accent,var(--fl-global-accent)) !important;font-family:inherit !important;font-size:11px !important;font-weight:700 !important;line-height:1 !important;letter-spacing:.1em !important;text-transform:uppercase !important;}
+.fl-builder-content .ds-drill .ds-drill-title{color:var(--ds-drill-text,#fff) !important;font-family:inherit !important;font-size:inherit !important;font-weight:inherit !important;line-height:1.15 !important;letter-spacing:inherit !important;text-transform:inherit !important;overflow-wrap:anywhere;}
 .fl-builder-content .ds-drill .ds-drill-overview{background:var(--ds-drill-row-bg,rgba(255,255,255,.06)) !important;}
 .fl-builder-content .ds-drill .ds-drill-overview small{color:var(--ds-drill-sub,#9a9a9a);font-size:12px;}
-.ds-drill-row:focus-visible,.ds-drill-back:focus-visible,.ds-drill-overview:focus-visible{outline:2px solid var(--ds-drill-accent,var(--fl-global-accent));outline-offset:-2px;}
+.ds-drill-row:focus-visible,.ds-drill-back:focus-visible,.ds-drill-overview:focus-visible,.ds-menu-wrap.ds-menu-open .ds-menu-toggle:focus-visible{outline:2px solid var(--ds-drill-accent,var(--fl-global-accent));outline-offset:-2px;}
 .fl-builder-content .ds-drill .ds-drill-cta{background:var(--ds-drill-cta-bg,var(--fl-global-button)) !important;color:var(--ds-drill-cta-text,var(--fl-global-white)) !important;margin:14px 22px 0;width:auto;border-radius:8px;justify-content:center;font-weight:700;text-transform:uppercase;letter-spacing:.06em;border-bottom:0 !important;}
 .fl-builder-content .ds-drill .ds-drill-cta:hover{background:var(--ds-drill-cta-bg-hover,var(--fl-global-accent)) !important;}
 @media (prefers-reduced-motion:reduce){
   .ds-drill,.ds-drill-panel{transition:none;}
 }
+@media (max-height:500px) and (max-width:1000px){
+  .ds-drill-panel{padding-top:calc(54px + env(safe-area-inset-top));padding-bottom:calc(12px + env(safe-area-inset-bottom));}
+  .fl-builder-content .ds-drill .ds-drill-row,
+  .fl-builder-content .ds-drill .ds-drill-back,
+  .fl-builder-content .ds-drill .ds-drill-overview{min-height:44px;padding-top:11px;padding-bottom:11px;}
+  .fl-builder-content .ds-drill .ds-drill-cta{margin-top:8px;}
+}
 
 /* Drill drawer brand bar: persistent above the sliding panels. Right-aligned
    variant pads past the pinned close X so they sit side by side. */
-.ds-drill-brand{position:absolute;top:0;left:0;right:0;height:64px;display:flex;align-items:center;z-index:3;padding:0 22px;pointer-events:none;}
+.ds-drill-brand{position:absolute;top:0;left:0;right:0;height:calc(64px + env(safe-area-inset-top));display:flex;align-items:center;z-index:3;padding:env(safe-area-inset-top) 22px 0;box-sizing:border-box;pointer-events:none;}
 .ds-drill-brand--right{justify-content:flex-end;padding-right:76px;}
 .ds-drill-brand--left{justify-content:flex-start;}
 .ds-drill-brand img{height:30px;width:auto;max-width:200px;object-fit:contain;display:block;}
 .ds-drill-panels{position:absolute;inset:0;}
+@media (max-height:500px) and (max-width:1000px){
+  .ds-drill-brand{height:calc(52px + env(safe-area-inset-top));}
+}

--- a/modules/ds-menu/includes/frontend.css.php
+++ b/modules/ds-menu/includes/frontend.css.php
@@ -356,7 +356,7 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 	}
 	/* Pin the open hamburger to the viewport corner so it can never overlap the items
 	   (it sits in the header flow otherwise, which is what caused the overlap). */
-	<?php echo $open; ?> .ds-menu-toggle { position: fixed; top: 16px; right: 18px; margin: 0; z-index: 100001; color: <?php echo $otext; ?> !important; background: transparent !important; border-color: <?php echo $otext; ?>; }
+	<?php echo $open; ?> .ds-menu-toggle { position: fixed; top: 16px; top: max(16px, env(safe-area-inset-top)); right: 18px; right: max(18px, env(safe-area-inset-right)); margin: 0; z-index: 100001; color: <?php echo $otext; ?> !important; background: transparent !important; border-color: <?php echo $otext; ?>; }
 
 	<?php
 	/* Overlay item divider. */

--- a/modules/ds-menu/js/frontend.js
+++ b/modules/ds-menu/js/frontend.js
@@ -42,6 +42,7 @@
 	   parents with a real URL can get an optional "Overview" link row. */
 	var CHEV_R = '<svg viewBox="0 0 24 24" aria-hidden="true"><polyline points="9 6 15 12 9 18"/></svg>';
 	var CHEV_L = '<svg viewBox="0 0 24 24" aria-hidden="true"><polyline points="15 6 9 12 15 18"/></svg>';
+	var drillCount = 0;
 
 	// Data tree from the rendered menu. Mega panels flatten into drill levels:
 	// each mega column heading becomes a drillable row over its column links.
@@ -94,11 +95,19 @@
 	function makeDrill( wrap ) {
 		var drawer = document.createElement( 'div' );
 		drawer.className = 'ds-drill';
+		drawer.id = 'ds-drill-' + ( ++drillCount );
+		drawer.setAttribute( 'aria-hidden', 'true' );
+		drawer.setAttribute( 'inert', '' );
 		wrap.appendChild( drawer );
 		var panelsEl = document.createElement( 'div' );
 		panelsEl.className = 'ds-drill-panels';
 		drawer.appendChild( panelsEl );
 		var stack = [];
+		var panelCount = 0;
+		var toggle = wrap.querySelector( '.ds-menu-toggle' );
+		if ( toggle ) {
+			toggle.setAttribute( 'aria-controls', drawer.id );
+		}
 
 		function normalizedUrl( value ) {
 			if ( ! value || '#' === value ) { return ''; }
@@ -141,12 +150,13 @@
 			label.textContent = node.label;
 			el.appendChild( label );
 			if ( hasKids ) {
+				el.setAttribute( 'aria-haspopup', 'true' );
 				var chev = document.createElement( 'span' );
 				chev.className = 'ds-drill-chev';
 				chev.setAttribute( 'aria-hidden', 'true' );
 				chev.innerHTML = CHEV_R;
 				el.appendChild( chev );
-				el.addEventListener( 'click', function () { push( node ); } );
+				el.addEventListener( 'click', function () { push( node, el, true ); } );
 			}
 			return el;
 		}
@@ -154,16 +164,35 @@
 		function buildPanel( node ) {
 			var p = document.createElement( 'div' );
 			p.className = 'ds-drill-panel' + ( node.root ? ' is-root' : '' );
+			p.tabIndex = -1;
+			p.setAttribute( 'role', 'group' );
+			p.setAttribute( 'aria-hidden', 'false' );
+			p.dataset.panelLabel = node.root ? 'Main menu' : node.label;
+			if ( node.root ) {
+				p.setAttribute( 'aria-label', 'Main menu' );
+			}
 			if ( ! node.root ) {
 				var back = document.createElement( 'button' );
 				back.type = 'button';
 				back.className = 'ds-drill-back';
 				back.innerHTML = CHEV_L;
-				var bl = document.createElement( 'span' );
-				bl.textContent = node.label;
-				back.appendChild( bl );
+				var destination = stack.length ? stack[ stack.length - 1 ].dataset.panelLabel : 'Main menu';
+				back.setAttribute( 'aria-label', 'Back to ' + destination );
+				var copy = document.createElement( 'span' );
+				copy.className = 'ds-drill-back-copy';
+				var cue = document.createElement( 'span' );
+				cue.className = 'ds-drill-back-cue';
+				cue.textContent = 'Back';
+				var title = document.createElement( 'span' );
+				title.className = 'ds-drill-title';
+				title.id = drawer.id + '-title-' + ( ++panelCount );
+				title.textContent = node.label;
+				copy.appendChild( cue );
+				copy.appendChild( title );
+				back.appendChild( copy );
 				back.addEventListener( 'click', pop );
 				p.appendChild( back );
+				p.setAttribute( 'aria-labelledby', title.id );
 				if ( 'hide' !== wrap.dataset.drillOverview && node.url && '#' !== node.url ) {
 					var ov = document.createElement( 'a' );
 					ov.className = 'ds-drill-overview';
@@ -185,30 +214,55 @@
 			return p;
 		}
 
-		function push( node ) {
+		function push( node, trigger, moveFocus ) {
 			var prev = stack[ stack.length - 1 ];
-			if ( prev ) { prev.style.transform = 'translateX(-100%)'; }
+			if ( prev ) {
+				prev.style.transform = 'translateX(-100%)';
+				prev.setAttribute( 'aria-hidden', 'true' );
+				prev.setAttribute( 'inert', '' );
+			}
 			var p = buildPanel( node );
+			p.dsTrigger = trigger || null;
 			panelsEl.appendChild( p );
 			stack.push( p );
-			requestAnimationFrame( function () { p.style.transform = 'translateX(0)'; } );
+			requestAnimationFrame( function () {
+				p.style.transform = 'translateX(0)';
+				if ( moveFocus ) {
+					var focusTarget = p.querySelector( '.ds-drill-back' ) || p;
+					focusTarget.focus( { preventScroll: true } );
+				}
+			} );
 		}
 
 		function pop() {
 			if ( stack.length < 2 ) { return; }
 			var top = stack.pop();
+			var trigger = top.dsTrigger;
 			top.style.transform = 'translateX(100%)';
+			top.setAttribute( 'aria-hidden', 'true' );
+			top.setAttribute( 'inert', '' );
 			setTimeout( function () { top.remove(); }, 320 );
-			stack[ stack.length - 1 ].style.transform = 'translateX(0)';
+			var current = stack[ stack.length - 1 ];
+			current.removeAttribute( 'inert' );
+			current.setAttribute( 'aria-hidden', 'false' );
+			current.style.transform = 'translateX(0)';
+			if ( trigger ) {
+				requestAnimationFrame( function () { trigger.focus( { preventScroll: true } ); } );
+			}
 		}
 
 		return {
 			openRoot: function () {
 				panelsEl.innerHTML = '';
 				stack = [];
-				push( { root: true, label: '', url: '', isButton: false, children: drillTree( wrap ) } );
+				push( { root: true, label: '', url: '', isButton: false, children: drillTree( wrap ) }, toggle, false );
 			},
 			clear: function () { panelsEl.innerHTML = ''; stack = []; },
+			setOpen: function ( state ) {
+				drawer.setAttribute( 'aria-hidden', state ? 'false' : 'true' );
+				if ( state ) { drawer.removeAttribute( 'inert' ); } else { drawer.setAttribute( 'inert', '' ); }
+			},
+			activePanel: function () { return stack[ stack.length - 1 ] || null; },
 			brand: brand
 		};
 	}
@@ -221,14 +275,38 @@
 		var close   = wrap.querySelector( '.ds-menu-close' );
 		var isDrill = wrap.classList.contains( 'ds-menu-wrap--drill' );
 		var drill   = null;
+		var drillClearTimer = null;
+		var originalRole = wrap.getAttribute( 'role' );
+		var originalAriaModal = wrap.getAttribute( 'aria-modal' );
+		var originalAriaLabel = wrap.getAttribute( 'aria-label' );
+		var toggleLabel = toggle ? toggle.querySelector( '.ds-menu-toggle-label' ) : null;
+		var toggleLabelText = toggleLabel ? toggleLabel.textContent : '';
+		var toggleAriaLabel = toggle ? toggle.getAttribute( 'aria-label' ) : null;
+
+		function restoreAttribute( name, value ) {
+			if ( null === value ) { wrap.removeAttribute( name ); } else { wrap.setAttribute( name, value ); }
+		}
 
 		function open( state ) {
+			var wasOpen = wrap.classList.contains( 'ds-menu-open' );
 			wrap.classList.toggle( 'ds-menu-open', state );
-			if ( toggle ) { toggle.setAttribute( 'aria-expanded', state ? 'true' : 'false' ); }
+			if ( toggle ) {
+				toggle.setAttribute( 'aria-expanded', state ? 'true' : 'false' );
+				toggle.setAttribute( 'aria-label', state ? 'Close menu' : ( toggleAriaLabel || 'Toggle menu' ) );
+			}
+			if ( toggleLabel ) { toggleLabel.textContent = state ? 'Close' : toggleLabelText; }
 			document.body.classList.toggle( 'ds-menu-locked', state );
 			if ( isDrill ) {
 				if ( state ) {
+					if ( drillClearTimer ) {
+						clearTimeout( drillClearTimer );
+						drillClearTimer = null;
+					}
 					if ( ! drill ) { drill = makeDrill( wrap ); }
+					drill.setOpen( true );
+					wrap.setAttribute( 'role', 'dialog' );
+					wrap.setAttribute( 'aria-modal', 'true' );
+					wrap.setAttribute( 'aria-label', 'Site menu' );
 					drill.openRoot();
 					// Right-aligned brand clears the pinned X + label, whose width
 					// varies with the Hamburger Label — measure, don't guess.
@@ -239,7 +317,19 @@
 						} );
 					}
 				} else if ( drill ) {
-					setTimeout( drill.clear, 280 ); // after the fade-out
+					drill.setOpen( false );
+					drillClearTimer = setTimeout( function () {
+						drill.clear();
+						drillClearTimer = null;
+					}, 280 ); // after the fade-out
+				}
+				if ( ! state ) {
+					restoreAttribute( 'role', originalRole );
+					restoreAttribute( 'aria-modal', originalAriaModal );
+					restoreAttribute( 'aria-label', originalAriaLabel );
+					if ( wasOpen && toggle ) {
+						requestAnimationFrame( function () { toggle.focus( { preventScroll: true } ); } );
+					}
 				}
 				return;
 			}
@@ -282,7 +372,29 @@
 		}
 
 		document.addEventListener( 'keydown', function ( e ) {
-			if ( 'Escape' === e.key && wrap.classList.contains( 'ds-menu-open' ) ) { open( false ); }
+			if ( ! wrap.classList.contains( 'ds-menu-open' ) ) { return; }
+			if ( 'Escape' === e.key ) {
+				e.preventDefault();
+				open( false );
+				return;
+			}
+			if ( 'Tab' === e.key && isDrill && drill ) {
+				var panel = drill.activePanel();
+				if ( ! panel ) { return; }
+				var panelFocus = Array.prototype.slice.call( panel.querySelectorAll( 'a[href], button:not([disabled])' ) );
+				var focusable = ( toggle ? [ toggle ] : [] ).concat( panelFocus );
+				if ( ! focusable.length ) { return; }
+				var first = focusable[0];
+				var last = focusable[ focusable.length - 1 ];
+				var active = document.activeElement;
+				if ( e.shiftKey && ( active === first || active === panel || focusable.indexOf( active ) === -1 ) ) {
+					e.preventDefault();
+					last.focus();
+				} else if ( ! e.shiftKey && active === last ) {
+					e.preventDefault();
+					first.focus();
+				}
+			}
 		} );
 	}
 


### PR DESCRIPTION
## Summary

- add clear Back, section title, and Close states
- keep keyboard focus inside the drawer and restore it predictably
- add dialog and panel semantics plus safe-area and reduced-motion support
- preserve 44px or larger touch targets and keep the CTA visible in short landscape screens
- prevent rapid close and reopen from clearing the new panel

## Verification

- 20 Playwright candidate checks passed on https://risevolleyball.com/
- tested at 320x568, 390x844, 844x390, and 1440x900
- desktop closed state is pixel-identical to baseline
- JavaScript and PHP syntax checks passed