### PR TITLE
feat: mega Max Width fix + responsive offset + viewport clamp (#75) (1.9.53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.53] - 2026-07-28
+### Fixed
+- **Menu: mega panel Max Width now works with Auto sizing (GH #75).** The panel's 460px min-width silently beat any smaller cap (min-width wins over max-width in CSS); with a Max Width set, min-width now yields and column content wraps inside the cap.
+
+### Added
+- **Menu: mega panel Horizontal Offset (responsive) + Keep Panel On Screen (GH #75).** Nudge the auto-width panel left/right per breakpoint (composes with alignment), and an on-by-default smart clamp shifts the panel back into view whenever it would overflow past the browser edge -- measured fresh on every hover, applied on top of the editor's offset.
+
 ## [1.9.52] - 2026-07-28
 ### Added
 - **CTA Motion Cards: configurable default gradient overlay (GH #70).** Style 5 now includes an independent readability gradient with enable, colour, opacity, direction, and coverage controls. It is enabled by default, stays visible before interaction, and remains separate from image filters and hover effects.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.52
+ * Version:           1.9.53
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.52' );
+define( 'DS_TOOLKIT_VERSION', '1.9.53' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/ds-menu.php
+++ b/modules/ds-menu/ds-menu.php
@@ -130,7 +130,8 @@ class DS_Menu_Module extends FLBuilderModule {
 			$drill_attrs .= ' data-drill-logo-align="' . ( ( $s->drill_logo_align ?? 'right' ) === 'left' ? 'left' : 'right' ) . '"';
 		}
 
-		echo '<nav class="ds-menu-wrap' . ( 'drill' === $mstyle ? ' ds-menu-wrap--drill' : '' ) . '"' . $drill_attrs . ' aria-label="' . esc_attr__( 'Primary', 'ds-toolkit' ) . '">';
+		$megasmart = ( ( $s->mega_enabled ?? 'no' ) === 'yes' && ( $s->mega_smart ?? 'yes' ) === 'yes' );
+		echo '<nav class="ds-menu-wrap' . ( 'drill' === $mstyle ? ' ds-menu-wrap--drill' : '' ) . ( $megasmart ? ' ds-menu-wrap--megasmart' : '' ) . '"' . $drill_attrs . ' aria-label="' . esc_attr__( 'Primary', 'ds-toolkit' ) . '">';
 
 		// Hamburger toggle (animates into an X via CSS when the overlay opens).
 		echo '<button type="button" class="ds-menu-toggle" aria-expanded="false" aria-label="' . esc_attr__( 'Toggle menu', 'ds-toolkit' ) . '">';
@@ -307,7 +308,7 @@ FLBuilder::register_module( 'DS_Menu_Module', array(
 						'default' => 'no',
 						'options' => array( 'no' => __( 'No', 'ds-toolkit' ), 'yes' => __( 'Yes', 'ds-toolkit' ) ),
 						'help'    => __( 'Lets top-level items open as a wide multi-column panel. Pick which items below; leave the picker empty to make every item that has sub-items a mega panel.', 'ds-toolkit' ),
-						'toggle'  => array( 'yes' => array( 'fields' => array( 'mega_picker', 'mega_items', 'mega_columns', 'mega_width', 'mega_align', 'mega_max_width' ) ) ),
+						'toggle'  => array( 'yes' => array( 'fields' => array( 'mega_picker', 'mega_items', 'mega_columns', 'mega_width', 'mega_align', 'mega_max_width', 'mega_offset_x', 'mega_smart' ) ) ),
 					),
 					// In-builder picker: lists this menu's top-level items as clickable pills.
 					// The pill UI is drawn by js/admin.js, which writes the chosen items
@@ -359,7 +360,7 @@ FLBuilder::register_module( 'DS_Menu_Module', array(
 							'viewport' => __( 'Full screen width', 'ds-toolkit' ),
 						),
 						'help'    => __( 'Auto sizes the panel under its item. Full menu width spans the menu bar. Full screen width goes edge to edge.', 'ds-toolkit' ),
-						'toggle'  => array( 'auto' => array( 'fields' => array( 'mega_align', 'mega_max_width' ) ) ),
+						'toggle'  => array( 'auto' => array( 'fields' => array( 'mega_align', 'mega_max_width', 'mega_offset_x', 'mega_smart' ) ) ),
 					),
 					'mega_align'     => array(
 						'type'    => 'select',
@@ -377,8 +378,24 @@ FLBuilder::register_module( 'DS_Menu_Module', array(
 						'label'       => __( 'Max Width', 'ds-toolkit' ),
 						'default'     => '',
 						'description' => 'px',
-						'help'        => __( 'Optional cap on the auto-width panel. Blank keeps the default.', 'ds-toolkit' ),
-						'slider'      => array( 'min' => 300, 'max' => 1200, 'step' => 10 ),
+						'help'        => __( 'Cap on the auto-width panel: it sizes to its columns up to this width, then stops (content wraps inside). Blank keeps the default.', 'ds-toolkit' ),
+						'slider'      => array( 'min' => 200, 'max' => 1200, 'step' => 10 ),
+					),
+					'mega_offset_x'  => array(
+						'type'        => 'unit',
+						'label'       => __( 'Horizontal Offset', 'ds-toolkit' ),
+						'default'     => '',
+						'description' => 'px',
+						'responsive'  => true,
+						'slider'      => array( 'min' => -300, 'max' => 300, 'step' => 2 ),
+						'help'        => __( 'Nudge the panel left (negative) or right (positive), per breakpoint. Desktop menu only — below the Mobile Breakpoint the mega stacks inside the mobile menu, so smaller-breakpoint values matter only when your Mobile Breakpoint is set low.', 'ds-toolkit' ),
+					),
+					'mega_smart'     => array(
+						'type'    => 'select',
+						'label'   => __( 'Keep Panel On Screen', 'ds-toolkit' ),
+						'default' => 'yes',
+						'options' => array( 'yes' => __( 'Yes (auto-shift into view)', 'ds-toolkit' ), 'no' => __( 'No', 'ds-toolkit' ) ),
+						'help'    => __( 'If the panel would overflow past the browser edge, it automatically shifts back into view — applied on top of your Horizontal Offset.', 'ds-toolkit' ),
 					),
 				),
 			),

--- a/modules/ds-menu/includes/frontend.css.php
+++ b/modules/ds-menu/includes/frontend.css.php
@@ -185,9 +185,43 @@ if ( 'bar' === $mw ) {
 	} elseif ( 'right' === $mal ) {
 		echo "\t$mPan { left: auto; right: 0; }\n";
 	}
-	if ( $mmax ) { echo "\t$mPan { max-width: {$mmax}px; }\n"; }
+	// Max Width (GH #75): min-width must yield or it silently beats any cap below
+	// the 460px base (min-width wins over max-width in CSS) — the "Max Width has
+	// no effect" report. Columns are minmax(0,1fr), so content wraps inside.
+	if ( $mmax ) { echo "\t$mPan { max-width: {$mmax}px; min-width: 0; }\n"; }
+	// Horizontal Offset (GH #75) + the smart viewport shift written by JS,
+	// composed so the clamp stacks on top of the editor's offset.
+	$mox = ( isset( $settings->mega_offset_x ) && '' !== $settings->mega_offset_x ) ? (int) $settings->mega_offset_x : 0;
+	if ( 'right' === $mal ) {
+		echo "\t$mPan { margin-right: calc(" . ( -1 * $mox ) . "px - var(--ds-mega-shift, 0px)); }\n";
+	} else {
+		echo "\t$mPan { margin-left: calc({$mox}px + var(--ds-mega-shift, 0px)); }\n";
+	}
 }
 echo "}\n";
+
+/* Responsive Horizontal Offset overrides (GH #75). The mega only exists as a
+   dropdown ABOVE the menu breakpoint, so each override window is intersected
+   with it; breakpoint values below the menu breakpoint simply never apply. */
+if ( 'auto' === $mw ) {
+	$gs_bp   = FLBuilderModel::get_global_settings();
+	$bp_lg   = (int) ( $gs_bp->large_breakpoint ?? 1200 );
+	list( $bpm, $bpr ) = DS_Module_UI::breakpoints();
+	$windows = array(
+		'mega_offset_x_large'      => $bp_lg,
+		'mega_offset_x_medium'     => $bpm,
+		'mega_offset_x_responsive' => $bpr,
+	);
+	foreach ( $windows as $key => $upper ) {
+		if ( isset( $settings->$key ) && '' !== $settings->$key && $upper > $bp ) {
+			$v = (int) $settings->$key;
+			$rule = ( 'right' === $mal )
+				? 'margin-right: calc(' . ( -1 * $v ) . 'px - var(--ds-mega-shift, 0px));'
+				: "margin-left: calc({$v}px + var(--ds-mega-shift, 0px));";
+			echo "@media (min-width:" . ( $bp + 1 ) . "px) and (max-width:{$upper}px){ $mPan { {$rule} } }\n";
+		}
+	}
+}
 
 /* ---- Mega column heading style (the bold link atop each mega column) ----
    Selector includes .ds-mega-col so these out-rank the generic ".ds-mega a"

--- a/modules/ds-menu/js/frontend.js
+++ b/modules/ds-menu/js/frontend.js
@@ -409,6 +409,28 @@
 			if ( wrap.classList.contains( 'ds-menu-open' ) ) { return; } // mobile overlay
 			var li = e.target && e.target.closest ? e.target.closest( '.ds-menu-item.has-children' ) : null;
 			if ( ! li || ! wrap.contains( li ) ) { return; }
+
+			// Mega smart viewport clamp (Keep Panel On Screen): if the panel would
+			// overflow past either browser edge, shift it back in via a CSS var the
+			// alignment/offset rules compose with. Measured fresh on every hover.
+			if ( li.classList.contains( 'is-mega' ) && wrap.classList.contains( 'ds-menu-wrap--megasmart' ) ) {
+				var pan = null;
+				for ( var m = 0; m < li.children.length; m++ ) {
+					if ( li.children[ m ].classList && li.children[ m ].classList.contains( 'ds-mega' ) ) { pan = li.children[ m ]; break; }
+				}
+				if ( pan ) {
+					pan.style.setProperty( '--ds-mega-shift', '0px' );
+					var pr = pan.getBoundingClientRect();
+					if ( pr.width > 0 ) {
+						var shift = 0;
+						if ( pr.right > window.innerWidth - 8 ) { shift = ( window.innerWidth - 8 ) - pr.right; }
+						else if ( pr.left < 8 ) { shift = 8 - pr.left; }
+						if ( shift ) { pan.style.setProperty( '--ds-mega-shift', Math.round( shift ) + 'px' ); }
+					}
+				}
+				return; // mega items never use the flyout flip below
+			}
+
 			var sub = null;
 			for ( var i = 0; i < li.children.length; i++ ) {
 				if ( li.children[ i ].classList && li.children[ i ].classList.contains( 'ds-submenu' ) ) { sub = li.children[ i ]; break; }


### PR DESCRIPTION
All three parts of #75:

1. **Max Width respected in Auto sizing (bug).** Root cause: the panel's static `min-width: 460px` silently beats any smaller cap — in CSS, min-width wins over max-width. With a Max Width set, min-width now yields (`min-width: 0`), and since columns are `minmax(0,1fr)`, content wraps inside the cap instead of expanding.
2. **Responsive Horizontal Offset.** New unit field (responsive — every enabled BB breakpoint gets its own value): negative moves left, positive right. Emitted as margins that compose with all three alignments; breakpoint windows are intersected with the menu breakpoint since the mega only exists as a dropdown above it.
3. **Keep Panel On Screen (default on).** On hover the panel is measured; if it would overflow past either browser edge it shifts back in via a `--ds-mega-shift` CSS var, applied ON TOP of the editor's offset — same measurement approach as the existing flyout edge-flip.

Closes #75.
