### PR TITLE
Improve Motion Card logo and gradient behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.52] - 2026-07-28
+### Added
+- **CTA Motion Cards: configurable default gradient overlay (GH #70).** Style 5 now includes an independent readability gradient with enable, colour, opacity, direction, and coverage controls. It is enabled by default, stays visible before interaction, and remains separate from image filters and hover effects.
+- **CTA Motion Cards: Logo Display modes (GH #70).** Editors can keep logos always visible or reveal them only when the card is hovered or keyboard-focused.
+
+### Changed
+- **The whole Motion Card now triggers logo motion (GH #70).** Entrance and hover animations start together with the card and background effects, replay after leaving and returning, work from keyboard focus, and respect reduced-motion preferences. Scale Up and Scale Down no longer require hovering directly over the logo.
+
 ## [1.9.51] - 2026-07-28
 ### Changed
 - **Menu: more usable and accessible mobile drill drawer.** The open control now says Close, drilled panels show a clear Back cue and current section title, and focus moves with navigation, stays inside the drawer, returns to the parent row on Back, and returns to the menu control on Escape. The drawer now exposes dialog and panel semantics, honors device safe areas and reduced motion, wraps long labels, retains 44px or larger touch targets, and compacts short landscape screens so the CTA remains visible. Rapid close and reopen actions no longer clear the fresh panel.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.51
+ * Version:           1.9.52
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.51' );
+define( 'DS_TOOLKIT_VERSION', '1.9.52' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-cta/css/frontend.css
+++ b/modules/ds-cta/css/frontend.css
@@ -130,42 +130,46 @@
 /* ---- Style 5: Motion Cards ---- */
 .ds-mcard-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:24px;}
 .ds-mcard{position:relative;display:block;overflow:hidden;border-radius:var(--mc-radius,14px);aspect-ratio:var(--mc-ratio,4 / 5);box-shadow:var(--mc-shadow,0 10px 26px -16px rgba(10,30,60,.35));text-decoration:none;color:inherit;transition:transform var(--mc-speed,.25s) ease,box-shadow var(--mc-speed,.25s) ease;transform:translateY(0);}
-.ds-mcard:hover{transform:translateY(calc(-1 * var(--mc-lift,6px)));box-shadow:var(--mc-shadow-hover,0 24px 48px -20px rgba(10,30,60,.5));}
+.ds-mcard:hover,.ds-mcard:focus-visible{transform:translateY(calc(-1 * var(--mc-lift,6px)));box-shadow:var(--mc-shadow-hover,0 24px 48px -20px rgba(10,30,60,.5));}
+.ds-mcard:focus-visible{outline:3px solid var(--fl-global-accent,#1476d4);outline-offset:3px;}
 .ds-mcard-bg{position:absolute;inset:0;background:#20242a center center/cover no-repeat;filter:var(--mc-fx,none);transform:scale(var(--mc-bg-scale,1));transition:filter var(--mc-speed,.25s) ease,transform calc(var(--mc-speed,.25s) * 2) ease;}
 .ds-mcard-tint{position:absolute;inset:0;background:var(--mc-tint,transparent);mix-blend-mode:var(--mc-blend,normal);pointer-events:none;transition:opacity var(--mc-speed,.25s) ease;}
+.ds-mcard-gradient{position:absolute;inset:0;z-index:1;background:var(--mc-gradient,linear-gradient(to top,rgba(0,0,0,.6),transparent 75%));pointer-events:none;}
 /* hover behaviours (module class picks one) */
-.ds-mcards--hov-clear .ds-mcard:hover .ds-mcard-bg{filter:none;}
-.ds-mcards--hov-clear .ds-mcard:hover .ds-mcard-tint{opacity:0;}
-.ds-mcards--hov-brighten .ds-mcard:hover .ds-mcard-bg{filter:brightness(1.12);}
-.ds-mcards--hov-zoom-in .ds-mcard:hover .ds-mcard-bg{transform:scale(var(--mc-zoom,1.06));}
+.ds-mcards--hov-clear .ds-mcard:is(:hover,:focus-visible) .ds-mcard-bg{filter:none;}
+.ds-mcards--hov-clear .ds-mcard:is(:hover,:focus-visible) .ds-mcard-tint{opacity:0;}
+.ds-mcards--hov-brighten .ds-mcard:is(:hover,:focus-visible) .ds-mcard-bg{filter:brightness(1.12);}
+.ds-mcards--hov-zoom-in .ds-mcard:is(:hover,:focus-visible) .ds-mcard-bg{transform:scale(var(--mc-zoom,1.06));}
 .ds-mcards--hov-zoom-out .ds-mcard-bg{transform:scale(var(--mc-zoom,1.06));}
-.ds-mcards--hov-zoom-out .ds-mcard:hover .ds-mcard-bg{transform:scale(1);}
+.ds-mcards--hov-zoom-out .ds-mcard:is(:hover,:focus-visible) .ds-mcard-bg{transform:scale(1);}
 /* body */
 .ds-mcard-body{position:absolute;left:0;right:0;bottom:0;z-index:2;display:flex;flex-direction:column;gap:4px;padding:18px 20px;background:linear-gradient(180deg,transparent,rgba(0,0,0,.55));}
 .ds-mcard-eyebrow{color:rgba(255,255,255,.85);font-size:.72rem;font-weight:700;letter-spacing:.12em;text-transform:uppercase;}
 .ds-mcard-title{color:var(--fl-global-white);font-weight:800;font-size:1.15rem;line-height:1.15;text-transform:uppercase;}
 /* logo overlay */
 .ds-mcard-logo{position:absolute;z-index:3;display:flex;align-items:center;justify-content:center;background:var(--mcl-bg,transparent);padding:var(--mcl-pad,10px);border-radius:var(--mcl-radius,999px);box-shadow:var(--mcl-shadow,none);opacity:0;}
+.ds-mcards--logo-always .ds-mcard-logo{opacity:1;}
+.ds-mcard:hover .ds-mcard-logo,.ds-mcard:focus-visible .ds-mcard-logo{opacity:1;}
 .ds-mcard-logo img{width:var(--mcl-size,84px);height:auto;display:block;object-fit:contain;}
 .ds-mcard-logo--center{top:50%;left:50%;transform:translate(-50%,-50%);}
 .ds-mcard-logo--top-left{top:16px;left:16px;}
 .ds-mcard-logo--top-right{top:16px;right:16px;}
 .ds-mcard-logo--bottom-left{bottom:72px;left:16px;}
 .ds-mcard-logo--bottom-right{bottom:72px;right:16px;}
-/* entrance: hidden until .is-in (IntersectionObserver), then the keyframe plays */
-.ds-mcard-logo.is-in,.ds-mcin--none{opacity:1;}
-.ds-mcard-logo.is-in{animation-duration:var(--mcl-dur,.6s);animation-delay:var(--mcl-delay,.15s);animation-timing-function:var(--mcl-ease,ease-out);animation-fill-mode:both;}
-.ds-mcin--fade.is-in{animation-name:dsMcFade;}
-.ds-mcin--fade-up.is-in{animation-name:dsMcFadeUp;}
-.ds-mcin--fade-down.is-in{animation-name:dsMcFadeDown;}
-.ds-mcin--fade-left.is-in{animation-name:dsMcFadeLeft;}
-.ds-mcin--fade-right.is-in{animation-name:dsMcFadeRight;}
-.ds-mcin--slide-up.is-in{animation-name:dsMcSlideUp;}
-.ds-mcin--slide-down.is-in{animation-name:dsMcSlideDown;}
-.ds-mcin--slide-left.is-in{animation-name:dsMcSlideLeft;}
-.ds-mcin--slide-right.is-in{animation-name:dsMcSlideRight;}
-.ds-mcin--zoom-in.is-in{animation-name:dsMcZoomIn;}
-.ds-mcin--zoom-out.is-in{animation-name:dsMcZoomOut;}
+/* The whole card activates the logo. The class is managed by frontend.js so
+   pointer and keyboard interactions share one replayable animation state. */
+.ds-mcin--fade{--mcl-animation:dsMcFade;}
+.ds-mcin--fade-up{--mcl-animation:dsMcFadeUp;}
+.ds-mcin--fade-down{--mcl-animation:dsMcFadeDown;}
+.ds-mcin--fade-left{--mcl-animation:dsMcFadeLeft;}
+.ds-mcin--fade-right{--mcl-animation:dsMcFadeRight;}
+.ds-mcin--slide-up{--mcl-animation:dsMcSlideUp;}
+.ds-mcin--slide-down{--mcl-animation:dsMcSlideDown;}
+.ds-mcin--slide-left{--mcl-animation:dsMcSlideLeft;}
+.ds-mcin--slide-right{--mcl-animation:dsMcSlideRight;}
+.ds-mcin--zoom-in{--mcl-animation:dsMcZoomIn;}
+.ds-mcin--zoom-out{--mcl-animation:dsMcZoomOut;}
+.ds-mcard.is-logo-active .ds-mcard-logo{opacity:1;animation-name:var(--mcl-animation,none);animation-duration:var(--mcl-dur,.6s);animation-delay:var(--mcl-delay,0s);animation-timing-function:var(--mcl-ease,ease-out);animation-fill-mode:both;}
 @keyframes dsMcFade{from{opacity:0}to{opacity:1}}
 @keyframes dsMcFadeUp{from{opacity:0;translate:0 18px}to{opacity:1;translate:0 0}}
 @keyframes dsMcFadeDown{from{opacity:0;translate:0 -18px}to{opacity:1;translate:0 0}}
@@ -178,14 +182,14 @@
 @keyframes dsMcZoomIn{from{opacity:0;scale:.6}to{opacity:1;scale:1}}
 @keyframes dsMcZoomOut{from{opacity:0;scale:1.35}to{opacity:1;scale:1}}
 /* logo hover animations (composited on the inner img so entrance transforms on the wrapper survive) */
-.ds-mchov--scale-up:hover img{transform:scale(1.12);}
-.ds-mchov--scale-down:hover img{transform:scale(.9);}
-.ds-mcard:hover .ds-mchov--float img{animation:dsMcFloat 1.6s ease-in-out infinite;}
-.ds-mcard:hover .ds-mchov--bounce img{animation:dsMcBounce .7s cubic-bezier(.28,.84,.42,1) infinite;}
-.ds-mcard:hover .ds-mchov--rotate img{transform:rotate(8deg);}
-.ds-mcard:hover .ds-mchov--pulse img{animation:dsMcPulse 1.2s ease-in-out infinite;}
-.ds-mcard:hover .ds-mchov--fade img{opacity:.55;}
-.ds-mcard:hover .ds-mchov--glow{box-shadow:0 0 24px 4px rgba(255,255,255,.55);}
+.ds-mcard.is-logo-active .ds-mchov--scale-up img{transform:scale(1.12);}
+.ds-mcard.is-logo-active .ds-mchov--scale-down img{transform:scale(.9);}
+.ds-mcard.is-logo-active .ds-mchov--float img{animation:dsMcFloat 1.6s ease-in-out infinite;}
+.ds-mcard.is-logo-active .ds-mchov--bounce img{animation:dsMcBounce .7s cubic-bezier(.28,.84,.42,1) infinite;}
+.ds-mcard.is-logo-active .ds-mchov--rotate img{transform:rotate(8deg);}
+.ds-mcard.is-logo-active .ds-mchov--pulse img{animation:dsMcPulse 1.2s ease-in-out infinite;}
+.ds-mcard.is-logo-active .ds-mchov--fade img{opacity:.55;}
+.ds-mcard.is-logo-active .ds-mchov--glow{box-shadow:0 0 24px 4px rgba(255,255,255,.55);}
 .ds-mcard-logo img{transition:transform var(--mc-speed,.25s) ease,opacity var(--mc-speed,.25s) ease;}
 @keyframes dsMcFloat{0%,100%{translate:0 0}50%{translate:0 -8px}}
 @keyframes dsMcBounce{0%,100%{translate:0 0}40%{translate:0 -12px}60%{translate:0 -6px}}
@@ -194,5 +198,5 @@
 @media(max-width:600px){.ds-mcard-grid{grid-template-columns:1fr;}}
 @media(prefers-reduced-motion:reduce){
   .ds-mcard,.ds-mcard-bg,.ds-mcard-logo,.ds-mcard-logo img{transition:none !important;animation:none !important;}
-  .ds-mcard-logo{opacity:1 !important;}
+  .ds-mcards--logo-always .ds-mcard-logo,.ds-mcard.is-logo-active .ds-mcard-logo{opacity:1 !important;}
 }

--- a/modules/ds-cta/ds-cta.php
+++ b/modules/ds-cta/ds-cta.php
@@ -56,8 +56,10 @@ class DS_CTA_Module extends FLBuilderModule {
 		$logo_in  = preg_replace( '/[^a-z-]/', '', (string) ( $s->mcl_in ?? 'fade-up' ) );
 		$logo_hov = preg_replace( '/[^a-z-]/', '', (string) ( $s->mcl_hover ?? 'float' ) );
 		$logo_pos = in_array( $s->mcl_pos ?? 'center', array( 'center', 'top-left', 'top-right', 'bottom-left', 'bottom-right' ), true ) ? ( $s->mcl_pos ?? 'center' ) : 'center';
+		$logo_display = in_array( $s->mcl_display ?? 'always', array( 'always', 'hover' ), true ) ? ( $s->mcl_display ?? 'always' ) : 'always';
+		$gradient = ( $s->mcgrad_enable ?? 'yes' ) === 'yes';
 
-		$mods = 'ds-cta ds-cta--style5 ds-mcards ds-mcards--fx-' . $fx_base . ' ds-mcards--hov-' . $fx_hover;
+		$mods = 'ds-cta ds-cta--style5 ds-mcards ds-mcards--fx-' . $fx_base . ' ds-mcards--hov-' . $fx_hover . ' ds-mcards--logo-' . $logo_display;
 		echo '<section class="' . esc_attr( $mods ) . '"><div class="ds-cta-wrap">';
 
 		if ( ( $s->show_header ?? 'yes' ) === 'yes' && ( ! empty( $s->heading ) || ! empty( $s->header_label ) ) ) {
@@ -85,6 +87,9 @@ class DS_CTA_Module extends FLBuilderModule {
 			echo '<a class="ds-mcard" href="' . $url . '" target="' . esc_attr( $target ) . '"' . $rel . '>';
 			echo '<span class="ds-mcard-bg"' . ( $img ? ' style="background-image:url(' . esc_url( $img ) . ')"' : '' ) . ' aria-hidden="true"></span>';
 			echo '<span class="ds-mcard-tint" aria-hidden="true"></span>';
+			if ( $gradient ) {
+				echo '<span class="ds-mcard-gradient" aria-hidden="true"></span>';
+			}
 			if ( '' !== $logo ) {
 				echo '<span class="ds-mcard-logo ds-mcard-logo--' . esc_attr( $logo_pos ) . ' ds-mcin--' . esc_attr( $logo_in ) . ' ds-mchov--' . esc_attr( $logo_hov ) . '"><img src="' . esc_url( $logo ) . '" alt="" loading="lazy" /></span>';
 			}
@@ -966,6 +971,29 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 			'mcard_fx' => array(
 				'title'  => __( 'Background Effects', 'ds-toolkit' ),
 				'fields' => array(
+					'mcgrad_enable' => array(
+						'type'    => 'select',
+						'label'   => __( 'Default Gradient', 'ds-toolkit' ),
+						'default' => 'yes',
+						'options' => array( 'yes' => __( 'Enabled', 'ds-toolkit' ), 'no' => __( 'Disabled', 'ds-toolkit' ) ),
+						'toggle'  => array( 'yes' => array( 'fields' => array( 'mcgrad_color', 'mcgrad_opacity', 'mcgrad_direction', 'mcgrad_coverage' ) ) ),
+						'help'    => __( 'Adds a persistent gradient above the image for consistent text readability. It works independently from the default and hover effects below.', 'ds-toolkit' ),
+					),
+					'mcgrad_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Gradient Colour', 'ds-toolkit' ), 'default' => 'var(--fl-global-dark-background)', 'show_reset' => true ),
+					'mcgrad_opacity' => array( 'type' => 'unit', 'label' => __( 'Gradient Opacity', 'ds-toolkit' ), 'default' => '60', 'description' => '%', 'slider' => array( 'min' => 0, 'max' => 100, 'step' => 1 ) ),
+					'mcgrad_direction' => array(
+						'type'    => 'select',
+						'label'   => __( 'Gradient Direction', 'ds-toolkit' ),
+						'default' => 'bottom-top',
+						'options' => array(
+							'top-bottom' => __( 'Top to Bottom', 'ds-toolkit' ),
+							'bottom-top' => __( 'Bottom to Top', 'ds-toolkit' ),
+							'left-right' => __( 'Left to Right', 'ds-toolkit' ),
+							'right-left' => __( 'Right to Left', 'ds-toolkit' ),
+							'radial'     => __( 'Radial', 'ds-toolkit' ),
+						),
+					),
+					'mcgrad_coverage' => array( 'type' => 'unit', 'label' => __( 'Gradient Coverage', 'ds-toolkit' ), 'default' => '75', 'description' => '%', 'slider' => array( 'min' => 10, 'max' => 100, 'step' => 1 ), 'help' => __( 'Controls how far the gradient extends from its solid edge. Radial mode uses it as the width of the dark outer fade.', 'ds-toolkit' ) ),
 					'mcfx_base'    => array(
 						'type'    => 'select',
 						'label'   => __( 'Default Effect', 'ds-toolkit' ),
@@ -995,15 +1023,25 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 				'title'       => __( 'Logo Overlay', 'ds-toolkit' ),
 				'description' => __( 'Styling + animation for each card\'s Logo / Badge image (set per card).', 'ds-toolkit' ),
 				'fields'      => array(
+					'mcl_display' => array(
+						'type'    => 'select',
+						'label'   => __( 'Logo Display', 'ds-toolkit' ),
+						'default' => 'always',
+						'options' => array(
+							'always' => __( 'Always Visible', 'ds-toolkit' ),
+							'hover'  => __( 'Show On Card Hover', 'ds-toolkit' ),
+						),
+						'help'    => __( 'The whole card triggers the logo animation. Hover mode hides the logo until the card is hovered or keyboard-focused.', 'ds-toolkit' ),
+					),
 					'mcl_pos'    => array( 'type' => 'select', 'label' => __( 'Position', 'ds-toolkit' ), 'default' => 'center', 'options' => array( 'center' => __( 'Center', 'ds-toolkit' ), 'top-left' => __( 'Top Left', 'ds-toolkit' ), 'top-right' => __( 'Top Right', 'ds-toolkit' ), 'bottom-left' => __( 'Bottom Left', 'ds-toolkit' ), 'bottom-right' => __( 'Bottom Right', 'ds-toolkit' ) ) ),
 					'mcl_size'   => array( 'type' => 'unit', 'label' => __( 'Size', 'ds-toolkit' ), 'default' => '84', 'description' => 'px', 'slider' => array( 'min' => 32, 'max' => 200, 'step' => 2 ), 'preview' => array( 'type' => 'css', 'selector' => '.ds-mcard-logo img', 'property' => 'width', 'unit' => 'px' ) ),
 					'mcl_bg'     => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Backing Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true, 'help' => __( 'Optional plate behind the logo. Blank = none.', 'ds-toolkit' ) ),
 					'mcl_pad'    => array( 'type' => 'unit', 'label' => __( 'Padding', 'ds-toolkit' ), 'default' => '10', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 40, 'step' => 1 ) ),
 					'mcl_radius' => array( 'type' => 'unit', 'label' => __( 'Corner Radius', 'ds-toolkit' ), 'default' => '999', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 999, 'step' => 1 ) ),
 					'mcl_shadow' => array( 'type' => 'select', 'label' => __( 'Shadow', 'ds-toolkit' ), 'default' => 'soft', 'options' => array( 'none' => __( 'None', 'ds-toolkit' ), 'soft' => __( 'Soft', 'ds-toolkit' ), 'medium' => __( 'Medium', 'ds-toolkit' ), 'strong' => __( 'Strong', 'ds-toolkit' ) ) ),
-					'mcl_in'     => array( 'type' => 'select', 'label' => __( 'Entrance Animation', 'ds-toolkit' ), 'default' => 'fade-up', 'options' => array( 'none' => __( 'None', 'ds-toolkit' ), 'fade' => __( 'Fade In', 'ds-toolkit' ), 'fade-up' => __( 'Fade Up', 'ds-toolkit' ), 'fade-down' => __( 'Fade Down', 'ds-toolkit' ), 'fade-left' => __( 'Fade Left', 'ds-toolkit' ), 'fade-right' => __( 'Fade Right', 'ds-toolkit' ), 'slide-up' => __( 'Slide Up', 'ds-toolkit' ), 'slide-down' => __( 'Slide Down', 'ds-toolkit' ), 'slide-left' => __( 'Slide Left', 'ds-toolkit' ), 'slide-right' => __( 'Slide Right', 'ds-toolkit' ), 'zoom-in' => __( 'Zoom In', 'ds-toolkit' ), 'zoom-out' => __( 'Zoom Out', 'ds-toolkit' ) ), 'help' => __( 'Plays when the card scrolls into view. Skipped for reduced-motion visitors.', 'ds-toolkit' ) ),
+					'mcl_in'     => array( 'type' => 'select', 'label' => __( 'Card Hover Entrance', 'ds-toolkit' ), 'default' => 'fade-up', 'options' => array( 'none' => __( 'None', 'ds-toolkit' ), 'fade' => __( 'Fade In', 'ds-toolkit' ), 'fade-up' => __( 'Fade Up', 'ds-toolkit' ), 'fade-down' => __( 'Fade Down', 'ds-toolkit' ), 'fade-left' => __( 'Fade Left', 'ds-toolkit' ), 'fade-right' => __( 'Fade Right', 'ds-toolkit' ), 'slide-up' => __( 'Slide Up', 'ds-toolkit' ), 'slide-down' => __( 'Slide Down', 'ds-toolkit' ), 'slide-left' => __( 'Slide Left', 'ds-toolkit' ), 'slide-right' => __( 'Slide Right', 'ds-toolkit' ), 'zoom-in' => __( 'Zoom In', 'ds-toolkit' ), 'zoom-out' => __( 'Zoom Out', 'ds-toolkit' ) ), 'help' => __( 'Plays whenever the whole card is hovered or keyboard-focused. It can replay after the pointer leaves and returns. Skipped for reduced-motion visitors.', 'ds-toolkit' ) ),
 					'mcl_dur'    => array( 'type' => 'unit', 'label' => __( 'Animation Duration', 'ds-toolkit' ), 'default' => '600', 'description' => 'ms', 'slider' => array( 'min' => 100, 'max' => 2000, 'step' => 50 ) ),
-					'mcl_delay'  => array( 'type' => 'unit', 'label' => __( 'Animation Delay', 'ds-toolkit' ), 'default' => '150', 'description' => 'ms', 'slider' => array( 'min' => 0, 'max' => 2000, 'step' => 50 ) ),
+					'mcl_delay'  => array( 'type' => 'unit', 'label' => __( 'Animation Delay', 'ds-toolkit' ), 'default' => '0', 'description' => 'ms', 'slider' => array( 'min' => 0, 'max' => 2000, 'step' => 50 ) ),
 					'mcl_ease'   => array( 'type' => 'select', 'label' => __( 'Animation Easing', 'ds-toolkit' ), 'default' => 'ease-out', 'options' => array( 'ease' => 'Ease', 'ease-out' => 'Ease Out', 'ease-in-out' => 'Ease In-Out', 'cubic-bezier(.34,1.56,.64,1)' => __( 'Spring (overshoot)', 'ds-toolkit' ) ) ),
 					'mcl_hover'  => array( 'type' => 'select', 'label' => __( 'Hover Animation', 'ds-toolkit' ), 'default' => 'float', 'options' => array( 'none' => __( 'None', 'ds-toolkit' ), 'scale-up' => __( 'Scale Up', 'ds-toolkit' ), 'scale-down' => __( 'Scale Down', 'ds-toolkit' ), 'float' => __( 'Float', 'ds-toolkit' ), 'bounce' => __( 'Bounce', 'ds-toolkit' ), 'rotate' => __( 'Rotate', 'ds-toolkit' ), 'pulse' => __( 'Pulse', 'ds-toolkit' ), 'fade' => __( 'Fade', 'ds-toolkit' ), 'glow' => __( 'Glow', 'ds-toolkit' ) ) ),
 				),

--- a/modules/ds-cta/includes/frontend.css.php
+++ b/modules/ds-cta/includes/frontend.css.php
@@ -313,6 +313,20 @@ if ( 'style3' === $style ) {
 	}
 	$zoom = 1 + max( 1, min( 25, (int) ( $settings->mcfx_zoom ?? 6 ) ) ) / 100;
 
+	// Persistent readability gradient, independent from image effects.
+	$grad_color = $mix( $settings->mcgrad_color ?? 'var(--fl-global-dark-background)', $settings->mcgrad_opacity ?? 60 );
+	if ( '' === $grad_color ) { $grad_color = 'color-mix(in srgb, #000 60%, transparent)'; }
+	$grad_coverage = max( 10, min( 100, (int) ( $settings->mcgrad_coverage ?? 75 ) ) );
+	$grad_direction = in_array( $settings->mcgrad_direction ?? 'bottom-top', array( 'top-bottom', 'bottom-top', 'left-right', 'right-left', 'radial' ), true ) ? ( $settings->mcgrad_direction ?? 'bottom-top' ) : 'bottom-top';
+	$gradients = array(
+		'top-bottom' => "linear-gradient(to bottom, {$grad_color} 0%, transparent {$grad_coverage}%)",
+		'bottom-top' => "linear-gradient(to top, {$grad_color} 0%, transparent {$grad_coverage}%)",
+		'left-right' => "linear-gradient(to right, {$grad_color} 0%, transparent {$grad_coverage}%)",
+		'right-left' => "linear-gradient(to left, {$grad_color} 0%, transparent {$grad_coverage}%)",
+		'radial'     => 'radial-gradient(ellipse at center, transparent 0%, transparent ' . max( 0, 100 - $grad_coverage ) . "%, {$grad_color} 100%)",
+	);
+	$gradient = $gradients[ $grad_direction ];
+
 	// Logo overlay.
 	$lsz  = $u( $settings->mcl_size ?? '', 84 );
 	$lpad = $u( $settings->mcl_pad ?? '', 10 );
@@ -320,11 +334,11 @@ if ( 'style3' === $style ) {
 	$lbg  = $col( $settings->mcl_bg ?? '' ) ?: 'transparent';
 	$lsh  = $settings->mcl_shadow ?? 'soft'; if ( ! isset( $sh_map[ $lsh ] ) ) { $lsh = 'soft'; }
 	$ldur = max( 50, $u( $settings->mcl_dur ?? '', 600 ) );
-	$ldel = max( 0, $u( $settings->mcl_delay ?? '', 150 ) );
+	$ldel = max( 0, $u( $settings->mcl_delay ?? '', 0 ) );
 	$ease_allow = array( 'ease', 'ease-out', 'ease-in-out', 'cubic-bezier(.34,1.56,.64,1)' );
 	$lease = in_array( $settings->mcl_ease ?? 'ease-out', $ease_allow, true ) ? ( $settings->mcl_ease ?? 'ease-out' ) : 'ease-out';
 
-	echo "$node .ds-mcard-grid{--mc-ratio:{$ratio};--mc-radius:{$rad}px;--mc-lift:{$lift}px;--mc-speed:{$spd}ms;--mc-shadow:{$sh_map[$sh]};--mc-shadow-hover:{$shh_map[$sh]};--mc-fx:{$fx};--mc-tint:{$tint};--mc-blend:{$blend};--mc-zoom:{$zoom};--mcl-size:{$lsz}px;--mcl-pad:{$lpad}px;--mcl-radius:{$lrad}px;--mcl-bg:{$lbg};--mcl-shadow:{$sh_map[$lsh]};--mcl-dur:{$ldur}ms;--mcl-delay:{$ldel}ms;--mcl-ease:{$lease};}\n";
+	echo "$node .ds-mcard-grid{--mc-ratio:{$ratio};--mc-radius:{$rad}px;--mc-lift:{$lift}px;--mc-speed:{$spd}ms;--mc-shadow:{$sh_map[$sh]};--mc-shadow-hover:{$shh_map[$sh]};--mc-fx:{$fx};--mc-tint:{$tint};--mc-blend:{$blend};--mc-zoom:{$zoom};--mc-gradient:{$gradient};--mcl-size:{$lsz}px;--mcl-pad:{$lpad}px;--mcl-radius:{$lrad}px;--mcl-bg:{$lbg};--mcl-shadow:{$sh_map[$lsh]};--mcl-dur:{$ldur}ms;--mcl-delay:{$ldel}ms;--mcl-ease:{$lease};}\n";
 
 	$typo = array( 'heading_typography' => '.ds-cta-heading', 'title_typography' => '.ds-mcard-title', 'eyebrow_typography' => '.ds-mcard-eyebrow' );
 } else {

--- a/modules/ds-cta/js/frontend.js
+++ b/modules/ds-cta/js/frontend.js
@@ -1,22 +1,29 @@
-/* LeagueApps CTA — Motion Cards (Style 5) logo entrance trigger. Vanilla, idempotent. */
+/* LeagueApps CTA: Motion Cards card-wide logo trigger. Vanilla, idempotent. */
 (function () {
 	function boot(root) {
 		(root || document).querySelectorAll('.ds-mcards').forEach(function (sec) {
 			if (sec.dsMcInit) { return; }
 			sec.dsMcInit = true;
-			var logos = [].slice.call(sec.querySelectorAll('.ds-mcard-logo'));
-			if (!logos.length) { return; }
-			var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-			if (reduce || !('IntersectionObserver' in window)) {
-				logos.forEach(function (l) { l.classList.add('is-in'); });
-				return;
-			}
-			var io = new IntersectionObserver(function (entries) {
-				entries.forEach(function (e) {
-					if (e.isIntersecting) { e.target.classList.add('is-in'); io.unobserve(e.target); }
-				});
-			}, { threshold: 0.25 });
-			logos.forEach(function (l) { io.observe(l); });
+			sec.querySelectorAll('.ds-mcard').forEach(function (card) {
+				if (!card.querySelector('.ds-mcard-logo')) { return; }
+				var enterEvent = ('onpointerenter' in window) ? 'pointerenter' : 'mouseenter';
+				var leaveEvent = ('onpointerleave' in window) ? 'pointerleave' : 'mouseleave';
+
+				function activate() {
+					card.classList.remove('is-logo-active');
+					void card.offsetWidth;
+					card.classList.add('is-logo-active');
+				}
+
+				function deactivate() {
+					card.classList.remove('is-logo-active');
+				}
+
+				card.addEventListener(enterEvent, activate);
+				card.addEventListener(leaveEvent, deactivate);
+				card.addEventListener('focus', activate);
+				card.addEventListener('blur', deactivate);
+			});
 		});
 	}
 	if ('loading' !== document.readyState) { boot(); } else { document.addEventListener('DOMContentLoaded', function () { boot(); }); }


### PR DESCRIPTION
## Summary

- make the whole Motion Card trigger logo entrance and hover motion
- add Always Visible and Show On Card Hover logo modes
- add an independent default gradient with colour, opacity, direction, and coverage controls
- add keyboard focus parity, a visible focus ring, animation replay, and reduced-motion behavior

## Validation

- PHP syntax checks passed for the CTA module and dynamic CSS
- JavaScript syntax check passed
- 10 Playwright interaction and reduced-motion checks passed
- responsive layouts passed at 320, 600, 1024, and 1280px with zero horizontal overflow
- PHP render tests passed for default, hover-only, and gradient-disabled markup
- all five gradient directions and editor field toggles passed isolated checks

Closes #70