### PR TITLE
fix: only the visible label switches away from an open mega panel (GH #82) (1.9.59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.59] - 2026-07-31
+### Fixed
+- **Menu: hovering inside an open mega panel can no longer trigger a neighbouring menu (GH #82 follow-up).** On sites with a tall header row the top-level hit boxes extend well below the visible labels, so the invisible strip between the labels and the panel reads as panel whitespace — and dwelling there (e.g. moving across the top of the open Flag Football panel under the Soccer label on pennathleticsclub.org) still swapped panels after v1.9.57's pass-through guard. While a panel is open, only the visible label of another item can now switch away; the enlarged hit boxes still work for opening when nothing is open, and label hover, keyboard, nested flyouts, and the mobile drawer are unchanged.
+
 ## [1.9.58] - 2026-07-30
 ### Changed
 - **Program Cards moved from Post Loop to CTA (Style 6).** The `Custom Program Card (manual list)` layout never queried a post type, so it did not belong in a module whose contract is "loop over posts of type X". It is now **CTA -> Style 6 - Program Cards (manual list)**, with the same fields, the same `programs` repeater and the same `pg_*` styling keys. Both modules render through one shared `DS_Program_Cards` class, so legacy Post Loop instances and the new CTA style produce byte-identical markup by construction.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.58
+ * Version:           1.9.59
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.58' );
+define( 'DS_TOOLKIT_VERSION', '1.9.59' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/js/frontend.js
+++ b/modules/ds-menu/js/frontend.js
@@ -427,11 +427,18 @@
 			if ( ! li || ! menu.contains( li ) ) { return; }
 			if ( li === openLi ) { clearTimer(); return; } // back on the open item / inside its panel
 			var next = li.classList.contains( 'has-children' ) ? li : null;
+			if ( ! openLi ) { clearTimer(); setOpen( next ); return; } // nothing open: open instantly
+			// A panel is open: only the VISIBLE label (the <a>) of another item may
+			// switch away. The li hit-box is often far taller than the label (a
+			// stretched header row), so its invisible strip overlaps what reads as
+			// panel whitespace — dwelling there must not swap panels (GH #82,
+			// pennathleticsclub). The open panel keeps priority everywhere else.
+			var link = e.target.closest( '.ds-menu > .ds-menu-item > a' );
+			if ( ! link || link.parentNode !== li ) { return; }
 			clearTimer();
-			if ( ! openLi ) { setOpen( next ); return; } // nothing open: open instantly
 			timer = setTimeout( function () {
 				timer = null;
-				if ( li.matches( ':hover' ) ) { setOpen( next ); } // still there → intentional
+				if ( link.matches( ':hover' ) ) { setOpen( next ); } // still on the label → intentional
 			}, SWITCH_MS );
 		} );
 		menu.addEventListener( 'mouseenter', function () { clearTimer(); } );


### PR DESCRIPTION
Follow-up to #83 for #82 — the swap still happened on pennathleticsclub.org.

## Why v1.9.57 wasn't enough there

Measured on the live site: the visible labels are 50px tall (y 80–130) but the top-level `li` hit boxes are **110px** (y 50–160, a stretched header row), with the mega panel starting at y 166. That leaves a ~36px **invisible strip below the labels** that visually reads as panel whitespace. Hovering "the right side" of the open Flag Football panel means **dwelling** in Soccer's invisible hit box — a genuine dwell, which the v1.9.57 pass-through guard correctly lets through. (The site is also still on pre-1.9.57 code, so it currently has the original instant-swap too.)

## Fix

While a panel is open, only a pointer on the **visible label** (`.ds-menu > .ds-menu-item > a`) of another item can start the dwell-switch; events from the enlarged li box are ignored, so the open panel keeps priority everywhere except on an actual label. When nothing is open, the whole li box still opens instantly (unchanged, friendlier target). Everything else from #83 stands: dwell verification now checks the label's `:hover`, close-on-leave grace, keyboard `:focus-within`, nested flyouts, mobile drawer, no-JS fallback.

## Verified on the ds-launchpad-6 Local blueprint (Playwright)

Reproduced penn's geometry by stretching the li boxes (+30px top/bottom) around the compact labels:

- **Baseline (1.9.57):** open About us → move into the strip below Programs' label and dwell 600ms → panels swap (the reported residual bug).
- **After:** identical path → About us stays open. Dwelling on Programs' actual label still switches.
- Full regression suite from #83 re-run green: pass-through diagonal guarded, intentional dwell switch, dropdown open/stay-open/close-on-leave, keyboard focus opens panels, iPhone drill drawer opens, zero console errors.

**Note for release:** main already carries the unreleased 1.9.58 (Program Cards → CTA Style 6, #84); tagging v1.9.59 ships both, per the merged-means-ready convention.
