### PR TITLE
Move Program Cards from Post Loop to CTA Style 6 (1.9.58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.58] - 2026-07-30
+### Changed
+- **Program Cards moved from Post Loop to CTA (Style 6).** The `Custom Program Card (manual list)` layout never queried a post type, so it did not belong in a module whose contract is "loop over posts of type X". It is now **CTA -> Style 6 - Program Cards (manual list)**, with the same fields, the same `programs` repeater and the same `pg_*` styling keys. Both modules render through one shared `DS_Program_Cards` class, so legacy Post Loop instances and the new CTA style produce byte-identical markup by construction.
+- **`program` is hidden from the Post Loop Card Layout picker for NEW modules only.** A module that already uses it still shows the option, because removing it outright would leave the select with no matching value and Beaver Builder would silently fall back to the first layout — converting a partner's program list into a news grid the moment they opened the panel. The layout still renders forever, so un-migrated sites and revision restores are unaffected.
+- `Sponsors: Grid (manual list)` has the same defect but is deliberately left in place until it has a CTA style of its own; retiring it with nowhere to rebuild would block editors from creating sponsor grids.
+
+### Added
+- **`wp ds migrate-program-cards`** — moves existing nodes from `ds-post-loop card_layout=program` to `ds-cta cta_style=style6`. **Dry run by default**; `--execute` writes. Refuses posts that have only `_fl_builder_data` or only `_fl_builder_draft` (a half-migrated post reverts the next time an editor opens it) unless `--allow-unpaired` is passed. Clears the Beaver Builder asset cache per post.
+- **`wp ds rollback-program-cards`** — undoes the above from a `_ds_premigration` stash kept on each node, so rollback needs no external state.
+
+### Notes
+- The migration is a verbatim settings carry: Beaver Builder merges stored settings over module defaults and preserves unknown keys, so no field map is required. Only three keys need handling — `cta_style` (set to style6), `cards` (emptied so the styles 1-5 repeater stays inert) and `header_label` (blanked so CTA's default "Lorem ipsum" label cannot appear).
+- Verified on the DS Launchpad 6 blueprint and on a production install (huskyvbc, 10 posts / 20 nodes): rendered HTML byte-identical before and after, and every generated CSS rule targeting a rendered element identical on both paths (212 rules, 0 added, 0 removed).
+
 ## [1.9.57] - 2026-07-30
 ### Fixed
 - **Menu: crossing a neighbouring trigger no longer swaps mega panels (GH #82).** Mega panels are far wider than their nav item, so a cursor travelling from a trigger into a far column of its open panel could clip the next top-level item on the way, and pure CSS `:hover` swapped panels instantly (e.g. Soccer opening while browsing the Flag Football panel). Desktop top-level open state is now JS-managed with hover intent: with nothing open, hover still opens instantly; with a panel open, switching to a sibling (or closing over a childless item) requires the pointer to dwell ~120ms on it, and a brief pass-through is ignored. Leaving the whole menu closes after a short grace instead of slamming shut. Keyboard (`:focus-within`), nested flyouts, the mobile overlay/drill drawer, and the no-JS fallback (pure `:hover`) are unchanged.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.57
+ * Version:           1.9.58
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.57' );
+define( 'DS_TOOLKIT_VERSION', '1.9.58' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 
@@ -34,6 +34,10 @@ if ( ! defined( 'DS_TOOLKIT_ADMIN_DOMAIN' ) ) {
 // + SVG icon registry), loaded once so every in-house module can reuse them.
 require_once DS_TOOLKIT_PATH . 'includes/class-ds-module-ui.php';
 require_once DS_TOOLKIT_PATH . 'includes/class-ds-card.php';
+require_once DS_TOOLKIT_PATH . 'includes/class-ds-program-cards.php';
+if ( ( defined( 'WP_CLI' ) && WP_CLI ) || is_admin() ) {
+	require_once DS_TOOLKIT_PATH . 'includes/class-ds-program-cards-migrator.php';
+}
 
 require_once DS_TOOLKIT_PATH . 'includes/class-ds-toolkit.php';
 

--- a/includes/class-ds-program-cards-migrator.php
+++ b/includes/class-ds-program-cards-migrator.php
@@ -1,0 +1,353 @@
+<?php
+/**
+ * Migrate manual-list card nodes out of ds-post-loop and into ds-cta.
+ *
+ *   ds-post-loop card_layout=program  ->  ds-cta cta_style=style6
+ *
+ * WHY IT IS A VERBATIM CARRY
+ * --------------------------
+ * Beaver Builder merges a node's STORED settings over the module defaults and
+ * keeps keys it does not recognise (FLBuilderModel::get_node_settings_with_defaults_merged).
+ * So changing `type` and adding `cta_style` preserves every value the node
+ * already holds; keys that only mean something to Post Loop become inert. That
+ * removes the need for a 300-key field map, which is where a migration like this
+ * would normally go wrong.
+ *
+ * The three keys that DO need handling are the ones ds-cta defines but a
+ * post-loop node never stored, where CTA's default would newly apply:
+ *   - cta_style   : set to style6 (the point of the migration)
+ *   - cards       : CTA's styles 1-5 repeater, defaults to 4 dummy cards. Style 6
+ *                   reads `programs`, so `cards` is forced empty to keep it inert.
+ *   - header_label: CTA's header adds a right-side label defaulting to
+ *                   "Lorem ipsum →" which would appear on every migrated node.
+ *
+ * SAFETY
+ * ------
+ *   - Dry run is the default. Writing requires --execute.
+ *   - `_fl_builder_data` and `_fl_builder_draft` migrate TOGETHER per post; if
+ *     only one is present that is reported, because a half-migrated post reverts
+ *     the next time an editor opens it.
+ *   - `card_layout` is left in place as the rollback discriminator.
+ *   - Revisions are never touched. A revision restore therefore resurrects a
+ *     ds-post-loop/program node, which is exactly why that layout still renders.
+ *   - The original settings are stashed on the node (`_ds_premigration`) so a
+ *     rollback needs no external state.
+ *
+ * @package ds-toolkit
+ * @since   1.10.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class DS_Program_Cards_Migrator {
+
+	const STASH_KEY = '_ds_premigration';
+
+	/** Layout -> target CTA style. */
+	public static function map() {
+		return array( 'program' => 'style6' );
+	}
+
+	/**
+	 * Find every affected node, grouped by post.
+	 *
+	 * @return array post_id => array( 'post' => WP_Post, 'nodes' => array( meta_key => array( node_id => layout ) ) )
+	 */
+	public static function scan() {
+		global $wpdb;
+		$map  = self::map();
+		$rows = $wpdb->get_results(
+			"SELECT p.ID, m.meta_key, m.meta_value
+			   FROM {$wpdb->postmeta} m
+			   JOIN {$wpdb->posts} p ON p.ID = m.post_id
+			  WHERE m.meta_key IN ('_fl_builder_data','_fl_builder_draft')
+			    AND p.post_type <> 'revision'
+			    AND m.meta_value LIKE '%ds-post-loop%'"
+		);
+
+		$out = array();
+		foreach ( $rows as $r ) {
+			$data = maybe_unserialize( $r->meta_value );
+			if ( ! is_array( $data ) ) {
+				continue;
+			}
+			foreach ( $data as $node_id => $node ) {
+				if ( ! is_object( $node ) || ( $node->settings->type ?? '' ) !== 'ds-post-loop' ) {
+					continue;
+				}
+				$layout = $node->settings->card_layout ?? '';
+				if ( ! isset( $map[ $layout ] ) ) {
+					continue;
+				}
+				if ( ! isset( $out[ $r->ID ] ) ) {
+					$out[ $r->ID ] = array(
+						'post'  => get_post( $r->ID ),
+						'nodes' => array(),
+					);
+				}
+				$out[ $r->ID ]['nodes'][ $r->meta_key ][ $node_id ] = $layout;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Convert one node's settings in place.
+	 *
+	 * @param object $settings Node settings (modified by reference semantics via return).
+	 * @param string $layout   Source card_layout.
+	 * @return object
+	 */
+	public static function convert( $settings, $layout ) {
+		$map = self::map();
+
+		// Stash the original so rollback needs no external state.
+		if ( ! isset( $settings->{self::STASH_KEY} ) ) {
+			$settings->{self::STASH_KEY} = array(
+				'type'        => 'ds-post-loop',
+				'card_layout' => $layout,
+			);
+		}
+
+		$settings->type      = 'ds-cta';
+		$settings->cta_style = $map[ $layout ];
+
+		// Neutralise the two CTA defaults that would otherwise newly apply.
+		$settings->cards        = array();
+		$settings->header_label = '';
+
+		// card_layout intentionally retained as the rollback discriminator.
+		return $settings;
+	}
+
+	/**
+	 * Run the migration.
+	 *
+	 * @param bool $execute      Write when true; report only when false.
+	 * @param bool $require_pair Skip posts that do not have both data and draft.
+	 * @return array Report lines + counters.
+	 */
+	public static function run( $execute = false, $require_pair = true ) {
+		$found  = self::scan();
+		$report = array();
+		$stats  = array(
+			'posts'   => 0,
+			'nodes'   => 0,
+			'skipped' => 0,
+		);
+
+		foreach ( $found as $post_id => $info ) {
+			$keys      = array_keys( $info['nodes'] );
+			$has_data  = in_array( '_fl_builder_data', $keys, true );
+			$has_draft = in_array( '_fl_builder_draft', $keys, true );
+			$title     = $info['post'] ? $info['post']->post_title : '(unknown)';
+			$ptype     = $info['post'] ? $info['post']->post_type : '?';
+
+			// A post whose published and draft layouts disagree would visually
+			// revert as soon as an editor opened it, so pairs are enforced unless
+			// explicitly overridden.
+			if ( $require_pair && ! ( $has_data && $has_draft ) ) {
+				$stats['skipped']++;
+				$report[] = sprintf(
+					'SKIP  post %d (%s: %s) — only %s present; re-run with --allow-unpaired to migrate anyway',
+					$post_id,
+					$ptype,
+					$title,
+					$has_data ? '_fl_builder_data' : '_fl_builder_draft'
+				);
+				continue;
+			}
+
+			$stats['posts']++;
+			foreach ( $info['nodes'] as $meta_key => $nodes ) {
+				$data = maybe_unserialize( get_post_meta( $post_id, $meta_key, true ) );
+				if ( ! is_array( $data ) ) {
+					continue;
+				}
+				$changed = false;
+				foreach ( $nodes as $node_id => $layout ) {
+					if ( ! isset( $data[ $node_id ] ) ) {
+						continue;
+					}
+					$data[ $node_id ]->settings = self::convert( $data[ $node_id ]->settings, $layout );
+					$changed = true;
+					$stats['nodes']++;
+					$report[] = sprintf(
+						'%s post %d (%s: %s) %s node %s : ds-post-loop/%s -> ds-cta/%s',
+						$execute ? 'DONE ' : 'WOULD',
+						$post_id,
+						$ptype,
+						$title,
+						str_replace( '_fl_builder_', '', $meta_key ),
+						$node_id,
+						$layout,
+						self::map()[ $layout ]
+					);
+				}
+				if ( $changed && $execute ) {
+					update_post_meta( $post_id, $meta_key, $data );
+				}
+			}
+
+			if ( $execute ) {
+				self::clear_cache( $post_id );
+			}
+		}
+
+		return array(
+			'report' => $report,
+			'stats'  => $stats,
+		);
+	}
+
+	/**
+	 * Roll one or all migrated nodes back to ds-post-loop using the stash.
+	 *
+	 * @param bool $execute Write when true.
+	 * @return array
+	 */
+	public static function rollback( $execute = false ) {
+		global $wpdb;
+		$rows   = $wpdb->get_results(
+			"SELECT p.ID, m.meta_key, m.meta_value
+			   FROM {$wpdb->postmeta} m
+			   JOIN {$wpdb->posts} p ON p.ID = m.post_id
+			  WHERE m.meta_key IN ('_fl_builder_data','_fl_builder_draft')
+			    AND p.post_type <> 'revision'
+			    AND m.meta_value LIKE '%" . self::STASH_KEY . "%'"
+		);
+		$report = array();
+		$n      = 0;
+
+		foreach ( $rows as $r ) {
+			$data = maybe_unserialize( $r->meta_value );
+			if ( ! is_array( $data ) ) {
+				continue;
+			}
+			$changed = false;
+			foreach ( $data as $node_id => $node ) {
+				if ( ! is_object( $node ) || empty( $node->settings->{self::STASH_KEY} ) ) {
+					continue;
+				}
+				$stash = (array) $node->settings->{self::STASH_KEY};
+				$node->settings->type        = $stash['type'] ?? 'ds-post-loop';
+				$node->settings->card_layout = $stash['card_layout'] ?? 'program';
+				unset( $node->settings->cta_style, $node->settings->{self::STASH_KEY} );
+				$changed = true;
+				$n++;
+				$report[] = sprintf(
+					'%s post %d %s node %s -> ds-post-loop/%s',
+					$execute ? 'DONE ' : 'WOULD',
+					$r->ID,
+					str_replace( '_fl_builder_', '', $r->meta_key ),
+					$node_id,
+					$node->settings->card_layout
+				);
+			}
+			if ( $changed && $execute ) {
+				update_post_meta( $r->ID, $r->meta_key, $data );
+				self::clear_cache( $r->ID );
+			}
+		}
+
+		return array(
+			'report' => $report,
+			'stats'  => array( 'nodes' => $n ),
+		);
+	}
+
+	/**
+	 * Drop Beaver Builder's cached CSS/JS for a post so the new module's assets
+	 * are regenerated. Without this the page keeps serving the old layout CSS.
+	 *
+	 * @param int $post_id Post id.
+	 */
+	public static function clear_cache( $post_id ) {
+		if ( class_exists( 'FLBuilderModel' ) && method_exists( 'FLBuilderModel', 'delete_asset_cache' ) ) {
+			FLBuilderModel::delete_asset_cache( $post_id );
+		}
+		// The asset cache helper misses symlinked/renamed files on some hosts, so
+		// unlink the layout files directly as well.
+		$dir = defined( 'WP_CONTENT_DIR' ) ? WP_CONTENT_DIR . '/uploads/bb-plugin/cache' : '';
+		if ( $dir && is_dir( $dir ) ) {
+			foreach ( glob( $dir . '/' . (int) $post_id . '-layout*.{css,js}', GLOB_BRACE ) as $f ) {
+				@unlink( $f );
+			}
+		}
+	}
+}
+
+/* -------------------------------------------------------------- WP-CLI ---- */
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+
+	/**
+	 * Move manual-list card modules out of Post Loop into CTA.
+	 */
+	class DS_Program_Cards_CLI {
+
+		/**
+		 * Report or perform the migration.
+		 *
+		 * ## OPTIONS
+		 *
+		 * [--execute]
+		 * : Write the changes. Without this flag nothing is modified.
+		 *
+		 * [--allow-unpaired]
+		 * : Migrate posts that only have published OR draft builder data.
+		 *
+		 * ## EXAMPLES
+		 *
+		 *     wp ds migrate-program-cards
+		 *     wp ds migrate-program-cards --execute
+		 */
+		public function __invoke( $args, $assoc ) {
+			$execute = isset( $assoc['execute'] );
+			$paired  = ! isset( $assoc['allow-unpaired'] );
+
+			$res = DS_Program_Cards_Migrator::run( $execute, $paired );
+			foreach ( $res['report'] as $line ) {
+				WP_CLI::log( $line );
+			}
+			WP_CLI::log( '' );
+			WP_CLI::log( sprintf( 'posts: %d   nodes: %d   skipped posts: %d', $res['stats']['posts'], $res['stats']['nodes'], $res['stats']['skipped'] ) );
+			if ( ! $execute ) {
+				WP_CLI::success( 'DRY RUN — nothing was written. Re-run with --execute to apply.' );
+			} else {
+				WP_CLI::success( 'Migration applied. Verify the pages before purging any host cache.' );
+			}
+		}
+	}
+
+	/**
+	 * Undo the migration using the settings stash.
+	 */
+	class DS_Program_Cards_Rollback_CLI {
+
+		/**
+		 * ## OPTIONS
+		 *
+		 * [--execute]
+		 * : Write the changes. Without this flag nothing is modified.
+		 */
+		public function __invoke( $args, $assoc ) {
+			$execute = isset( $assoc['execute'] );
+			$res     = DS_Program_Cards_Migrator::rollback( $execute );
+			foreach ( $res['report'] as $line ) {
+				WP_CLI::log( $line );
+			}
+			WP_CLI::log( '' );
+			WP_CLI::log( sprintf( 'nodes: %d', $res['stats']['nodes'] ) );
+			if ( ! $execute ) {
+				WP_CLI::success( 'DRY RUN — nothing was written. Re-run with --execute to apply.' );
+			} else {
+				WP_CLI::success( 'Rolled back.' );
+			}
+		}
+	}
+
+	WP_CLI::add_command( 'ds migrate-program-cards', 'DS_Program_Cards_CLI' );
+	WP_CLI::add_command( 'ds rollback-program-cards', 'DS_Program_Cards_Rollback_CLI' );
+}

--- a/includes/class-ds-program-cards.php
+++ b/includes/class-ds-program-cards.php
@@ -1,0 +1,481 @@
+<?php
+/**
+ * Shared renderer for the manual "Program Cards" list.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The program card list is a MANUAL list of hand-built cards. It never queries a
+ * post type, so it does not belong in the Post Loop module (whose whole contract
+ * is "loop over posts of type X"). It now lives in the CTA module instead.
+ *
+ * Both modules render through this ONE class, so:
+ *   - ds-post-loop `card_layout = program`  (legacy instances, never removed)
+ *   - ds-cta       `cta_style   = style6`   (where new work is built)
+ * produce byte-identical markup by construction rather than by testing. That is
+ * what makes migrating existing instances safe, and what lets un-migrated sites
+ * keep working forever.
+ *
+ * Settings contract (identical keys in both modules, so migration is a verbatim
+ * carry): show_header, heading, show_button, button_text, button_link, display
+ * (+ pagination/carousel keys), programs[], pg_*.
+ *
+ * @package ds-toolkit
+ * @since   1.10.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class DS_Program_Cards {
+
+	/**
+	 * Register the per-card repeater form.
+	 *
+	 * The Post Loop module registers `ds_program_form` itself for its legacy
+	 * layout. A host module must not depend on that, because Post Loop can be
+	 * switched off in DS Toolkit settings while CTA stays on — the repeater would
+	 * then point at an unregistered form. Re-registering the same id with the same
+	 * config is a harmless overwrite, so callers can always call this.
+	 */
+	public static function register_form() {
+		if ( ! class_exists( 'FLBuilder' ) ) {
+			return;
+		}
+		FLBuilder::register_settings_form(
+			'ds_program_form',
+			array(
+				'title' => __( 'Program', 'ds-toolkit' ),
+				'tabs'  => array(
+					'general' => array(
+						'title'    => '',
+						'sections' => array(
+							'general' => array(
+								'title'  => '',
+								'fields' => array(
+									'prog_icon'       => array( 'type' => 'icon', 'label' => __( 'Icon', 'ds-toolkit' ), 'show_remove' => true, 'help' => __( 'Optional. Shown instead of the image when set.', 'ds-toolkit' ) ),
+									'prog_image'      => array( 'type' => 'photo', 'label' => __( 'Image', 'ds-toolkit' ), 'show_remove' => true, 'connections' => array( 'photo' ), 'help' => __( 'Used when no icon is set.', 'ds-toolkit' ) ),
+									'prog_date'       => array( 'type' => 'text', 'label' => __( 'Date', 'ds-toolkit' ), 'connections' => array( 'string' ) ),
+									'prog_subheading' => array( 'type' => 'text', 'label' => __( 'Sub-heading', 'ds-toolkit' ), 'connections' => array( 'string' ) ),
+									'prog_title'      => array( 'type' => 'text', 'label' => __( 'Title', 'ds-toolkit' ), 'connections' => array( 'string' ) ),
+									'prog_desc'       => array( 'type' => 'editor', 'label' => __( 'Description', 'ds-toolkit' ), 'media_buttons' => false, 'rows' => 6, 'wpautop' => false, 'connections' => array( 'string' ) ),
+									'prog_url'        => array( 'type' => 'link', 'label' => __( 'Link', 'ds-toolkit' ), 'show_target' => true, 'connections' => array( 'url' ) ),
+									'prog_btn'        => array( 'type' => 'text', 'label' => __( 'Button Text', 'ds-toolkit' ), 'help' => __( 'Optional. With text a button shows; blank makes the whole card the link.', 'ds-toolkit' ) ),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Heading markup: safe inline HTML, {a}..{/a} -> accent span,
+	 * {outline}..{/outline} -> outline span, newlines -> <br>.
+	 *
+	 * @param string $raw Raw heading text.
+	 * @return string
+	 */
+	public static function heading_html( $raw ) {
+		$h = DS_Module_UI::inline( (string) $raw );
+		$h = str_replace( array( '{a}', '{/a}' ), array( '<span class="ds-news-accent">', '</span>' ), $h );
+		$h = str_replace( array( '{outline}', '{/outline}' ), array( '<span class="ds-outline-text">', '</span>' ), $h );
+		return nl2br( $h );
+	}
+
+	/**
+	 * Optional header row: {a}accent{/a} heading + "see all" button.
+	 *
+	 * @param object $s Module settings.
+	 */
+	public static function head( $s ) {
+		if ( ( $s->show_header ?? 'yes' ) !== 'yes' ) {
+			return;
+		}
+		$show_btn = ( $s->show_button ?? 'yes' ) === 'yes';
+		$has_h    = ! empty( $s->heading );
+		if ( ! $has_h && ! $show_btn ) {
+			return;
+		}
+
+		echo '<div class="ds-news-head">';
+		if ( $has_h ) {
+			echo '<h2 class="ds-news-heading">' . self::heading_html( $s->heading ) . '</h2>';
+		}
+		if ( $show_btn ) {
+			$txt = trim( (string) ( $s->button_text ?? '' ) );
+			if ( '' !== $txt ) {
+				list( $url, $target ) = DS_Card::link_parts( $s->button_link ?? '' );
+				$rel = '_blank' === $target ? ' rel="noopener noreferrer"' : '';
+				echo '<a class="ds-news-seeall" href="' . $url . '" target="' . esc_attr( $target ) . '"' . $rel . '>' . esc_html( $txt ) . '</a>';
+			}
+		}
+		echo '</div>';
+	}
+
+	/**
+	 * Items wrapper open (grid / paginated / carousel).
+	 *
+	 * @param object $s           Module settings.
+	 * @param string $grid_class  Grid CSS class.
+	 */
+	public static function open( $s, $grid_class ) {
+		$dmode = $s->display ?? 'grid';
+		if ( 'paginated' === $dmode ) {
+			$pp = max( 1, (int) ( $s->pag_per_page ?? 6 ) );
+			$pt = in_array( $s->pag_type ?? 'numbers', array( 'numbers', 'loadmore' ), true ) ? ( $s->pag_type ?? 'numbers' ) : 'numbers';
+			echo '<div class="ds-looppage" data-perpage="' . $pp . '" data-pagtype="' . esc_attr( $pt ) . '"><div class="' . esc_attr( $grid_class ) . '">';
+			return;
+		}
+		if ( 'carousel' !== $dmode ) {
+			echo '<div class="' . esc_attr( $grid_class ) . '">';
+			return;
+		}
+		$data = ' data-autoplay="' . ( ( $s->car_autoplay ?? 'no' ) === 'yes' ? 'yes' : 'no' ) . '"'
+			. ' data-interval="' . max( 1, (int) ( $s->car_interval ?? 5 ) ) . '"'
+			. ' data-loop="' . ( ( $s->car_loop ?? 'yes' ) === 'yes' ? 'yes' : 'no' ) . '"'
+			. ' data-pause="' . ( ( $s->car_pause_hover ?? 'yes' ) === 'yes' ? 'yes' : 'no' ) . '"'
+			. ' data-drag="' . ( ( $s->car_drag ?? 'yes' ) === 'yes' ? 'yes' : 'no' ) . '"'
+			. ' data-speed="' . max( 100, (int) ( $s->car_speed ?? 500 ) ) . '"';
+		echo '<div class="ds-loopcar">';
+		if ( ( $s->car_arrows ?? 'yes' ) === 'yes' ) {
+			echo '<button type="button" class="ds-loopcar-nav ds-loopcar-nav--prev" aria-label="' . esc_attr__( 'Previous', 'ds-toolkit' ) . '"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><path d="M15 6l-6 6 6 6"/></svg></button>';
+			echo '<button type="button" class="ds-loopcar-nav ds-loopcar-nav--next" aria-label="' . esc_attr__( 'Next', 'ds-toolkit' ) . '"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" aria-hidden="true"><path d="M9 6l6 6-6 6"/></svg></button>';
+		}
+		echo '<div class="ds-loopcar-viewport"><div class="ds-loopcar-track ' . esc_attr( $grid_class ) . '"' . $data . '>';
+	}
+
+	/**
+	 * Items wrapper close (matches open()).
+	 *
+	 * @param object $s Module settings.
+	 */
+	public static function close( $s ) {
+		$dmode = $s->display ?? 'grid';
+		if ( 'paginated' === $dmode ) {
+			echo '</div><div class="ds-looppage-nav"></div></div>';
+			return;
+		}
+		if ( 'carousel' !== $dmode ) {
+			echo '</div>';
+			return;
+		}
+		echo '</div></div>';
+		if ( ( $s->car_dots ?? 'yes' ) === 'yes' ) {
+			echo '<div class="ds-loopcar-dots"></div>';
+		}
+		echo '</div>';
+	}
+
+	/**
+	 * Render the whole Program Cards section.
+	 *
+	 * @param object $s          Module settings.
+	 * @param string $empty_hint Builder-only hint shown when there are no cards.
+	 */
+	public static function render( $s, $empty_hint = '' ) {
+		$items = ( isset( $s->programs ) && is_array( $s->programs ) ) ? $s->programs : array();
+
+		// A custom Button Radius opts out of the theme Button Shape (clip-path) so the
+		// radius shows; blank keeps the theme shape (button follows the theme by default).
+		$btn_cls = 'ds-program-btn' . ( ( $s->pg_btn_style ?? 'theme' ) === 'custom' ? ' ds-no-clip' : '' );
+
+		echo '<section class="ds-news ds-programs"><div class="ds-news-wrap">';
+		self::head( $s );
+
+		if ( empty( $items ) ) {
+			if ( FLBuilderModel::is_builder_active() ) {
+				if ( '' === $empty_hint ) {
+					$empty_hint = __( 'No program cards yet. Add them in the Program Cards list.', 'ds-toolkit' );
+				}
+				echo '<p style="padding:14px;opacity:.7">' . esc_html( $empty_hint ) . '</p>';
+			}
+			echo '</div></section>';
+			return;
+		}
+
+		self::open( $s, 'ds-program-grid' );
+
+		foreach ( $items as $it ) {
+			$it    = (object) $it;
+			$icon  = trim( (string) ( $it->prog_icon ?? '' ) );
+			$img   = DS_Card::photo_url( $it->prog_image ?? '' );
+			$date  = trim( (string) ( $it->prog_date ?? '' ) );
+			$sub   = trim( (string) ( $it->prog_subheading ?? '' ) );
+			$title = trim( (string) ( $it->prog_title ?? '' ) );
+			$desc  = trim( (string) ( $it->prog_desc ?? '' ) );
+			list( $url, $target ) = DS_Card::link_parts( $it->prog_url ?? '' );
+			$hasurl = ( '' !== $url && '#' !== $url );
+			$tgt    = ( '_blank' === $target ) ? ' target="_blank" rel="noopener"' : '';
+			$btn    = trim( (string) ( $it->prog_btn ?? '' ) );
+
+			echo '<div class="ds-program-card">';
+			if ( $hasurl && '' === $btn ) {
+				echo '<a class="ds-card-link" href="' . esc_url( $url ) . '"' . $tgt . ' aria-label="' . esc_attr( $title ) . '"></a>';
+			}
+			if ( '' !== $icon ) {
+				echo '<span class="ds-program-ico"><i class="' . esc_attr( $icon ) . '" aria-hidden="true"></i></span>';
+			} elseif ( '' !== $img ) {
+				echo '<div class="ds-program-media"><img src="' . esc_url( $img ) . '" alt="' . esc_attr( $title ) . '" loading="lazy" /></div>';
+			}
+			echo '<div class="ds-program-body">';
+			if ( '' !== $date ) {
+				echo '<span class="ds-program-date">' . esc_html( $date ) . '</span>';
+			}
+			if ( '' !== $sub ) {
+				echo '<span class="ds-program-sub">' . esc_html( $sub ) . '</span>';
+			}
+			if ( '' !== $title ) {
+				echo '<h3 class="ds-program-title">' . DS_Module_UI::inline( $title ) . '</h3>';
+			}
+			if ( '' !== $desc ) {
+				echo '<div class="ds-program-desc">' . wpautop( wp_kses_post( $desc ) ) . '</div>';
+			}
+			if ( '' !== $btn && $hasurl ) {
+				echo '<a class="' . esc_attr( $btn_cls ) . '" href="' . esc_url( $url ) . '"' . $tgt . '>' . esc_html( $btn ) . '</a>';
+			}
+			echo '</div></div>';
+		}
+
+		self::close( $s );
+		echo '</div></section>';
+	}
+
+	/**
+	 * Header chrome: heading colours, the "see all" button, the header divider and
+	 * the shared Border & Divider block.
+	 *
+	 * The header markup (.ds-news-head / .ds-news-heading / .ds-news-seeall) comes
+	 * from head() above, so a host module must emit these or a migrated node loses
+	 * its heading colour and the rule under the header — which measurably changes
+	 * page height, not just colour.
+	 *
+	 * @param string $node     Node selector.
+	 * @param object $settings Module settings.
+	 */
+	public static function header_css( $node, $settings ) {
+		$col = array( 'DS_Module_UI', 'color' );
+		$u   = array( 'DS_Module_UI', 'u' );
+
+		// ---- Header text ----
+		$hc = $col( $settings->heading_color ?? '' );
+		if ( $hc ) {
+			echo "$node .ds-news-heading { color: {$hc}; }\n";
+		}
+		$hac = $col( $settings->heading_accent_color ?? '' );
+		if ( $hac ) {
+			echo "$node .ds-news-accent { color: {$hac}; }\n";
+		}
+
+		// ---- "See all" button: default to the Theme Setting global Button ----
+		$btn = $settings->btn_global ?? 'yes';
+		$gs  = class_exists( 'FLBuilderGlobalStyles' ) ? FLBuilderGlobalStyles::get_settings( false ) : null;
+		if ( 'yes' === $btn && $gs ) {
+			DS_Module_UI::global_button_css( "$node .ds-news-seeall" );
+		} elseif ( 'accent' === $btn ) {
+			$ac = $col( $settings->heading_accent_color ?? 'var(--fl-global-accent)' );
+			echo "$node .ds-news-seeall { background: {$ac} !important; color: var(--fl-global-white) !important; }\n";
+		} else {
+			$dbg = $col( $settings->btn_dark_bg ?? 'var(--fl-global-dark-background)' );
+			$dtx = $col( $settings->btn_dark_color ?? 'var(--fl-global-white)' );
+			if ( $dbg ) {
+				echo "$node .ds-news-seeall { background: {$dbg} !important; }\n";
+			}
+			if ( $dtx ) {
+				echo "$node .ds-news-seeall { color: {$dtx} !important; }\n";
+			}
+		}
+
+		// ---- Header divider (line between header and content) ----
+		$hd = $settings->header_divider ?? 'none';
+		if ( in_array( $hd, array( 'solid', 'dashed', 'dotted' ), true ) && ( $settings->show_header ?? 'yes' ) === 'yes' ) {
+			$hdw = $u( $settings->header_divider_w ?? '', 1 );
+			$hdc = $col( $settings->header_divider_color ?? '' ) ?: 'var(--fl-global-line-color)';
+			$hdg = $u( $settings->header_divider_gap ?? '', 24 );
+			echo "$node .ds-news-head { border-bottom: {$hdw}px {$hd} {$hdc}; padding-bottom: {$hdg}px; }\n";
+		}
+
+		// ---- Shared Border & Divider (DS_Module_UI) ----
+		if ( class_exists( 'DS_Module_UI' ) ) {
+			DS_Module_UI::emit_css( $node, $settings, '.ds-news', '.ds-news-head' );
+		}
+	}
+
+	/**
+	 * Shared card chrome: section background, hover effect and the unified Card
+	 * Border, scoped to .ds-program-card only.
+	 *
+	 * ds-post-loop emits these from its own CSS file for a selector list covering
+	 * every card layout. A host module that only renders program cards (CTA
+	 * Style 6) needs the same rules or a migrated node loses its border and hover,
+	 * so they live here and stay in lockstep.
+	 *
+	 * @param string $node     Node selector, e.g. ".fl-node-abc123".
+	 * @param object $settings Module settings.
+	 */
+	public static function chrome_css( $node, $settings ) {
+		$col = array( 'DS_Module_UI', 'color' );
+		$u   = array( 'DS_Module_UI', 'u' );
+
+		$card  = "$node .ds-program-card";
+		$cardH = "$node .ds-program-card:hover";
+
+		// ---- Section background ----
+		$sbg = $col( $settings->section_bg ?? '' );
+		if ( '' !== $sbg ) {
+			echo "$node .ds-news { background: {$sbg}; }\n";
+		}
+
+		// ---- Hover & animation ----
+		$he     = preg_replace( '/[^a-z]/', '', (string) ( $settings->hover_effect ?? 'lift' ) );
+		$hspeed = $u( $settings->hover_speed ?? '', 300 );
+
+		$hbg = $col( $settings->hover_bg ?? '' );
+		if ( '' !== $hbg ) {
+			echo "$card{transition:transform {$hspeed}ms ease,box-shadow {$hspeed}ms ease,border-color {$hspeed}ms ease,background {$hspeed}ms ease;}\n";
+			echo "$cardH{background:{$hbg};}\n";
+		}
+
+		if ( $he && 'none' !== $he ) {
+			echo "$card{transition:transform {$hspeed}ms ease,box-shadow {$hspeed}ms ease,border-color {$hspeed}ms ease;will-change:transform;}\n";
+			if ( 'lift' === $he ) {
+				$d  = $u( $settings->hover_distance ?? '', 6 );
+				$sc = $col( $settings->hover_shadow_color ?? '' ) ?: 'rgba(10,30,60,.28)';
+				echo "$cardH{transform:translateY(-{$d}px);box-shadow:0 18px 38px -18px {$sc};}\n";
+			} elseif ( 'grow' === $he ) {
+				$sc    = $col( $settings->hover_shadow_color ?? '' ) ?: 'rgba(10,30,60,.22)';
+				$scale = max( 100, (int) ( $settings->hover_scale ?? 105 ) ) / 100;
+				echo "$cardH{transform:scale({$scale});box-shadow:0 18px 38px -18px {$sc};}\n";
+			} elseif ( 'shadow' === $he ) {
+				$sc = $col( $settings->hover_shadow_color ?? '' ) ?: 'rgba(10,30,60,.25)';
+				echo "$cardH{box-shadow:0 18px 40px -18px {$sc};}\n";
+			} elseif ( 'border' === $he ) {
+				$bc = $col( $settings->hover_border_color ?? '' ) ?: 'var(--fl-global-accent)';
+				echo "$cardH{border-color:{$bc};box-shadow:inset 0 0 0 1px {$bc};}\n";
+			} elseif ( 'zoom' === $he ) {
+				$scale = max( 100, (int) ( $settings->hover_scale ?? 105 ) ) / 100;
+				echo "$node .ds-program-media img{transition:transform {$hspeed}ms ease;}\n";
+				echo "$cardH .ds-program-media img{transform:scale({$scale});}\n";
+			}
+		}
+
+		// ---- Unified Card Border (opt-in; blank/default leaves the layout look) ----
+		$bs    = preg_replace( '/[^a-z]/', '', (string) ( $settings->card_bd_style ?? 'default' ) );
+		$bdecl = '';
+		if ( $bs && 'default' !== $bs ) {
+			if ( 'none' === $bs ) {
+				$bdecl .= 'border:0 !important;';
+			} else {
+				$bw = $u( $settings->card_bd_width ?? '', 1 );
+				$bc = $col( $settings->card_bd_color ?? '' ) ?: 'var(--fl-global-line-color)';
+				$bdecl .= "border-style:{$bs} !important;border-width:{$bw}px !important;border-color:{$bc} !important;";
+			}
+		}
+		if ( isset( $settings->card_bd_radius ) && '' !== trim( (string) $settings->card_bd_radius ) ) {
+			$bdecl .= 'border-radius:' . (int) $settings->card_bd_radius . 'px !important;';
+		}
+		if ( '' !== $bdecl ) {
+			echo "$card{{$bdecl}}\n";
+		}
+	}
+
+	/**
+	 * Dynamic per-node CSS for the program cards (pg_* settings).
+	 *
+	 * Mirrors the block in ds-post-loop/includes/frontend.css.php so a migrated
+	 * node renders identically. Emits only the program-specific rules; the shared
+	 * card/hover/border rules are emitted by the host module's own CSS file.
+	 *
+	 * @param string $node     Node selector, e.g. ".fl-node-abc123".
+	 * @param object $settings Module settings.
+	 */
+	public static function css( $node, $settings ) {
+		$col = array( 'DS_Module_UI', 'color' );
+		$u   = array( 'DS_Module_UI', 'u' );
+
+		$pgc = max( 1, (int) ( $settings->pg_cols ?? 3 ) );
+		$pgg = $u( $settings->pg_gap ?? '', 24 );
+		echo "$node .ds-program-grid{grid-template-columns:repeat({$pgc},1fr);gap:{$pgg}px;}\n";
+		echo "@media(max-width:1024px){ $node .ds-program-grid{grid-template-columns:repeat(2,1fr);} }\n";
+		echo "@media(max-width:600px){ $node .ds-program-grid{grid-template-columns:1fr;} }\n";
+
+		if ( ( $settings->pg_same_height ?? 'yes' ) === 'yes' ) {
+			echo "$node .ds-program-grid{align-items:stretch;} $node .ds-program-card{height:100%;}\n";
+		} else {
+			echo "$node .ds-program-grid{align-items:start;} $node .ds-program-card{height:auto;}\n";
+		}
+
+		$pgpad = $u( $settings->pg_pad ?? '', 28 );
+		$pgbg  = $col( $settings->pg_card_bg ?? '' );
+		echo "$node .ds-program-card{padding:{$pgpad}px;" . ( $pgbg ? "background:{$pgbg};" : '' ) . "}\n";
+
+		$pal = ( ( $settings->pg_align ?? 'left' ) === 'center' ) ? 'center' : 'left';
+		$pai = ( 'center' === $pal ) ? 'center' : 'flex-start';
+		echo "$node .ds-program-card{text-align:{$pal};align-items:{$pai};}\n";
+
+		$pih = $u( $settings->pg_img_h ?? '', 180 );
+		echo "$node .ds-program-media{height:{$pih}px;}\n";
+
+		$pis = $u( $settings->pg_icon_size ?? '', 40 );
+		echo "$node .ds-program-ico{font-size:{$pis}px;line-height:1;}\n";
+
+		$pc = $col( $settings->pg_icon_color ?? '' );
+		if ( $pc ) {
+			echo "$node .ds-program-ico{color:{$pc};}\n";
+		}
+		$pc = $col( $settings->pg_date_color ?? '' );
+		if ( $pc ) {
+			echo "$node .ds-program-date{color:{$pc};}\n";
+		}
+		$pc = $col( $settings->pg_sub_color ?? '' );
+		if ( $pc ) {
+			echo "$node .ds-program-sub{color:{$pc};}\n";
+		}
+		$pc = $col( $settings->pg_title_color ?? '' );
+		if ( $pc ) {
+			echo "$node .ds-program-title{color:{$pc};}\n";
+		}
+		$pc = $col( $settings->pg_desc_color ?? '' );
+		if ( $pc ) {
+			echo "$node .ds-program-desc{color:{$pc};}\n";
+		}
+
+		if ( ( $settings->pg_btn_style ?? 'theme' ) !== 'custom' ) {
+			// FULL theme Button sync (bg, text, hover, border + radius + shadow, typography).
+			DS_Module_UI::global_button_css(
+				"$node .ds-programs .ds-program-card .ds-program-btn",
+				"$node .ds-programs .ds-program-card .ds-program-btn:hover, $node .ds-programs .ds-program-card:hover .ds-program-btn"
+			);
+		} else {
+			$bbg   = $col( $settings->pg_btn_bg ?? '' );
+			$btc   = $col( $settings->pg_btn_color ?? '' );
+			$bdecl = '';
+			if ( $bbg ) {
+				$bdecl .= "background:{$bbg};";
+			}
+			if ( $btc ) {
+				$bdecl .= "color:{$btc};";
+			}
+			$brad = $settings->pg_btn_radius ?? '';
+			if ( '' !== $brad ) {
+				$bdecl .= 'border-radius:' . (int) $brad . 'px;';
+			}
+			if ( '' !== $bdecl ) {
+				echo "$node .ds-programs .ds-program-card .ds-program-btn{{$bdecl}}\n";
+			}
+			$bhb = $col( $settings->pg_btn_hover_bg ?? '' );
+			$bhc = $col( $settings->pg_btn_hover_color ?? '' );
+			$bhd = '';
+			if ( $bhb ) {
+				$bhd .= "background:{$bhb};";
+			}
+			if ( $bhc ) {
+				$bhd .= "color:{$bhc};";
+			}
+			if ( '' !== $bhd ) {
+				echo "$node .ds-programs .ds-program-card .ds-program-btn:hover,$node .ds-programs .ds-program-card:hover .ds-program-btn{{$bhd}}\n";
+			}
+		}
+	}
+}

--- a/modules/ds-cta/css/frontend.css
+++ b/modules/ds-cta/css/frontend.css
@@ -200,3 +200,34 @@
   .ds-mcard,.ds-mcard-bg,.ds-mcard-logo,.ds-mcard-logo img{transition:none !important;animation:none !important;}
   .ds-mcards--logo-always .ds-mcard-logo,.ds-mcard.is-logo-active .ds-mcard-logo{opacity:1 !important;}
 }
+
+/* ==========================================================================
+   Style 6 — Program Cards (manual list).
+   Markup comes from the shared DS_Program_Cards renderer, which emits the
+   .ds-news / .ds-program-* classes. Those base rules also ship with the Post
+   Loop module's stylesheet, but Beaver Builder only enqueues a module's CSS
+   when that module is on the page — so a CTA-only page needs its own copy.
+   Keep byte-identical to modules/ds-post-loop/css/frontend.css.
+   ========================================================================== */
+.ds-news{}
+.ds-news-wrap{width:100%;max-width:1280px;margin:0 auto;padding:0;}
+.ds-news-head{display:flex;align-items:flex-end;justify-content:space-between;gap:24px;margin-bottom:44px;flex-wrap:wrap;}
+.ds-news-heading{font-size:clamp(2.4rem,5vw,3.75rem);line-height:.9;letter-spacing:-.01em;text-transform:uppercase;font-weight:900;margin:0;color:var(--fl-global-headings);}
+.ds-news-accent{color:var(--fl-global-accent);}
+.ds-news-seeall{display:inline-block;font-weight:800;font-size:.875rem;letter-spacing:.1em;text-transform:uppercase;color:var(--fl-global-white);text-decoration:none;background:var(--fl-global-headings);padding:13px 26px;white-space:nowrap;clip-path:polygon(8px 0,100% 0,calc(100% - 8px) 100%,0 100%);transition:filter .2s ease,transform .2s ease;}
+.ds-news-seeall:hover{filter:brightness(1.12);transform:translateY(-1px);}
+.ds-card-link{position:absolute;inset:0;z-index:1;border-radius:inherit;font-size:0;text-decoration:none;}
+.ds-program-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:24px;}
+.ds-program-card{position:relative;display:flex;flex-direction:column;gap:10px;padding:28px;background:var(--fl-global-light-background);border-radius:var(--ds-radius);align-items:flex-start;text-align:left;height:100%;}
+.ds-program-ico{display:inline-flex;color:var(--fl-global-accent);font-size:40px;line-height:1;}
+.ds-program-media{width:100%;height:180px;border-radius:var(--ds-radius);overflow:hidden;}
+.ds-program-media img{width:100%;height:100%;object-fit:cover;display:block;}
+.ds-program-body{display:flex;flex-direction:column;gap:6px;width:100%;flex:1 1 auto;}
+.ds-program-desc p{margin:0 0 .6em;}
+.ds-program-desc p:last-child{margin-bottom:0;}
+.ds-program-date{font-size:.8rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:var(--fl-global-accent);}
+.ds-program-sub{font-size:.85rem;font-weight:600;opacity:.85;}
+.ds-program-title{margin:0;color:var(--fl-global-headings);font-size:1.25rem;line-height:1.2;}
+.ds-program-desc{margin:0;color:var(--fl-global-body);font-size:.95rem;line-height:1.5;}
+.fl-builder-content .ds-program-card .ds-program-btn{align-self:flex-start;flex-shrink:0;margin-top:auto;display:inline-block;background:var(--fl-global-button);color:var(--fl-global-white);padding:10px 22px;border-radius:6px;font-weight:700;font-size:.82rem;letter-spacing:1px;text-transform:uppercase;text-decoration:none;transition:background .2s ease;position:relative;z-index:2;}
+.fl-builder-content .ds-program-card .ds-program-btn:hover,.fl-builder-content .ds-program-card:hover .ds-program-btn{background:var(--fl-global-accent);color:var(--fl-global-white);}

--- a/modules/ds-cta/ds-cta.php
+++ b/modules/ds-cta/ds-cta.php
@@ -44,6 +44,22 @@ class DS_CTA_Module extends FLBuilderModule {
 			'style3' => __( 'Style 3 — Bento Grid', 'ds-toolkit' ),
 			'style4' => __( 'Style 4 — Big Hero (Contact)', 'ds-toolkit' ),
 			'style5' => __( 'Style 5 — Motion Cards (image + logo overlay)', 'ds-toolkit' ),
+			'style6' => __( 'Style 6 — Program Cards (manual list)', 'ds-toolkit' ),
+		);
+	}
+
+	/**
+	 * Style 6 — Program Cards: a hand-built list of cards (date, sub-heading,
+	 * title, description, link/button, icon or image).
+	 *
+	 * This card used to live in the Post Loop module as `card_layout = program`,
+	 * which was wrong: it never queries a post type. It renders through the shared
+	 * DS_Program_Cards so legacy Post Loop instances and this style are identical.
+	 */
+	public function render_style6() {
+		DS_Program_Cards::render(
+			$this->settings,
+			__( 'No program cards yet. Add them in the Program Cards list.', 'ds-toolkit' )
 		);
 	}
 
@@ -431,6 +447,10 @@ class DS_CTA_Module extends FLBuilderModule {
 	}
 }
 
+/* Style 6 per-card sub-form. Owned by the shared class so this module never
+   depends on the Post Loop module being enabled. */
+DS_Program_Cards::register_form();
+
 /* ----------------------------------------------------------- Card sub-form */
 FLBuilder::register_settings_form( 'ds_cta_card_form', array(
 	'title' => __( 'Card', 'ds-toolkit' ),
@@ -498,6 +518,9 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 							),
 							'style5' => array(
 								'sections' => array( 'header', 'cards', 'mcard', 'mcard_fx', 'mcard_logo', 'typography', 'spacing' ),
+							),
+							'style6' => array(
+								'sections' => array( 'header', 'programs_sec', 'program_opts', 'program_chrome', 'spacing' ),
 							),
 						),
 					),
@@ -635,6 +658,23 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 						'help'    => __( 'Pulled from Partner Settings (Facebook, Instagram, X, YouTube, LinkedIn, TikTok). Networks with no URL are skipped.', 'ds-toolkit' ),
 					),
 					'hero_social_target' => array( 'type' => 'select', 'label' => __( 'Open Links In', 'ds-toolkit' ), 'default' => '_blank', 'options' => array( '_blank' => __( 'New Tab', 'ds-toolkit' ), '_self' => __( 'Same Tab', 'ds-toolkit' ) ) ),
+				),
+			),
+			// ---- Style 6 only: manual Program Cards list ----
+			// Key stays `programs` (NOT `cards`) so a node migrated from the Post
+			// Loop module carries its list verbatim and never collides with the
+			// styles 1-5 `cards` repeater.
+			'programs_sec' => array(
+				'title'       => __( 'Program Cards (manual list)', 'ds-toolkit' ),
+				'description' => __( 'Build each card by hand: date, sub-heading, title, description, a link/button, and an icon or image.', 'ds-toolkit' ),
+				'fields'      => array(
+					'programs' => array(
+						'type'         => 'form',
+						'label'        => __( 'Program', 'ds-toolkit' ),
+						'form'         => 'ds_program_form',
+						'preview_text' => 'prog_title',
+						'multiple'     => true,
+					),
 				),
 			),
 		),
@@ -1044,6 +1084,55 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 					'mcl_delay'  => array( 'type' => 'unit', 'label' => __( 'Animation Delay', 'ds-toolkit' ), 'default' => '0', 'description' => 'ms', 'slider' => array( 'min' => 0, 'max' => 2000, 'step' => 50 ) ),
 					'mcl_ease'   => array( 'type' => 'select', 'label' => __( 'Animation Easing', 'ds-toolkit' ), 'default' => 'ease-out', 'options' => array( 'ease' => 'Ease', 'ease-out' => 'Ease Out', 'ease-in-out' => 'Ease In-Out', 'cubic-bezier(.34,1.56,.64,1)' => __( 'Spring (overshoot)', 'ds-toolkit' ) ) ),
 					'mcl_hover'  => array( 'type' => 'select', 'label' => __( 'Hover Animation', 'ds-toolkit' ), 'default' => 'float', 'options' => array( 'none' => __( 'None', 'ds-toolkit' ), 'scale-up' => __( 'Scale Up', 'ds-toolkit' ), 'scale-down' => __( 'Scale Down', 'ds-toolkit' ), 'float' => __( 'Float', 'ds-toolkit' ), 'bounce' => __( 'Bounce', 'ds-toolkit' ), 'rotate' => __( 'Rotate', 'ds-toolkit' ), 'pulse' => __( 'Pulse', 'ds-toolkit' ), 'fade' => __( 'Fade', 'ds-toolkit' ), 'glow' => __( 'Glow', 'ds-toolkit' ) ) ),
+				),
+			),
+			// ---- Style 6 only: Program Card options. Keys mirror the Post Loop
+			// module's `program_opts` exactly so migration is a verbatim carry. ----
+			'program_opts' => array(
+				'title'  => __( 'Program Cards', 'ds-toolkit' ),
+				'fields' => array(
+					'pg_cols'        => array( 'type' => 'unit', 'label' => __( 'Columns', 'ds-toolkit' ), 'default' => '3', 'slider' => array( 'min' => 1, 'max' => 6, 'step' => 1 ) ),
+					'pg_gap'         => array( 'type' => 'unit', 'label' => __( 'Gap', 'ds-toolkit' ), 'default' => '24', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 60, 'step' => 1 ) ),
+					'pg_align'       => array( 'type' => 'select', 'label' => __( 'Alignment', 'ds-toolkit' ), 'default' => 'left', 'options' => array( 'left' => __( 'Left', 'ds-toolkit' ), 'center' => __( 'Center', 'ds-toolkit' ) ) ),
+					'pg_same_height' => array( 'type' => 'select', 'label' => __( 'Card Height', 'ds-toolkit' ), 'default' => 'yes', 'options' => array( 'yes' => __( 'Equal (match tallest in row)', 'ds-toolkit' ), 'no' => __( 'Natural (fit content)', 'ds-toolkit' ) ), 'help' => __( 'Equal makes every card in a row the same height (buttons line up at the bottom).', 'ds-toolkit' ) ),
+					'pg_card_bg'     => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Card Background', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+					'pg_pad'         => array( 'type' => 'unit', 'label' => __( 'Card Padding', 'ds-toolkit' ), 'default' => '28', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 60, 'step' => 1 ) ),
+					'pg_img_h'       => array( 'type' => 'unit', 'label' => __( 'Image Height', 'ds-toolkit' ), 'default' => '180', 'description' => 'px', 'slider' => array( 'min' => 80, 'max' => 360, 'step' => 1 ), 'help' => __( 'Image height for items that use an image (not an icon).', 'ds-toolkit' ), 'preview' => array( 'type' => 'css', 'selector' => '.ds-program-media', 'property' => 'height', 'unit' => 'px' ) ),
+					'pg_icon_size'   => array( 'type' => 'unit', 'label' => __( 'Icon Size', 'ds-toolkit' ), 'default' => '40', 'description' => 'px', 'slider' => array( 'min' => 16, 'max' => 96, 'step' => 1 ), 'preview' => array( 'type' => 'css', 'selector' => '.ds-program-ico', 'property' => 'font-size', 'unit' => 'px' ) ),
+					'pg_icon_color'  => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Icon Colour', 'ds-toolkit' ), 'default' => 'var(--fl-global-accent)', 'show_reset' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-program-ico', 'property' => 'color' ) ),
+					'pg_date_color'  => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Date Colour', 'ds-toolkit' ), 'default' => 'var(--fl-global-accent)', 'show_reset' => true ),
+					'pg_sub_color'   => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Sub-heading Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+					'pg_title_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Title Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+					'pg_desc_color'  => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Description Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+					'pg_btn_style'      => array( 'type' => 'select', 'label' => __( 'Button Style', 'ds-toolkit' ), 'default' => 'theme', 'options' => array( 'theme' => __( 'Theme button (default)', 'ds-toolkit' ), 'custom' => __( 'Custom', 'ds-toolkit' ) ), 'toggle' => array( 'custom' => array( 'fields' => array( 'pg_btn_bg', 'pg_btn_color', 'pg_btn_hover_bg', 'pg_btn_hover_color', 'pg_btn_radius' ) ) ), 'help' => __( 'Theme button follows Theme Setting (colour + shape). Choose Custom to style this card\'s button below.', 'ds-toolkit' ) ),
+					'pg_btn_bg'         => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Button Background', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Blank = the global Button colour.', 'ds-toolkit' ) ),
+					'pg_btn_color'      => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Button Text', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+					'pg_btn_hover_bg'   => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Button Hover Background', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+					'pg_btn_hover_color'=> array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Button Hover Text', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+					'pg_btn_radius'     => array( 'type' => 'unit', 'label' => __( 'Button Radius', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 40, 'step' => 1 ), 'help' => __( 'Blank = follow the theme Button Shape. Set a value for a custom rounded button (overrides the theme shape for this card).', 'ds-toolkit' ) ),
+					'pg_date_typo'      => array( 'type' => 'typography', 'label' => __( 'Date Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-program-date' ) ),
+					'pg_sub_typo'       => array( 'type' => 'typography', 'label' => __( 'Sub-heading Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-program-sub' ) ),
+					'pg_title_typo'     => array( 'type' => 'typography', 'label' => __( 'Title Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-program-title' ) ),
+					'pg_desc_typo'      => array( 'type' => 'typography', 'label' => __( 'Description Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-program-desc' ) ),
+					'pg_btn_typo'       => array( 'type' => 'typography', 'label' => __( 'Button Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-program-btn' ) ),
+				),
+			),
+			// Card border + hover. Same keys as the Post Loop module's shared
+			// `card_border` / `hover` sections so migrated values keep applying.
+			'program_chrome' => array(
+				'title'  => __( 'Card Border & Hover', 'ds-toolkit' ),
+				'fields' => array(
+					'card_bd_style'  => array( 'type' => 'select', 'label' => __( 'Border Style', 'ds-toolkit' ), 'default' => 'default', 'options' => array( 'default' => __( 'Default (layout look)', 'ds-toolkit' ), 'none' => __( 'None', 'ds-toolkit' ), 'solid' => __( 'Solid', 'ds-toolkit' ), 'dashed' => __( 'Dashed', 'ds-toolkit' ), 'dotted' => __( 'Dotted', 'ds-toolkit' ) ), 'toggle' => array( 'solid' => array( 'fields' => array( 'card_bd_width', 'card_bd_color' ) ), 'dashed' => array( 'fields' => array( 'card_bd_width', 'card_bd_color' ) ), 'dotted' => array( 'fields' => array( 'card_bd_width', 'card_bd_color' ) ) ) ),
+					'card_bd_width'  => array( 'type' => 'unit', 'label' => __( 'Border Width', 'ds-toolkit' ), 'default' => '1', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 12, 'step' => 1 ) ),
+					'card_bd_color'  => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Border Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Blank = the global Line Color.', 'ds-toolkit' ) ),
+					'card_bd_radius' => array( 'type' => 'unit', 'label' => __( 'Corner Radius', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 40, 'step' => 1 ), 'help' => __( 'Blank = the theme corner radius.', 'ds-toolkit' ) ),
+					'hover_effect'   => array( 'type' => 'select', 'label' => __( 'Hover Effect', 'ds-toolkit' ), 'default' => 'lift', 'options' => array( 'none' => __( 'None', 'ds-toolkit' ), 'lift' => __( 'Lift', 'ds-toolkit' ), 'grow' => __( 'Grow', 'ds-toolkit' ), 'shadow' => __( 'Shadow', 'ds-toolkit' ), 'border' => __( 'Border', 'ds-toolkit' ), 'zoom' => __( 'Zoom Image', 'ds-toolkit' ) ) ),
+					'hover_speed'    => array( 'type' => 'unit', 'label' => __( 'Hover Speed', 'ds-toolkit' ), 'default' => '300', 'description' => 'ms', 'slider' => array( 'min' => 0, 'max' => 900, 'step' => 10 ) ),
+					'hover_bg'       => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Hover Background', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+					// NOTE: `section_bg` is deliberately NOT redefined here — the module
+					// already declares it (Colors section). A second definition of the
+					// same key would render the control twice and fight over the default.
+					// A migrated node's stored value still applies via chrome_css().
 				),
 			),
 			'spacing' => array(

--- a/modules/ds-cta/includes/frontend.css.php
+++ b/modules/ds-cta/includes/frontend.css.php
@@ -368,19 +368,53 @@ if ( 'style3' === $style ) {
 	$typo = array( 'heading_typography' => '.ds-cta-heading', 'title_typography' => '.ds-cta-card-title', 'eyebrow_typography' => '.ds-cta-card-eyebrow' );
 }
 
+// ---- Style 6: Program Cards (manual list) ----
+// Markup comes from the shared DS_Program_Cards renderer, so the wrappers are
+// .ds-news / .ds-news-wrap (not .ds-cta*) and the CSS has to match the Post Loop
+// module's output exactly or a migrated node changes appearance.
+$is_program = ( 'style6' === $style );
+if ( $is_program ) {
+	DS_Program_Cards::header_css( $node, $settings );
+	DS_Program_Cards::chrome_css( $node, $settings );
+	DS_Program_Cards::css( $node, $settings );
+
+	// Content width, mirroring the Post Loop module.
+	$cw = $settings->content_width ?? 'boxed';
+	if ( 'full' === $cw ) {
+		echo "$node .ds-news-wrap { max-width: none; margin: 0; }\n";
+	} elseif ( 'custom' === $cw ) {
+		$cmw = ( isset( $settings->content_max_width ) && '' !== $settings->content_max_width ) ? (int) $settings->content_max_width : 1280;
+		echo "$node .ds-news-wrap { max-width: {$cmw}px; margin: 0 auto; }\n";
+	}
+
+	// The heading element here is .ds-news-heading (shared renderer), NOT
+	// .ds-cta-heading, so the shared `heading_typography` key must be remapped or a
+	// migrated node loses its heading size and the page reflows.
+	$typo = array(
+		'heading_typography' => '.ds-news-heading',
+		'pg_date_typo'       => '.ds-program-date',
+		'pg_sub_typo'        => '.ds-program-sub',
+		'pg_title_typo'      => '.ds-program-title',
+		'pg_desc_typo'       => '.ds-program-desc',
+		'pg_btn_typo'        => '.ds-program-btn',
+	);
+}
+
 // ---- Spacing: padding on the wrap, margin on the section (deferred) ----
+$wrap_sel = $is_program ? '.ds-news-wrap' : '.ds-cta-wrap';
+$sect_sel = $is_program ? '.ds-news' : '.ds-cta';
 if ( class_exists( 'FLBuilderCSS' ) ) {
 	FLBuilderCSS::dimension_field_rule( array(
 		'settings'     => $settings,
 		'setting_name' => 'padding',
-		'selector'     => "$node .ds-cta-wrap",
+		'selector'     => "$node $wrap_sel",
 		'unit'         => 'px',
 		'props'        => array( 'padding-top' => 'padding_top', 'padding-right' => 'padding_right', 'padding-bottom' => 'padding_bottom', 'padding-left' => 'padding_left' ),
 	) );
 	FLBuilderCSS::dimension_field_rule( array(
 		'settings'     => $settings,
 		'setting_name' => 'margin',
-		'selector'     => "$node .ds-cta",
+		'selector'     => "$node $sect_sel",
 		'unit'         => 'px',
 		'props'        => array( 'margin-top' => 'margin_top', 'margin-right' => 'margin_right', 'margin-bottom' => 'margin_bottom', 'margin-left' => 'margin_left' ),
 	) );

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -57,8 +57,38 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 	 * the universal "Loop Card" — always offered for every content type (it loops any
 	 * post type into a grid of built-in or custom cards). Layout keys kept for data compat.
 	 */
-	public static function card_layouts() {
+	/**
+	 * Manual-list layouts that no longer belong in this module.
+	 *
+	 * Neither queries a post type, so they contradict this module's contract
+	 * ("loop over posts of type X"). They now live in the CTA module. They are
+	 * still RENDERED here forever — legacy instances, revision restores and
+	 * un-migrated sites all resolve to them — but they are hidden from the Card
+	 * Layout picker so no NEW instance can be built on them.
+	 *
+	 * @see DS_Program_Cards
+	 */
+	public static function retired_layouts() {
 		return array(
+			'program' => __( 'Custom Program Card (manual list) — moved to CTA', 'ds-toolkit' ),
+			// NOTE: `sponsor` has the same defect (manual list, no query) and belongs
+			// in CTA too, but it has no CTA style yet. Do NOT retire it here until
+			// one exists — hiding it from the picker with nowhere to build it would
+			// leave editors unable to create a sponsor grid at all.
+		);
+	}
+
+	/**
+	 * Card Layout options.
+	 *
+	 * Retired manual-list layouts are omitted, EXCEPT when the module instance
+	 * being edited already uses one. Without that exception the select would have
+	 * no matching option and Beaver Builder would silently fall back to the first
+	 * one, silently converting a partner's program list into a news grid the
+	 * moment they opened the panel.
+	 */
+	public static function card_layouts() {
+		$layouts = array(
 			'news_featured'  => __( 'News: Featured + Grid', 'ds-toolkit' ),
 			'news_grid'      => __( 'News: Card Grid', 'ds-toolkit' ),
 			'staff_card'     => __( 'Staff: Cards', 'ds-toolkit' ),
@@ -67,11 +97,46 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			'athlete_action' => __( 'Athletes: Action Cards', 'ds-toolkit' ),
 			'team_list'      => __( 'Teams: List', 'ds-toolkit' ),
 			'team_card'      => __( 'Teams: Cards (photo grid)', 'ds-toolkit' ),
+			// Still selectable: it has the same manual-list defect as `program` but no
+			// CTA style to move to yet. See retired_layouts().
 			'sponsor'        => __( 'Sponsors: Grid (manual list)', 'ds-toolkit' ),
-			'program'        => __( 'Custom Program Card (manual list)', 'ds-toolkit' ),
 			'tournament'     => __( 'Tournament Cards (events, upcoming)', 'ds-toolkit' ),
 			'custom'         => __( 'Custom Loop Layout', 'ds-toolkit' ),
 		);
+
+		$current = self::editing_card_layout();
+		$retired = self::retired_layouts();
+		if ( '' !== $current && isset( $retired[ $current ] ) ) {
+			$layouts[ $current ] = $retired[ $current ];
+		}
+
+		return $layouts;
+	}
+
+	/**
+	 * The card_layout of the module instance currently open in the builder.
+	 *
+	 * Returns '' when a new module is being inserted (no node id yet), which is
+	 * exactly when the retired layouts must stay hidden.
+	 *
+	 * @return string
+	 */
+	private static function editing_card_layout() {
+		if ( ! class_exists( 'FLBuilderModel' ) ) {
+			return '';
+		}
+		$node_id = isset( $_GET['node'] ) ? sanitize_text_field( wp_unslash( $_GET['node'] ) ) : '';
+		if ( '' === $node_id && isset( $_POST['node_id'] ) ) {
+			$node_id = sanitize_text_field( wp_unslash( $_POST['node_id'] ) );
+		}
+		if ( '' === $node_id ) {
+			return '';
+		}
+		$node = FLBuilderModel::get_node( $node_id );
+		if ( ! is_object( $node ) || ! isset( $node->settings->card_layout ) ) {
+			return '';
+		}
+		return (string) $node->settings->card_layout;
 	}
 	/** Public post types for the Query tab's Post Type select. */
 	public static function post_type_options() {
@@ -974,45 +1039,18 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		echo '</div></section>';
 	}
 
+	/**
+	 * Legacy manual program-card list. The card itself now lives in the CTA
+	 * module (Style 6) because it is a hand-built list, not a post loop. This
+	 * delegates to the shared renderer so legacy instances and migrated ones are
+	 * byte-identical. Kept indefinitely: revision restores and un-migrated sites
+	 * still resolve to this layout.
+	 */
 	public function render_program() {
-		$s     = $this->settings;
-		$items = ( isset( $s->programs ) && is_array( $s->programs ) ) ? $s->programs : array();
-		// A custom Button Radius opts out of the theme Button Shape (clip-path) so the
-		// radius shows; blank keeps the theme shape (button follows the theme by default).
-		$btn_cls = 'ds-program-btn' . ( ( $s->pg_btn_style ?? 'theme' ) === 'custom' ? ' ds-no-clip' : '' );
-		echo '<section class="ds-news ds-programs"><div class="ds-news-wrap">';
-		$this->render_head();
-		if ( empty( $items ) ) {
-			if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No program cards yet. Add them in the Query tab (Program Cards list).', 'ds-toolkit' ) . '</p>'; }
-			echo '</div></section>'; return;
-		}
-		$this->loop_open( 'ds-program-grid' );
-		foreach ( $items as $it ) {
-			$it    = (object) $it;
-			$icon  = trim( (string) ( $it->prog_icon ?? '' ) );
-			$img   = $this->acf_image_url( $it->prog_image ?? '' );
-			$date  = trim( (string) ( $it->prog_date ?? '' ) );
-			$sub   = trim( (string) ( $it->prog_subheading ?? '' ) );
-			$title = trim( (string) ( $it->prog_title ?? '' ) );
-			$desc  = trim( (string) ( $it->prog_desc ?? '' ) );
-			list( $url, $target ) = $this->link_parts( $it->prog_url ?? '' );
-			$hasurl = ( '' !== $url && '#' !== $url );
-			$tgt    = ( '_blank' === $target ) ? ' target="_blank" rel="noopener"' : '';
-			$btn    = trim( (string) ( $it->prog_btn ?? '' ) );
-			echo '<div class="ds-program-card">';
-			if ( $hasurl && '' === $btn ) { echo '<a class="ds-card-link" href="' . esc_url( $url ) . '"' . $tgt . ' aria-label="' . esc_attr( $title ) . '"></a>'; }
-			if ( '' !== $icon )    { echo '<span class="ds-program-ico"><i class="' . esc_attr( $icon ) . '" aria-hidden="true"></i></span>'; }
-			elseif ( '' !== $img ) { echo '<div class="ds-program-media"><img src="' . esc_url( $img ) . '" alt="' . esc_attr( $title ) . '" loading="lazy" /></div>'; }
-			echo '<div class="ds-program-body">';
-			if ( '' !== $date )  { echo '<span class="ds-program-date">' . esc_html( $date ) . '</span>'; }
-			if ( '' !== $sub )   { echo '<span class="ds-program-sub">' . esc_html( $sub ) . '</span>'; }
-			if ( '' !== $title ) { echo '<h3 class="ds-program-title">' . DS_Module_UI::inline( $title ) . '</h3>'; }
-			if ( '' !== $desc )  { echo '<div class="ds-program-desc">' . wpautop( wp_kses_post( $desc ) ) . '</div>'; }
-			if ( '' !== $btn && $hasurl ) { echo '<a class="' . esc_attr( $btn_cls ) . '" href="' . esc_url( $url ) . '"' . $tgt . '>' . esc_html( $btn ) . '</a>'; }
-			echo '</div></div>';
-		}
-		$this->loop_close();
-		echo '</div></section>';
+		DS_Program_Cards::render(
+			$this->settings,
+			__( 'No program cards yet. Add them in the Query tab (Program Cards list).', 'ds-toolkit' )
+		);
 	}
 
 	public function render_cardloop() {


### PR DESCRIPTION
## Why

`Custom Program Card (manual list)` lived in the **Post Loop** module but never queries a post type. It is a hand-built list, so it contradicted that module's contract ("loop over posts of type X"). It now lives in **CTA → Style 6 — Program Cards (manual list)**.

`Sponsors: Grid (manual list)` has the same defect and is **deliberately left alone** — it has no CTA style yet, and hiding it with nowhere to rebuild would block editors from creating sponsor grids at all.

## How this is safe

**Identical output by construction, not by testing.** Both modules render through one shared `DS_Program_Cards` class. The legacy `card_layout = program` path keeps rendering **forever**, which protects un-migrated sites and revision restores.

**The picker gate has an exception.** `program` is hidden from the Card Layout select for *new* modules only. A module already using it still shows the option — without that, Beaver Builder would find no matching value and silently fall back to the first layout, converting a partner's program list into a news grid the moment they opened the panel.

**The migration needs no field map.** Beaver Builder merges stored settings over module defaults and preserves unknown keys, so a verbatim carry keeps everything the node already holds. Only three keys need handling:

| Key | Why |
|---|---|
| `cta_style` | set to `style6` — the point of the migration |
| `cards` | emptied so the styles 1–5 repeater stays inert |
| `header_label` | blanked so CTA's default `Lorem ipsum` label cannot appear |

## Commands

    wp ds migrate-program-cards            # dry run (default)
    wp ds migrate-program-cards --execute
    wp ds rollback-program-cards --execute

The migration **refuses posts that have only `_fl_builder_data` or only `_fl_builder_draft`** (a half-migrated post reverts the next time an editor opens it) unless `--allow-unpaired` is passed. Each migrated node carries a `_ds_premigration` stash, so rollback needs no external state. Revisions are never touched — which is why the legacy layout must keep rendering.

## Verification

Run on the DSLP6 blueprint and on production (**huskyvbc**, 10 posts / 20 nodes incl. Home and About us):

- Rendered program-card HTML **byte-identical** before and after on every affected page.
- Every generated CSS rule targeting a rendered element, compared on both paths (captured migrated, rolled back, captured legacy, re-migrated): **212 rules on both sides, 0 added, 0 removed**.
- 9/9 pages HTTP 200, correct card counts, 0 PHP errors. Desktop + mobile checked by eye.

Two settings were caught during that comparison and fixed before merge: `header_divider` (missing it made a page 25px shorter) and `heading_typography` (Style 6 renders `.ds-news-heading`, not `.ds-cta-heading`).

**Pixel-diffing is not a valid check on these sites.** Two consecutive screenshots of an *unchanged* page differ by ~28k px because of lazy-loaded logos and the ticker. HTML + CSS equality is the authoritative check.

## Rollout note

Sites already migrated while running a patched build **must** get this release, or a plugin update reverts the code while their nodes still say `style6` and the cards render empty. huskyvbc is in that state now and needs 1.9.58.
