### PR TITLE
fix: Theme Setting alpha colours no longer wiped on save (GH #80) (1.9.56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.56] - 2026-07-29
+### Fixed
+- **Theme Setting: colours with opacity below 100% no longer vanish on save (GH #80).** The colour picker stores a semi-transparent pick as 8-digit hex (`#rrggbbaa`), but the save sanitizer only accepted 3/6-digit hex, `rgb()/rgba()`, or a global-colour `var()` reference, so any alpha-adjusted colour (e.g. the Page Banner Background Color) was wiped to empty and the banner fell back to the default background. 4- and 8-digit alpha hex now survives every Theme Setting colour field; display, swatches, and the front-end CSS already handled it.
+
 ## [1.9.55] - 2026-07-29
 ### Added
 - **Hero Banner: "Mixed Media (Images + Videos)" background type (GH #78).** Build the hero slideshow from any mix of image and video slides. Each video slide can come from the WordPress Media Library or a direct MP4 URL, with an optional poster image (shown while the video loads) and a per-slide choice of when the slideshow advances: when the video ends (the progress line fills over the video's length) or after the Slide Interval (the video loops). Videos autoplay muted while their slide is showing, pause when it isn't, and restart from the beginning on return; slideshow navigation (arrows / dots / progress lines), cross-fade, and the overlay all work unchanged. Ken Burns applies to image slides only, and reduced-motion visitors get looping videos with no auto-advance.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.55
+ * Version:           1.9.56
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.55' );
+define( 'DS_TOOLKIT_VERSION', '1.9.56' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-theme-setting.php
+++ b/features/class-ds-theme-setting.php
@@ -1218,7 +1218,9 @@ JS;
         $value = trim( (string) $value );
         if ( '' === $value ) { return ''; }
         // BB's picker stores hex WITHOUT a leading '#'; normalize to #hex.
-        if ( preg_match( '/^#?([A-Fa-f0-9]{3}|[A-Fa-f0-9]{6})$/', $value, $m ) ) { return '#' . strtolower( $m[1] ); }
+        // 4- and 8-digit hex carry the Pickr alpha channel (#rgba / #rrggbbaa) —
+        // rejecting them wiped any colour saved with opacity below 100% (GH #80).
+        if ( preg_match( '/^#?([A-Fa-f0-9]{3,4}|[A-Fa-f0-9]{6}|[A-Fa-f0-9]{8})$/', $value, $m ) ) { return '#' . strtolower( $m[1] ); }
         if ( preg_match( '/^rgba?\(\s*[\d.,\s%]+\)$/', $value ) ) { return $value; }
         // Synced global-color reference, e.g. var(--fl-global-primary).
         if ( preg_match( '/^var\(\s*--[A-Za-z0-9_-]+\s*\)$/', $value ) ) { return $value; }


### PR DESCRIPTION
Closes #80.

## Root cause

The Theme Setting colour picker (Pickr) commits `toHEXA().toString()`: `#rrggbb` at 100% opacity, but **`#rrggbbaa` (8-digit hex) the moment the alpha slider drops below 100%**. `DS_Theme_Setting::sanitize_color()` only accepted 3/6-digit hex, `rgb()/rgba()`, or a global-colour `var()` reference; an 8-digit value fell through to WordPress core's `sanitize_hex_color()`, which returns `null` for it — so the saved value became `''` and (for the reported field) the Page Banner fell back to the default background. That's why it only broke below 100%.

## Fix

One line: the hex branch of `sanitize_color()` now accepts 4-digit (`#rgba`) and 8-digit (`#rrggbbaa`) alpha hex alongside 3/6-digit, still normalising to lowercase `#hex`. Every Theme Setting colour field goes through this one sanitizer, so all of them are fixed at once (Page Banner Background Color, title colours, body/content backgrounds, Global Colors, outline, etc.). Display was never broken — `dsResolve` (JS), `swatch_color()` (PHP), and browsers all pass `#rrggbbaa` through fine — only the save sanitizer ate the value.

## Verified on the ds-launchpad-6 Local blueprint

- Sanitizer matrix via reflection: `#ff000080` / `ff000080` / `#F00A` → preserved + normalised; `#188830` / `188830` / `rgba(24, 136, 48, 0.5)` / `var(--fl-global-accent)` → unchanged behaviour; `#12345` / `javascript:x` → still rejected to `''`.
- End-to-end save path: green at 50% (`#18883080`) through the sanitizer into `ds-banner-nobg-color` → front end emits `.ds-banner--no-bg{background-color:#18883080;…}` in `#ds-banner-nobg-css`.
- Playwright on /register/ (no-image banner): computed background `rgba(24, 136, 48, 0.5)` and the screenshot shows the semi-transparent colour blending with the pattern.
- `php -l` clean; local site's original colour restored after testing.
