### PR TITLE
fix: mega auto panel intrinsic-width collapse (1.9.54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.54] - 2026-07-28
+### Fixed
+- **Mega panel (Auto) no longer collapses into letter-wrapped columns.** v1.9.53's Max-Width fix removed the panel's min-width floor when a cap was set, exposing an intrinsic-width collapse of the absolutely-positioned grid (fr tracks contribute ~0 to shrink-to-fit width) -- panels squeezed to a few pixels per column, wrapping headings one letter per line (seen on pennathleticsc). The panel now declares width: max-content (truly "sized to columns"), columns floor at min-content so text wraps at words never letters, and an overflow guard keeps extreme caps readable.
+
 ## [1.9.53] - 2026-07-28
 ### Fixed
 - **Menu: mega panel Max Width now works with Auto sizing (GH #75).** The panel's 460px min-width silently beat any smaller cap (min-width wins over max-width in CSS); with a Max Width set, min-width now yields and column content wraps inside the cap.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.53
+ * Version:           1.9.54
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.53' );
+define( 'DS_TOOLKIT_VERSION', '1.9.54' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/css/frontend.css
+++ b/modules/ds-menu/css/frontend.css
@@ -36,8 +36,12 @@
 /* Mega panel */
 .ds-mega {
 	position: absolute; top: 100%; left: 0; z-index: 999;
-	display: grid; grid-template-columns: repeat(var(--ds-cols, 3), minmax(0, 1fr));
-	gap: 8px 28px; padding: 22px 26px; min-width: 460px; max-width: 90vw;
+	display: grid; grid-template-columns: repeat(var(--ds-cols, 3), minmax(min-content, 1fr));
+	width: max-content; /* true "sized to columns": explicit intrinsic width so the
+	   absolutely-positioned panel never collapses (fr tracks contribute ~0 to the
+	   shrink-to-fit width, which letter-wrapped headings when a cap removed the
+	   min-width floor). min-content column floors keep text wrapping at words. */
+	gap: 8px 28px; padding: 22px 26px; min-width: 460px; max-width: 90vw; overflow-x: auto;
 	opacity: 0; visibility: hidden; transform: translateY(6px);
 	transition: opacity .15s ease, transform .15s ease, visibility .15s;
 	box-shadow: 0 12px 32px rgba(0,0,0,.14); border-radius: var(--ds-radius);


### PR DESCRIPTION
Follow-up to #75: the v1.9.53 `min-width: 0` release valve exposed an intrinsic-width collapse — an absolutely-positioned grid whose `fr` tracks contribute ~0 to shrink-to-fit width can compute a tiny used width, squeezing columns to a few pixels and wrapping headings one letter per line. Reproduced on pennathleticsc (Auto + Max Width 780 → 198px panel, 16px columns, 323px-tall heading).

Fix: the panel declares `width: max-content` (genuinely "sized to columns"), columns floor at `minmax(min-content, 1fr)` so text wraps at words never letters, and `overflow-x: auto` guards pathological caps. Max Width still clamps as designed; bar/viewport/mobile modes override width explicitly and are unaffected.
