### PR TITLE
fix: Post Loop Tournament Cards typography settings now emit CSS (1.9.61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.61] - 2026-07-31
+### Fixed
+- **Post Loop: Tournament Cards typography settings now reach the front end.** The Tournament Cards section's Title and Date/Location typography fields previewed live in the builder but never emitted CSS on save — they were missing from the module's typography emission map (reported on sportsatthebeach.com; affects every LaunchPad version). Both now emit per-module rules covering the card-grid and list-row variants, and the news-oriented Typography section (whose fields target classes that don't exist in tournament markup) no longer shows on the tournament layout's Style tab.
+
 ## [1.9.60] - 2026-07-31
 ### Fixed
 - **Menu: mega panels can no longer widen the page (horizontal scrollbar) and the Keep Panel On Screen clamp now survives hostile site CSS (GH #82 follow-up).** Two related problems from pennathleticsclub.org: hidden mega panels have layout, so a wide panel anchored near the right edge stretched the page sideways before anyone hovered; and site CSS resetting nav margins with `!important` silently defeated the clamp's `--ds-mega-shift` margin rule, so the open panel overflowed the browser edge. The clamp now runs for every mega panel at load and on resize (not just on hover), applies the shift as an inline margin with `!important` (verified empirically, falling back to the opposite margin for right-aligned panels), and clears its inline margins in mobile-overlay mode so the stacked overlay is never distorted.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.60' );
+define( 'DS_TOOLKIT_VERSION', '1.9.61' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -1154,7 +1154,10 @@ $ds_pl_form = array(
 							'custom'         => array( 'sections' => array( 'header', 'query', 'query_filter', 'loopcard', 'header_style', 'typography', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 							'sponsor'        => array( 'sections' => array( 'header', 'sponsors_sec', 'sponsor_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ) ),
 							'program'        => array( 'sections' => array( 'header', 'programs_sec', 'program_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ) ),
-							'tournament'     => array( 'sections' => array( 'header', 'query', 'query_filter', 'tn_filter_opts', 'tournament_opts', 'header_style', 'typography', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
+							// No news 'typography' section here: its fields target .ds-news-card-* classes
+							// that never render in tournament markup (GH: title/meta typography live in
+							// the Tournament Cards section as tn_title_typo / tn_meta_typo).
+							'tournament'     => array( 'sections' => array( 'header', 'query', 'query_filter', 'tn_filter_opts', 'tournament_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 						),
 					),
 				),

--- a/modules/ds-post-loop/includes/frontend.css.php
+++ b/modules/ds-post-loop/includes/frontend.css.php
@@ -281,10 +281,15 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 		'pg_title_typo'            => '.ds-program-title',
 		'pg_desc_typo'             => '.ds-program-desc',
 		'pg_btn_typo'              => '.ds-program-btn',
+		// Tournament Cards (grid card + list row variants — meta wrapper differs)
+		'tn_title_typo'            => '.ds-tourn-title',
+		'tn_meta_typo'             => '.ds-tourn-meta, .ds-tourn-rowmeta',
 	);
 	foreach ( $typo as $key => $sel ) {
 		if ( ! empty( $settings->{$key} ) ) {
-			FLBuilderCSS::typography_field_rule( array( 'settings' => $settings, 'setting_name' => $key, 'selector' => "$node $sel" ) );
+			// Scope every comma-separated part to the node, or the extra parts leak site-wide.
+			$scoped = implode( ', ', array_map( function ( $one ) use ( $node ) { return "$node " . trim( $one ); }, explode( ',', $sel ) ) );
+			FLBuilderCSS::typography_field_rule( array( 'settings' => $settings, 'setting_name' => $key, 'selector' => $scoped ) );
 		}
 	}
 }


### PR DESCRIPTION
Reported on sportsatthebeach.com: the Style-tab typography on the Post Loop's **Tournament Cards** layout has no effect on the front end.

## Root cause

Not a LaunchPad 6 override — the module never emitted the CSS. `tn_title_typo` and `tn_meta_typo` exist as settings (with working in-builder live previews, which is why it *looks* fine while editing), but they were missing from the typography emission map in `includes/frontend.css.php`, so no rule was ever written to the layout stylesheet. Confirmed on the live site: the Home tournament module has `tn_title_typo` = Poppins 500 / 28px stored and unrendered.

A second confusion multiplier: the tournament layout's Style tab also showed the news-oriented **Typography** section, whose six fields target `.ds-news-card-*` classes that don't exist in tournament markup — all inert ("same with other typography settings").

## Fix

- `tn_title_typo` → `.ds-tourn-title` and `tn_meta_typo` → `.ds-tourn-meta, .ds-tourn-rowmeta` added to the emission map (the meta wrapper differs between the card-grid and list-row variants; typography inherits into the date/location spans in both).
- The map loop now scopes **every comma-separated selector part** to the module node — otherwise the second part would leak site-wide.
- The inert news Typography section is removed from the tournament layout's Style tab (its fields keep their values; they simply no longer show where they can't work). Title/meta typography lives in the Tournament Cards section, as designed.

## Verified on the ds-launchpad-6 Local blueprint

Set Georgia 700 / 31px / uppercase / 2px tracking on the title and Courier 17px lowercase on the meta of the Tournaments page's two tournament modules, compiled the layout CSS, and confirmed the generated file contains correctly scoped rules per module node (both meta selector parts prefixed). `FLBuilder::render_css()` + `render_js()` compile cleanly; `php -l` clean on both files. Test data reset afterwards. Dynamic rules append after the module's static CSS, so they win the equal-specificity contest the same way every other working typo field in this module does (fleet-wide, LP5 and LP6 alike — this fix is version-agnostic).
