### PR TITLE
feat: Hero Banner Mixed Media background — images + videos in one slideshow (GH #78) (1.9.55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.55] - 2026-07-29
+### Added
+- **Hero Banner: "Mixed Media (Images + Videos)" background type (GH #78).** Build the hero slideshow from any mix of image and video slides. Each video slide can come from the WordPress Media Library or a direct MP4 URL, with an optional poster image (shown while the video loads) and a per-slide choice of when the slideshow advances: when the video ends (the progress line fills over the video's length) or after the Slide Interval (the video loops). Videos autoplay muted while their slide is showing, pause when it isn't, and restart from the beginning on return; slideshow navigation (arrows / dots / progress lines), cross-fade, and the overlay all work unchanged. Ken Burns applies to image slides only, and reduced-motion visitors get looping videos with no auto-advance.
+- **Hero Banner: the Video background type can use the Media Library (GH #78).** A "Video (Media Library)" picker joins the existing MP4 URL field on the plain Video background (the library pick wins when both are set), so editors no longer need externally hosted links.
+
 ## [1.9.54] - 2026-07-28
 ### Fixed
 - **Mega panel (Auto) no longer collapses into letter-wrapped columns.** v1.9.53's Max-Width fix removed the panel's min-width floor when a cap was set, exposing an intrinsic-width collapse of the absolutely-positioned grid (fr tracks contribute ~0 to shrink-to-fit width) -- panels squeezed to a few pixels per column, wrapping headings one letter per line (seen on pennathleticsc). The panel now declares width: max-content (truly "sized to columns"), columns floor at min-content so text wraps at words never letters, and an overflow guard keeps extreme caps readable.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.54
+ * Version:           1.9.55
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.54' );
+define( 'DS_TOOLKIT_VERSION', '1.9.55' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-hero/css/frontend.css
+++ b/modules/ds-hero/css/frontend.css
@@ -10,11 +10,18 @@
 .ds-hero-slide.is-active{opacity:1;}
 .ds-hero-overlay{position:absolute;inset:0;z-index:1;pointer-events:none;}
 
+/* Mixed Media: a video slide fills like an image slide; its poster (the slide's
+   background-image) paints behind the video while it loads. */
+.ds-hero-slide--video{background-position:center;background-size:cover;}
+.ds-hero-slide--video .ds-hero-video{z-index:0;}
+
 /* Ken Burns (slow zoom). Duration for slides comes from --ds-hero-kb (the slide interval). */
 @keyframes dsHeroKB{from{transform:scale(1);}to{transform:scale(1.14);}}
 .ds-hero--kenburns .ds-hero-slide{transform:scale(1);will-change:transform;}
 .ds-hero--kenburns .ds-hero-slide.is-active{animation:dsHeroKB var(--ds-hero-kb,8s) ease-out forwards;}
 .ds-hero--kenburns .ds-hero-img{animation:dsHeroKB 18s ease-in-out infinite alternate;transform-origin:center;will-change:transform;}
+/* Ken Burns is a photo treatment — a scaling video reads as broken playback. */
+.ds-hero--kenburns .ds-hero-slide--video.is-active{animation:none;transform:none;}
 
 /* Content */
 .ds-hero-wrap{position:relative;z-index:2;width:100%;max-width:1280px;margin:0 auto;padding:0;}

--- a/modules/ds-hero/ds-hero.php
+++ b/modules/ds-hero/ds-hero.php
@@ -6,7 +6,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  *
  * A full-bleed hero (eyebrow, big headline with an accent word, subtext, two
  * CTA buttons, and a stats/proof row) over a configurable background:
- *   - a single image, an image SLIDESHOW (cross-fade), or a looping VIDEO,
+ *   - a single image, an image SLIDESHOW (cross-fade), a looping VIDEO, or a
+ *     MIXED MEDIA slideshow (any mix of image and video slides — GH #78),
  * with a configurable colour OVERLAY (solid or gradient) on top.
  *
  * Modeled on the Style 1 hero in the DS blueprint (nhbfutbolclub design).
@@ -20,7 +21,7 @@ class DS_Hero_Module extends FLBuilderModule {
 	public function __construct() {
 		parent::__construct( array(
 			'name'            => __( 'Hero Banner', 'ds-toolkit' ),
-			'description'     => __( 'Full-bleed hero with image/slideshow/video background and overlay.', 'ds-toolkit' ),
+			'description'     => __( 'Full-bleed hero with image/slideshow/video/mixed-media background and overlay.', 'ds-toolkit' ),
 			'category'        => __( 'LeagueApps', 'ds-toolkit' ),
 			'dir'             => DS_TOOLKIT_PATH . 'modules/ds-hero/',
 			'url'             => DS_TOOLKIT_URL . 'modules/ds-hero/',
@@ -51,20 +52,88 @@ class DS_Hero_Module extends FLBuilderModule {
 		return $val ? esc_url( (string) $val ) : '';
 	}
 
-	/** Background markup (image / slideshow / video). */
+	/** Resolve a Media Library video (attachment id / {id} array|object) with a URL fallback. */
+	private function video_src( $media, $url ) {
+		if ( ! empty( $media ) ) {
+			$id = is_object( $media ) ? ( $media->id ?? 0 ) : ( is_array( $media ) ? ( $media['id'] ?? 0 ) : $media );
+			if ( is_numeric( $id ) ) {
+				$u = (string) wp_get_attachment_url( (int) $id );
+				if ( '' !== $u ) { return $u; }
+			}
+		}
+		return trim( (string) $url );
+	}
+
+	/**
+	 * Normalized Mixed Media slides: [{type, url, poster, advance}].
+	 * Slides without usable media are skipped, so render and nav always agree.
+	 */
+	private function mixed_slides() {
+		$out = array();
+		$raw = $this->settings->mixed_slides ?? array();
+		if ( ! is_array( $raw ) ) { return $out; }
+		foreach ( $raw as $slide ) {
+			$slide = (object) $slide;
+			if ( ( $slide->slide_type ?? 'image' ) === 'video' ) {
+				$url = $this->video_src( $slide->video_media ?? '', $slide->video_url ?? '' );
+				if ( '' === $url ) { continue; }
+				$out[] = array(
+					'type'    => 'video',
+					'url'     => $url,
+					'poster'  => ! empty( $slide->video_poster ) ? $this->photo_url( $slide->video_poster ) : '',
+					'advance' => ( $slide->video_advance ?? 'end' ) === 'interval' ? 'interval' : 'end',
+				);
+			} else {
+				$url = ! empty( $slide->photo ) ? $this->photo_url( $slide->photo, 'full' ) : '';
+				if ( '' === $url ) { continue; }
+				$out[] = array( 'type' => 'image', 'url' => $url, 'poster' => '', 'advance' => 'interval' );
+			}
+		}
+		return $out;
+	}
+
+	/** Background markup (image / slideshow / video / mixed media). */
 	private function render_bg() {
 		$s    = $this->settings;
 		$type = $s->bg_type ?? 'image';
+		$vurl = 'video' === $type ? $this->video_src( $s->video_media ?? '', $s->video_url ?? '' ) : '';
 
 		echo '<div class="ds-hero-bg">';
 
-		if ( 'video' === $type && ! empty( $s->video_url ) ) {
+		if ( 'video' === $type && '' !== $vurl ) {
 			$poster = ! empty( $s->video_poster ) ? $this->photo_url( $s->video_poster ) : '';
 			printf(
 				'<video class="ds-hero-video" autoplay muted loop playsinline%s><source src="%s" type="video/mp4"></video>',
 				$poster ? ' poster="' . esc_url( $poster ) . '"' : '',
-				esc_url( $s->video_url )
+				esc_url( $vurl )
 			);
+		} elseif ( 'mixed' === $type ) {
+			$i = 0;
+			foreach ( $this->mixed_slides() as $slide ) {
+				if ( 'video' === $slide['type'] ) {
+					// Poster paints the slide div behind the video while it loads.
+					// Only the first slide autoplays / preloads fully; later videos
+					// load metadata and are played by JS when their slide activates.
+					printf(
+						'<div class="ds-hero-slide ds-hero-slide--video%s" data-advance="%s"%s><video class="ds-hero-video" muted playsinline preload="%s"%s%s%s><source src="%s" type="video/mp4"></video></div>',
+						0 === $i ? ' is-active' : '',
+						esc_attr( $slide['advance'] ),
+						$slide['poster'] ? ' style="background-image:url(' . esc_url( $slide['poster'] ) . ')"' : '',
+						0 === $i ? 'auto' : 'metadata',
+						'interval' === $slide['advance'] ? ' loop' : '',
+						0 === $i ? ' autoplay' : '',
+						$slide['poster'] ? ' poster="' . esc_url( $slide['poster'] ) . '"' : '',
+						esc_url( $slide['url'] )
+					);
+				} else {
+					printf(
+						'<div class="ds-hero-slide%s" style="background-image:url(%s)"></div>',
+						0 === $i ? ' is-active' : '',
+						esc_url( $slide['url'] )
+					);
+				}
+				$i++;
+			}
 		} elseif ( 'slideshow' === $type && ! empty( $s->bg_photos ) ) {
 			$raw = $s->bg_photos;
 			$ids = is_array( $raw ) ? $raw : array_filter( array_map( 'trim', explode( ',', (string) $raw ) ) );
@@ -89,16 +158,21 @@ class DS_Hero_Module extends FLBuilderModule {
 		echo '</div><div class="ds-hero-overlay" aria-hidden="true"></div>';
 	}
 
-	/** Slideshow navigation (arrows / dots). Renders only for a 2+ image slideshow. */
+	/** Slideshow navigation (arrows / dots). Renders only for a 2+ slide slideshow (image or mixed). */
 	private function render_slide_nav() {
-		$s = $this->settings;
-		if ( ( $s->bg_type ?? 'image' ) !== 'slideshow' ) { return; }
+		$s    = $this->settings;
+		$type = $s->bg_type ?? 'image';
+		if ( ! in_array( $type, array( 'slideshow', 'mixed' ), true ) ) { return; }
 		$nav = $s->slide_nav ?? 'lines';
 		if ( 'none' === $nav ) { return; }
-		$raw = $s->bg_photos ?? '';
-		$ids = is_array( $raw ) ? $raw : array_filter( array_map( 'trim', explode( ',', (string) $raw ) ) );
-		$count = 0;
-		foreach ( $ids as $id ) { if ( $this->photo_url( $id, 'full' ) ) { $count++; } }
+		if ( 'mixed' === $type ) {
+			$count = count( $this->mixed_slides() );
+		} else {
+			$raw = $s->bg_photos ?? '';
+			$ids = is_array( $raw ) ? $raw : array_filter( array_map( 'trim', explode( ',', (string) $raw ) ) );
+			$count = 0;
+			foreach ( $ids as $id ) { if ( $this->photo_url( $id, 'full' ) ) { $count++; } }
+		}
 		if ( $count < 2 ) { return; }
 
 		$arrows = in_array( $nav, array( 'arrows', 'both', 'lines_arrows' ), true );
@@ -328,6 +402,71 @@ class DS_Hero_Module extends FLBuilderModule {
 	}
 }
 
+/* ---------------------------------------------------- Mixed Media slide sub-form */
+
+FLBuilder::register_settings_form( 'ds_hero_slide_form', array(
+	'title' => __( 'Slide', 'ds-toolkit' ),
+	'tabs'  => array(
+		'general' => array(
+			'title'    => __( 'Slide', 'ds-toolkit' ),
+			'sections' => array(
+				'general' => array(
+					'title'  => '',
+					'fields' => array(
+						'slide_type' => array(
+							'type'    => 'select',
+							'label'   => __( 'Slide Type', 'ds-toolkit' ),
+							'default' => 'image',
+							'options' => array(
+								'image' => __( 'Image', 'ds-toolkit' ),
+								'video' => __( 'Video', 'ds-toolkit' ),
+							),
+							'toggle'  => array(
+								'image' => array( 'fields' => array( 'photo' ) ),
+								'video' => array( 'fields' => array( 'video_media', 'video_url', 'video_poster', 'video_advance' ) ),
+							),
+						),
+						'photo' => array(
+							'type'        => 'photo',
+							'label'       => __( 'Image', 'ds-toolkit' ),
+							'show_remove' => true,
+							'connections' => array( 'photo' ),
+						),
+						'video_media' => array(
+							'type'  => 'video',
+							'label' => __( 'Video (Media Library)', 'ds-toolkit' ),
+							'help'  => __( 'Upload / pick an MP4 from the Media Library. Takes priority over the Video URL below.', 'ds-toolkit' ),
+						),
+						'video_url' => array(
+							'type'        => 'text',
+							'label'       => __( 'Video URL (MP4)', 'ds-toolkit' ),
+							'connections' => array( 'url' ),
+							'help'        => __( 'A direct .mp4 URL if the video is hosted elsewhere.', 'ds-toolkit' ),
+						),
+						'video_poster' => array(
+							'type'        => 'photo',
+							'label'       => __( 'Poster Image', 'ds-toolkit' ),
+							'show_remove' => true,
+							'connections' => array( 'photo' ),
+							'help'        => __( 'Optional. Shown while the video loads.', 'ds-toolkit' ),
+						),
+						'video_advance' => array(
+							'type'    => 'select',
+							'label'   => __( 'Next Slide', 'ds-toolkit' ),
+							'default' => 'end',
+							'options' => array(
+								'end'      => __( 'When the video ends', 'ds-toolkit' ),
+								'interval' => __( 'After the Slide Interval (video loops)', 'ds-toolkit' ),
+							),
+							'help'    => __( 'Videos autoplay muted while their slide is showing (browsers require muted autoplay). Choose when the slideshow moves on.', 'ds-toolkit' ),
+						),
+					),
+				),
+			),
+		),
+	),
+) );
+
 FLBuilder::register_module( 'DS_Hero_Module', array(
 	'content' => array(
 		'title'    => __( 'Content', 'ds-toolkit' ),
@@ -452,19 +591,30 @@ FLBuilder::register_module( 'DS_Hero_Module', array(
 							'image'     => __( 'Single Image', 'ds-toolkit' ),
 							'slideshow' => __( 'Image Slideshow', 'ds-toolkit' ),
 							'video'     => __( 'Video', 'ds-toolkit' ),
+							'mixed'     => __( 'Mixed Media (Images + Videos)', 'ds-toolkit' ),
 						),
 						'toggle'  => array(
 							'image'     => array( 'fields' => array( 'bg_photo', 'kenburns' ) ),
 							'slideshow' => array( 'fields' => array( 'bg_photos', 'slide_interval', 'kenburns', 'slide_nav' ) ),
-							'video'     => array( 'fields' => array( 'video_url', 'video_poster' ) ),
+							'video'     => array( 'fields' => array( 'video_media', 'video_url', 'video_poster' ) ),
+							'mixed'     => array( 'fields' => array( 'mixed_slides', 'slide_interval', 'kenburns', 'slide_nav' ) ),
 						),
 					),
 					'bg_photo'       => array( 'type' => 'photo', 'label' => __( 'Image', 'ds-toolkit' ), 'show_remove' => true ),
 					'bg_photos'      => array( 'type' => 'multiple-photos', 'label' => __( 'Slideshow Images', 'ds-toolkit' ) ),
+					'mixed_slides'   => array(
+						'type'         => 'form',
+						'label'        => __( 'Slide', 'ds-toolkit' ),
+						'form'         => 'ds_hero_slide_form',
+						'preview_text' => 'slide_type',
+						'multiple'     => true,
+						'help'         => __( 'Build the slideshow from any mix of image and video slides. Drag to reorder.', 'ds-toolkit' ),
+					),
 					'slide_interval' => array( 'type' => 'unit', 'label' => __( 'Slide Interval', 'ds-toolkit' ), 'default' => '6', 'description' => 's', 'slider' => array( 'min' => 2, 'max' => 15, 'step' => 1 ) ),
 					'kenburns'       => array( 'type' => 'select', 'label' => __( 'Ken Burns Effect', 'ds-toolkit' ), 'default' => 'no', 'options' => array( 'no' => __( 'No', 'ds-toolkit' ), 'yes' => __( 'Yes (slow zoom)', 'ds-toolkit' ) ), 'help' => __( 'Slowly zooms the background image(s). Disabled for reduced-motion visitors.', 'ds-toolkit' ) ),
-					'slide_nav'      => array( 'type' => 'select', 'label' => __( 'Slide Navigation', 'ds-toolkit' ), 'default' => 'lines', 'options' => array( 'none' => __( 'None', 'ds-toolkit' ), 'lines' => __( 'Progress Lines (cooldown)', 'ds-toolkit' ), 'dots' => __( 'Dots', 'ds-toolkit' ), 'arrows' => __( 'Arrows', 'ds-toolkit' ), 'lines_arrows' => __( 'Lines + Arrows', 'ds-toolkit' ), 'both' => __( 'Dots + Arrows', 'ds-toolkit' ) ), 'help' => __( 'Navigation for the slideshow (2+ images). Progress Lines are thin bars that fill over the slide interval (a cooldown to the next slide). The active indicator and arrow hover use the accent colour.', 'ds-toolkit' ) ),
-					'video_url'      => array( 'type' => 'text', 'label' => __( 'Video URL (MP4)', 'ds-toolkit' ), 'help' => __( 'Direct .mp4 URL. Autoplays muted and loops.', 'ds-toolkit' ) ),
+					'slide_nav'      => array( 'type' => 'select', 'label' => __( 'Slide Navigation', 'ds-toolkit' ), 'default' => 'lines', 'options' => array( 'none' => __( 'None', 'ds-toolkit' ), 'lines' => __( 'Progress Lines (cooldown)', 'ds-toolkit' ), 'dots' => __( 'Dots', 'ds-toolkit' ), 'arrows' => __( 'Arrows', 'ds-toolkit' ), 'lines_arrows' => __( 'Lines + Arrows', 'ds-toolkit' ), 'both' => __( 'Dots + Arrows', 'ds-toolkit' ) ), 'help' => __( 'Navigation for the slideshow (2+ slides). Progress Lines are thin bars that fill over the slide interval (a cooldown to the next slide; on a play-until-end video slide they fill over the video). The active indicator and arrow hover use the accent colour.', 'ds-toolkit' ) ),
+					'video_media'    => array( 'type' => 'video', 'label' => __( 'Video (Media Library)', 'ds-toolkit' ), 'help' => __( 'Upload / pick an MP4 from the Media Library. Takes priority over the Video URL below. Autoplays muted and loops.', 'ds-toolkit' ) ),
+					'video_url'      => array( 'type' => 'text', 'label' => __( 'Video URL (MP4)', 'ds-toolkit' ), 'connections' => array( 'url' ), 'help' => __( 'Direct .mp4 URL if the video is hosted elsewhere. Autoplays muted and loops.', 'ds-toolkit' ) ),
 					'video_poster'   => array( 'type' => 'photo', 'label' => __( 'Video Poster', 'ds-toolkit' ), 'show_remove' => true ),
 				),
 			),

--- a/modules/ds-hero/js/frontend.js
+++ b/modules/ds-hero/js/frontend.js
@@ -1,30 +1,75 @@
-/* Leagueapps Hero Banner — slideshow cross-fade + nav (arrows/dots). Vanilla, idempotent. */
+/* Leagueapps Hero Banner — slideshow cross-fade + nav (arrows/dots). Handles image
+   AND video slides (Mixed Media): the active slide's video plays from the start,
+   inactive videos pause, and a play-until-end video advances on its `ended` event
+   (with the progress bar tracking the video length). Vanilla, idempotent. */
 (function () {
 	function initHero(hero) {
 		if (hero.dsHeroInit) return;
-		var slides = hero.querySelectorAll('.ds-hero-slide');
-		if (slides.length < 2) { hero.dsHeroInit = true; return; }
 		hero.dsHeroInit = true;
+		var slides = hero.querySelectorAll('.ds-hero-slide');
+		var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+		// Reduced motion = no auto-advance, so a play-until-end video would freeze
+		// on its last frame; let every slide video loop in place instead.
+		if (reduce) {
+			hero.querySelectorAll('.ds-hero-slide video').forEach(function (v) { v.loop = true; });
+		}
+		if (slides.length < 2) return;
 
 		var dots   = hero.querySelectorAll('.ds-hero-dot');
 		var bars   = hero.querySelectorAll('.ds-hero-bar');
-		var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 		var interval = parseInt(hero.getAttribute('data-interval'), 10);
 		if (!interval || interval < 2) interval = 6;
 
-		var i = 0, timer = null;
+		var i = 0, timer = null, endedVid = null, onEnded = null;
+
+		function vid(idx) { return slides[idx].querySelector('video'); }
 
 		// Restart the cooldown fill animation on the newly-active bar.
-		function armBar(idx) {
+		// dur (seconds) overrides the CSS interval duration (video slides).
+		function armBar(idx, dur) {
 			if (!bars[idx]) return;
 			var fill = bars[idx].querySelector('.ds-hero-bar-fill');
 			if (!fill) return;
 			fill.style.animation = 'none';
 			void fill.offsetWidth; // reflow so the animation re-triggers
 			fill.style.animation = '';
+			fill.style.animationDuration = dur ? dur + 's' : '';
+		}
+
+		function clearPending() {
+			if (timer) { clearTimeout(timer); timer = null; }
+			if (endedVid && onEnded) { endedVid.removeEventListener('ended', onEnded); }
+			endedVid = null; onEnded = null;
+		}
+
+		// Queue the advance to the next slide: a play-until-end video advances on
+		// `ended`; everything else advances after the slide interval.
+		function schedule() {
+			clearPending();
+			if (reduce) return;
+			var v = vid(i);
+			if (v && slides[i].getAttribute('data-advance') === 'end') {
+				endedVid = v;
+				onEnded = function () { show(i + 1); };
+				v.addEventListener('ended', onEnded);
+				if (v.duration && isFinite(v.duration)) {
+					armBar(i, v.duration);
+				} else {
+					v.addEventListener('loadedmetadata', function lm() {
+						v.removeEventListener('loadedmetadata', lm);
+						if (endedVid === v && v.duration && isFinite(v.duration)) armBar(i, v.duration);
+					});
+				}
+			} else {
+				timer = setTimeout(function () { show(i + 1); }, interval * 1000);
+			}
 		}
 
 		function show(n) {
+			clearPending();
+			var v = vid(i);
+			if (v) v.pause();
 			slides[i].classList.remove('is-active');
 			if (dots[i]) dots[i].classList.remove('is-active');
 			if (bars[i]) bars[i].classList.remove('is-active');
@@ -32,27 +77,32 @@
 			slides[i].classList.add('is-active');
 			if (dots[i]) dots[i].classList.add('is-active');
 			if (bars[i]) { bars[i].classList.add('is-active'); armBar(i); }
+			v = vid(i);
+			if (v) {
+				try { v.currentTime = 0; } catch (e) {}
+				var p = v.play();
+				if (p && p.catch) p.catch(function () {});
+			}
+			schedule();
 		}
-		function stop()  { if (timer) { clearInterval(timer); timer = null; } }
-		function start() { if (reduce) return; stop(); timer = setInterval(function () { show(i + 1); }, interval * 1000); }
 
 		hero.querySelectorAll('.ds-hero-nav--next').forEach(function (b) {
-			b.addEventListener('click', function (e) { e.preventDefault(); show(i + 1); start(); });
+			b.addEventListener('click', function (e) { e.preventDefault(); show(i + 1); });
 		});
 		hero.querySelectorAll('.ds-hero-nav--prev').forEach(function (b) {
-			b.addEventListener('click', function (e) { e.preventDefault(); show(i - 1); start(); });
+			b.addEventListener('click', function (e) { e.preventDefault(); show(i - 1); });
 		});
 		dots.forEach(function (d, idx) {
-			d.addEventListener('click', function (e) { e.preventDefault(); show(idx); start(); });
+			d.addEventListener('click', function (e) { e.preventDefault(); show(idx); });
 		});
 		bars.forEach(function (b, idx) {
-			b.addEventListener('click', function (e) { e.preventDefault(); show(idx); start(); });
+			b.addEventListener('click', function (e) { e.preventDefault(); show(idx); });
 		});
 
 		// Sync the first bar's cooldown with autoplay on load.
 		if (!reduce) armBar(0);
 
-		start();
+		schedule();
 	}
 
 	// Parallax: photo banners with data-parallax move their background slower than


### PR DESCRIPTION
Closes #78.

## What

- **New "Mixed Media (Images + Videos)" background type** on the Hero Banner (Style 1). A repeater builds the slideshow from any mix of image and video slides (drag to reorder).
- **Per-slide video settings:** source from the WordPress Media Library **or** a direct MP4 URL (library wins), optional poster image shown while the video loads, and a per-slide **Next Slide** choice:
  - **When the video ends** — the slideshow waits for the video's `ended` event; the progress line fills over the video's real length.
  - **After the Slide Interval** — the video loops while its slide shows.
- **Media Library support for the plain Video background type** too: new "Video (Media Library)" picker alongside the existing MP4 URL field.
- **Playback handling:** only the first slide's video autoplays/preloads fully (later ones preload metadata); the active slide's video plays from the start, inactive videos pause; videos autoplay muted (browser requirement). Cross-fade, arrows/dots/progress-line nav, and the overlay work unchanged. Ken Burns stays a photo-only treatment (video slides excluded). Reduced-motion visitors get looping videos with no auto-advance (manual nav still plays the chosen slide's video).

## How it's wired

- `ds_hero_slide_form` sub-form registered (same pattern as `ds_carousel_slide_form`), `mixed_slides` form-repeater field, `mixed` option + toggles on `bg_type`.
- `render_bg()` renders video slides as `.ds-hero-slide--video` with `data-advance`; `mixed_slides()` normalizes/validates so render and nav always agree on the slide count.
- `js/frontend.js` scheduler rewritten from `setInterval` to a per-slide `schedule()` (timeout or `ended` listener, cleanly torn down on every transition, including manual nav).

## Verified on the ds-launchpad-6 Local blueprint (Playwright)

Test page with image → Media-Library video (advance on end) → image → URL video (loop + poster, advance on interval), interval 4s, Ken Burns on, lines+arrows nav:

- Full cycle observed at t = 0 / 3.6 / 7.7 (video A's `ended` at its 4s duration) / 11.3 / 15.5 / 19.5s — order and timing exactly as configured.
- Active video: `paused=false`, `currentTime` advancing, correct `loop` per advance mode; progress bar `animation-duration` = 4s (video length) on the play-until-end slide.
- Ken Burns animation = `dsHeroKB` on image slides, `none` on video slides.
- Arrow click pauses the current video and advances correctly.
- Desktop (1440×900) + iPhone 13 viewport screenshots: both videos paint full-bleed behind the overlay/content; poster shows during the cross-fade. Zero console/page errors.
- `php -l` + `node --check` clean. Single Image / Image Slideshow / Video / Style 2 paths untouched by default (`bg_type` still defaults to `image`).
