### PR TITLE
fix: mega panel hover-area overlap — hover intent stops accidental panel swaps (GH #82) (1.9.57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.57] - 2026-07-30
+### Fixed
+- **Menu: crossing a neighbouring trigger no longer swaps mega panels (GH #82).** Mega panels are far wider than their nav item, so a cursor travelling from a trigger into a far column of its open panel could clip the next top-level item on the way, and pure CSS `:hover` swapped panels instantly (e.g. Soccer opening while browsing the Flag Football panel). Desktop top-level open state is now JS-managed with hover intent: with nothing open, hover still opens instantly; with a panel open, switching to a sibling (or closing over a childless item) requires the pointer to dwell ~120ms on it, and a brief pass-through is ignored. Leaving the whole menu closes after a short grace instead of slamming shut. Keyboard (`:focus-within`), nested flyouts, the mobile overlay/drill drawer, and the no-JS fallback (pure `:hover`) are unchanged.
+
 ## [1.9.56] - 2026-07-29
 ### Fixed
 - **Theme Setting: colours with opacity below 100% no longer vanish on save (GH #80).** The colour picker stores a semi-transparent pick as 8-digit hex (`#rrggbbaa`), but the save sanitizer only accepted 3/6-digit hex, `rgb()/rgba()`, or a global-colour `var()` reference, so any alpha-adjusted colour (e.g. the Page Banner Background Color) was wiped to empty and the banner fell back to the default background. 4- and 8-digit alpha hex now survives every Theme Setting colour field; display, swatches, and the front-end CSS already handled it.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.56
+ * Version:           1.9.57
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.56' );
+define( 'DS_TOOLKIT_VERSION', '1.9.57' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/css/frontend.css
+++ b/modules/ds-menu/css/frontend.css
@@ -13,6 +13,7 @@
 .ds-sub-ind { display: inline-flex; align-items: center; margin-left: 6px; line-height: 1; }
 .ds-sub-ind-icon svg { display: block; transition: transform .2s ease; }
 .ds-menu > .ds-menu-item.has-children:hover > a .ds-sub-ind-icon svg,
+.ds-menu > .ds-menu-item.has-children.ds-hover-open > a .ds-sub-ind-icon svg,
 .ds-menu > .ds-menu-item.has-children:focus-within > a .ds-sub-ind-icon svg { transform: rotate(180deg); }
 
 /* Dropdowns (regular submenus) */
@@ -27,7 +28,15 @@
 /* Edge flip (class set by js when a panel would overflow the viewport's right edge). */
 .ds-menu .ds-submenu .ds-menu-item.ds-flip > .ds-submenu { left: auto; right: 100%; }
 .ds-menu > .ds-menu-item.ds-flip > .ds-submenu { left: auto; right: 0; }
-.ds-menu-item:hover > .ds-submenu,
+/* Open states. TOP-LEVEL items are JS-managed with hover intent (GH #82): the
+   wrap gets .ds-js-hover when the script boots and .ds-hover-open marks the open
+   item, so a cursor merely PASSING a neighbouring trigger on its way into a wide
+   open mega panel no longer swaps panels. Pure :hover stays as the no-JS
+   fallback and for nested flyouts (narrow — no overlap problem); :focus-within
+   keeps keyboard support CSS-driven. (.ds-open is the mobile overlay's class.) */
+.ds-menu-wrap:not(.ds-js-hover) .ds-menu > .ds-menu-item:hover > .ds-submenu,
+.ds-menu > .ds-menu-item.ds-hover-open > .ds-submenu,
+.ds-menu .ds-submenu .ds-menu-item:hover > .ds-submenu,
 .ds-menu-item:focus-within > .ds-submenu {
 	opacity: 1; visibility: visible; transform: translateY(0);
 }
@@ -46,7 +55,8 @@
 	transition: opacity .15s ease, transform .15s ease, visibility .15s;
 	box-shadow: 0 12px 32px rgba(0,0,0,.14); border-radius: var(--ds-radius);
 }
-.ds-menu-item.is-mega:hover > .ds-mega,
+.ds-menu-wrap:not(.ds-js-hover) .ds-menu-item.is-mega:hover > .ds-mega,
+.ds-menu-item.is-mega.ds-hover-open > .ds-mega,
 .ds-menu-item.is-mega:focus-within > .ds-mega { opacity: 1; visibility: visible; transform: translateY(0); }
 .ds-mega-col .ds-mega-head { display: block; font-weight: 700; text-decoration: none; padding: 4px 0 6px; }
 .ds-mega-col .ds-submenu { position: static; opacity: 1; visibility: visible; transform: none; box-shadow: none; padding: 0; min-width: 0; }

--- a/modules/ds-menu/includes/frontend.css.php
+++ b/modules/ds-menu/includes/frontend.css.php
@@ -181,7 +181,7 @@ if ( 'bar' === $mw ) {
 	if ( 'center' === $mal ) {
 		// Override both rest + open transforms so the translateY reveal is preserved.
 		echo "\t$mPan { left: 50%; right: auto; transform: translate(-50%, 6px); }\n";
-		echo "\t$mItem:hover > .ds-mega, $mItem:focus-within > .ds-mega { transform: translate(-50%, 0); }\n";
+		echo "\t$mItem:hover > .ds-mega, $mItem.ds-hover-open > .ds-mega, $mItem:focus-within > .ds-mega { transform: translate(-50%, 0); }\n";
 	} elseif ( 'right' === $mal ) {
 		echo "\t$mPan { left: auto; right: 0; }\n";
 	}

--- a/modules/ds-menu/js/frontend.js
+++ b/modules/ds-menu/js/frontend.js
@@ -398,6 +398,53 @@
 		} );
 	}
 
+	/* Hover intent (GH #82): the top-level open state is JS-managed on desktop so
+	   a cursor merely CROSSING a neighbouring trigger on its way into a wide open
+	   mega panel doesn't swap panels. With nothing open, hover opens instantly;
+	   with a panel open, switching (or closing over a childless item) requires
+	   the pointer to DWELL on the new item; leaving the whole menu closes after
+	   a short grace. CSS :hover stays as the no-JS fallback (the wrap only gets
+	   .ds-js-hover once this boots) and :focus-within keeps keyboard support. */
+	function initHoverIntent( wrap ) {
+		if ( wrap.dsHoverInit ) { return; }
+		wrap.dsHoverInit = true;
+		var menu = wrap.querySelector( '.ds-menu' );
+		if ( ! menu ) { return; }
+		wrap.classList.add( 'ds-js-hover' );
+		var SWITCH_MS = 120, CLOSE_MS = 220;
+		var openLi = null, timer = null;
+
+		function clearTimer() { if ( timer ) { clearTimeout( timer ); timer = null; } }
+		function setOpen( li ) {
+			if ( openLi === li ) { return; }
+			if ( openLi ) { openLi.classList.remove( 'ds-hover-open' ); }
+			openLi = li;
+			if ( openLi ) { openLi.classList.add( 'ds-hover-open' ); }
+		}
+		wrap.addEventListener( 'mouseover', function ( e ) {
+			if ( wrap.classList.contains( 'ds-menu-open' ) ) { return; } // mobile overlay: taps drive it
+			var li = e.target && e.target.closest ? e.target.closest( '.ds-menu > .ds-menu-item' ) : null;
+			if ( ! li || ! menu.contains( li ) ) { return; }
+			if ( li === openLi ) { clearTimer(); return; } // back on the open item / inside its panel
+			var next = li.classList.contains( 'has-children' ) ? li : null;
+			clearTimer();
+			if ( ! openLi ) { setOpen( next ); return; } // nothing open: open instantly
+			timer = setTimeout( function () {
+				timer = null;
+				if ( li.matches( ':hover' ) ) { setOpen( next ); } // still there → intentional
+			}, SWITCH_MS );
+		} );
+		menu.addEventListener( 'mouseenter', function () { clearTimer(); } );
+		menu.addEventListener( 'mouseleave', function () {
+			clearTimer();
+			timer = setTimeout( function () { timer = null; setOpen( null ); }, CLOSE_MS );
+		} );
+		// Opening the mobile overlay must never leave a desktop panel stuck open.
+		wrap.addEventListener( 'click', function () {
+			if ( wrap.classList.contains( 'ds-menu-open' ) ) { clearTimer(); setOpen( null ); }
+		} );
+	}
+
 	/* Edge flip: when a dropdown / nested flyout would overflow the viewport's
 	   right edge (e.g. the last "More" item), flip it to open leftward instead
 	   of overlapping or clipping. Desktop only — the overlay renders submenus
@@ -442,7 +489,7 @@
 		} );
 	}
 
-	function boot() { document.querySelectorAll( '.ds-menu-wrap' ).forEach( function ( w ) { init( w ); initFlip( w ); } ); }
+	function boot() { document.querySelectorAll( '.ds-menu-wrap' ).forEach( function ( w ) { init( w ); initHoverIntent( w ); initFlip( w ); } ); }
 
 	if ( 'loading' !== document.readyState ) { boot(); } else { document.addEventListener( 'DOMContentLoaded', boot ); }
 	// Re-init after a Beaver Builder partial refresh while editing.


### PR DESCRIPTION
Closes #82.

## Root cause

Mega panels are far wider than their nav item, and top-level open state was pure CSS `:hover` on the `li`. Travelling from a trigger into a far column of its open panel, the cursor's path clips the NEXT top-level item's box in the nav row ("the area where the Soccer dropdown is positioned") — and `:hover` swaps panels the instant it's touched, even for a ~50ms pass-through. Reproduced deterministically on the ds-launchpad-6 blueprint: a cursor sweep from an open mega's trigger through the neighbouring trigger into the panel below swapped panels on v1.9.56.

## Fix — hover intent (desktop top-level only)

Top-level open state is now JS-managed via a `.ds-hover-open` class:

- **Nothing open:** hover opens instantly (unchanged feel).
- **A panel open:** switching to a sibling — or closing over a childless item — requires the pointer to **dwell ~120ms** on it; at the timer the item must still match `:hover`. A pass-through never swaps.
- **Leaving the whole menu** closes after a ~220ms grace instead of slamming shut (also forgives clipping the gap under the bar).
- Pointer inside the open panel always cancels any pending close/switch (the panel is a DOM descendant of its trigger).

Untouched by design: nested flyouts (pure `:hover`, narrow — no overlap problem), keyboard (`:focus-within` rules unchanged), the mobile overlay / drill drawer (guarded by `.ds-menu-open`, and the overlay's own `.ds-open` class is untouched), and the **no-JS fallback** — the CSS `:hover` open rules still apply until the script adds `.ds-js-hover` to the wrap. Center-aligned megas keep their reveal transform via the same class in the dynamic CSS.

## Verified on the ds-launchpad-6 Local blueprint (Playwright)

- **Before (1.9.56):** trigger→neighbour→panel sweep = panels swap. **After:** the original panel stays open on the identical path.
- Intentional switch: dwelling 500ms on the neighbour opens it.
- Regular dropdown: opens on hover, stays open while hovering its links, closes after leaving the menu; no stray panels left open.
- Keyboard: `:focus-within` still opens panels.
- Mobile (iPhone 13): drill drawer opens with all rows; overlay unaffected.
- Zero console/page errors; `node --check` + `php -l` clean. Header layout settings used for the repro were restored to their original values.
