### PR TITLE
fix: mega panels never widen the page; clamp survives hostile !important CSS (GH #82) (1.9.60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.60] - 2026-07-31
+### Fixed
+- **Menu: mega panels can no longer widen the page (horizontal scrollbar) and the Keep Panel On Screen clamp now survives hostile site CSS (GH #82 follow-up).** Two related problems from pennathleticsclub.org: hidden mega panels have layout, so a wide panel anchored near the right edge stretched the page sideways before anyone hovered; and site CSS resetting nav margins with `!important` silently defeated the clamp's `--ds-mega-shift` margin rule, so the open panel overflowed the browser edge. The clamp now runs for every mega panel at load and on resize (not just on hover), applies the shift as an inline margin with `!important` (verified empirically, falling back to the opposite margin for right-aligned panels), and clears its inline margins in mobile-overlay mode so the stacked overlay is never distorted.
+
 ## [1.9.59] - 2026-07-31
 ### Fixed
 - **Menu: hovering inside an open mega panel can no longer trigger a neighbouring menu (GH #82 follow-up).** On sites with a tall header row the top-level hit boxes extend well below the visible labels, so the invisible strip between the labels and the panel reads as panel whitespace — and dwelling there (e.g. moving across the top of the open Flag Football panel under the Soccer label on pennathleticsclub.org) still swapped panels after v1.9.57's pass-through guard. While a panel is open, only the visible label of another item can now switch away; the enlarged hit boxes still work for opening when nothing is open, and label hover, keyboard, nested flyouts, and the mobile drawer are unchanged.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.59
+ * Version:           1.9.60
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.59' );
+define( 'DS_TOOLKIT_VERSION', '1.9.60' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/js/frontend.js
+++ b/modules/ds-menu/js/frontend.js
@@ -452,6 +452,78 @@
 		} );
 	}
 
+	/* Mega smart viewport clamp (Keep Panel On Screen): if the panel would
+	   overflow past either browser edge, shift it back in. The shift is applied
+	   as an inline margin with !important — site CSS resetting nav margins with
+	   !important beat both the css-var rule AND plain inline styles (seen on
+	   pennathleticsclub, GH #82) — and verified empirically: if margin-left
+	   didn't actually move the panel (right-anchored alignment), margin-right
+	   is used instead. The --ds-mega-shift var is still set for the stylesheet
+	   rules that compose it. Panels have layout while hidden, so this works at
+	   rest too — clampAllMegas() runs at boot and on resize so hidden panels
+	   never widen the page (the at-rest horizontal scrollbar report). */
+	function clampMega( pan ) {
+		pan.style.removeProperty( 'margin-left' );
+		pan.style.removeProperty( 'margin-right' );
+		pan.style.setProperty( '--ds-mega-shift', '0px' );
+		var pr = pan.getBoundingClientRect();
+		if ( ! pr.width ) { return; }
+		var shift = 0;
+		if ( pr.right > window.innerWidth - 8 ) { shift = ( window.innerWidth - 8 ) - pr.right; }
+		else if ( pr.left < 8 ) { shift = 8 - pr.left; }
+		if ( ! shift ) { return; }
+		shift = Math.round( shift );
+		pan.style.setProperty( '--ds-mega-shift', shift + 'px' );
+		var cs   = window.getComputedStyle( pan );
+		var base = parseFloat( cs.marginLeft ) || 0;
+		pan.style.setProperty( 'margin-left', Math.round( base + shift ) + 'px', 'important' );
+		var after = pan.getBoundingClientRect();
+		if ( Math.abs( after.left - ( pr.left + shift ) ) > 1.5 ) {
+			pan.style.removeProperty( 'margin-left' );
+			var baseR = parseFloat( window.getComputedStyle( pan ).marginRight ) || 0;
+			pan.style.setProperty( 'margin-right', Math.round( baseR - shift ) + 'px', 'important' );
+		}
+	}
+
+	function megaPanels( wrap ) {
+		var out = [];
+		wrap.querySelectorAll( '.ds-menu > .ds-menu-item.is-mega' ).forEach( function ( li ) {
+			for ( var m = 0; m < li.children.length; m++ ) {
+				if ( li.children[ m ].classList && li.children[ m ].classList.contains( 'ds-mega' ) ) { out.push( li.children[ m ] ); break; }
+			}
+		} );
+		return out;
+	}
+
+	// Clamp every mega panel; in mobile-overlay mode (hamburger visible) clear
+	// the inline margins instead so they can never distort the stacked overlay.
+	function clampAllMegas( wrap ) {
+		if ( ! wrap.classList.contains( 'ds-menu-wrap--megasmart' ) ) { return; }
+		var toggle = wrap.querySelector( '.ds-menu-toggle' );
+		var mobile = wrap.classList.contains( 'ds-menu-open' ) || ( toggle && 'none' !== window.getComputedStyle( toggle ).display );
+		megaPanels( wrap ).forEach( function ( pan ) {
+			if ( mobile ) {
+				pan.style.removeProperty( 'margin-left' );
+				pan.style.removeProperty( 'margin-right' );
+				pan.style.removeProperty( '--ds-mega-shift' );
+			} else {
+				clampMega( pan );
+			}
+		} );
+	}
+
+	function initMegaClamp( wrap ) {
+		if ( wrap.dsClampInit ) { return; }
+		wrap.dsClampInit = true;
+		if ( ! wrap.classList.contains( 'ds-menu-wrap--megasmart' ) ) { return; }
+		clampAllMegas( wrap );
+		var t = null;
+		window.addEventListener( 'resize', function () {
+			if ( t ) { clearTimeout( t ); }
+			t = setTimeout( function () { t = null; clampAllMegas( wrap ); }, 150 );
+		} );
+	}
+
 	/* Edge flip: when a dropdown / nested flyout would overflow the viewport's
 	   right edge (e.g. the last "More" item), flip it to open leftward instead
 	   of overlapping or clipping. Desktop only — the overlay renders submenus
@@ -464,24 +536,13 @@
 			var li = e.target && e.target.closest ? e.target.closest( '.ds-menu-item.has-children' ) : null;
 			if ( ! li || ! wrap.contains( li ) ) { return; }
 
-			// Mega smart viewport clamp (Keep Panel On Screen): if the panel would
-			// overflow past either browser edge, shift it back in via a CSS var the
-			// alignment/offset rules compose with. Measured fresh on every hover.
+			// Re-clamp the hovered mega fresh (viewport may have changed).
 			if ( li.classList.contains( 'is-mega' ) && wrap.classList.contains( 'ds-menu-wrap--megasmart' ) ) {
 				var pan = null;
 				for ( var m = 0; m < li.children.length; m++ ) {
 					if ( li.children[ m ].classList && li.children[ m ].classList.contains( 'ds-mega' ) ) { pan = li.children[ m ]; break; }
 				}
-				if ( pan ) {
-					pan.style.setProperty( '--ds-mega-shift', '0px' );
-					var pr = pan.getBoundingClientRect();
-					if ( pr.width > 0 ) {
-						var shift = 0;
-						if ( pr.right > window.innerWidth - 8 ) { shift = ( window.innerWidth - 8 ) - pr.right; }
-						else if ( pr.left < 8 ) { shift = 8 - pr.left; }
-						if ( shift ) { pan.style.setProperty( '--ds-mega-shift', Math.round( shift ) + 'px' ); }
-					}
-				}
+				if ( pan ) { clampMega( pan ); }
 				return; // mega items never use the flyout flip below
 			}
 
@@ -496,7 +557,7 @@
 		} );
 	}
 
-	function boot() { document.querySelectorAll( '.ds-menu-wrap' ).forEach( function ( w ) { init( w ); initHoverIntent( w ); initFlip( w ); } ); }
+	function boot() { document.querySelectorAll( '.ds-menu-wrap' ).forEach( function ( w ) { init( w ); initHoverIntent( w ); initFlip( w ); initMegaClamp( w ); } ); }
 
 	if ( 'loading' !== document.readyState ) { boot(); } else { document.addEventListener( 'DOMContentLoaded', boot ); }
 	// Re-init after a Beaver Builder partial refresh while editing.


### PR DESCRIPTION
Follow-up to #85 — the hover swap is fixed on pennathleticsclub.org, but the mega panel now overflows the page width (horizontal scrollbar), reported live.

## Two root causes (diagnosed on the live site)

1. **The clamp's CSS-var rule is defeated by site CSS.** The megasmart JS computed the correct shift (`--ds-mega-shift: -256px` inline on the panel), but computed `margin-left` stayed `0px` — even a *direct inline* `margin-left: calc(...)` test computed to 0. Something in the site's stylesheet resets nav margins with `!important`, which beats both the stylesheet calc rule and plain inline styles. Clamp dead → open panel hangs past the viewport edge.
2. **Hidden panels widen the page at rest.** `visibility:hidden` panels keep layout, and since 1.9.54 they are `width: max-content`; a wide panel anchored near the right edge extends `scrollWidth` past the viewport before anyone hovers → permanent horizontal scrollbar.

## Fix

- `clampMega()` applies the shift as an **inline margin with `!important`** (inline+important outranks any site rule), composed with the CSS-driven offset (measured with the var reset, so Horizontal Offset settings still apply). It then verifies the panel actually moved and falls back to `margin-right` for right-aligned panels. The `--ds-mega-shift` var is still set for the stylesheet rules that compose it.
- `clampAllMegas()` runs at **boot and on (debounced) resize** for megasmart wraps, so hidden panels are clamped before any hover and the page never scrolls sideways.
- In **mobile-overlay mode** (hamburger visible or overlay open) the inline margins are cleared so the stacked overlay is never distorted.
- The hover path now calls the same `clampMega()` (fresh re-measure per hover, unchanged semantics).

## Verified on the ds-launchpad-6 Local blueprint (Playwright)

With penn's hostile CSS simulated (`.ds-mega { margin: 0 !important }`) at a 1100px viewport:
- At rest: `scrollWidth == innerWidth` (no horizontal overflow), panel pre-clamped, inline `margin-left: -22px` applied and **winning** (computed style confirms).
- Hovered: panel open and fully on screen.
- Resize to 940px: re-clamped, no overflow (and the mobile-mode clearing path exercised).
- iPhone 13: inline margins cleared, no overflow.
- Full hover-intent regression suite from #85 re-run green (pass-through guard, dwell switch, close-on-leave, keyboard, drill drawer). Zero console errors; `node --check` clean.
