### PR TITLE
feat: Motion Cards responsive Columns + skip blank card rows (GH #88, #89) (1.9.62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.62] - 2026-08-03
+### Added
+- **CTA Motion Cards: responsive Columns (GH #88).** The Columns setting now takes independent per-device values (base / Large / Medium / Small) via the standard responsive control, applied at the site's builder breakpoints. Blank smaller sizes keep the previous automatic behaviour (max 2 columns on tablet, 1 on phone), so existing modules render unchanged until an editor sets an override.
+
+### Fixed
+- **CTA Motion Cards: blank card rows no longer render as empty space (GH #89).** A stray empty row in the Cards repeater rendered as a full-size invisible card, minting whole phantom grid rows below the real cards (a large blank band under the layout). Entries with no image, logo, title, eyebrow, and link are now skipped.
+
 ## [1.9.61] - 2026-07-31
 ### Fixed
 - **Post Loop: Tournament Cards typography settings now reach the front end.** The Tournament Cards section's Title and Date/Location typography fields previewed live in the builder but never emitted CSS on save — they were missing from the module's typography emission map (reported on sportsatthebeach.com; affects every LaunchPad version). Both now emit per-module rules covering the card-grid and list-row variants, and the news-oriented Typography section (whose fields target classes that don't exist in tournament markup) no longer shows on the tournament layout's Style tab.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.61' );
+define( 'DS_TOOLKIT_VERSION', '1.9.62' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-cta/ds-cta.php
+++ b/modules/ds-cta/ds-cta.php
@@ -100,6 +100,13 @@ class DS_CTA_Module extends FLBuilderModule {
 			list( $url, $target ) = $this->link_parts( $card->link ?? '' );
 			$rel  = '_blank' === $target ? ' rel="noopener noreferrer"' : '';
 
+			// Skip stray blank repeater rows: they rendered as full-size empty cards,
+			// pushing phantom rows / empty space below the real grid (GH #89).
+			// link_parts() maps an empty link to '#', so '#' counts as no-link here.
+			if ( '' === $img && '' === $logo && '' === trim( (string) ( $card->title ?? '' ) ) && '' === trim( (string) ( $card->eyebrow ?? '' ) ) && ( '' === $url || '#' === $url ) ) {
+				continue;
+			}
+
 			echo '<a class="ds-mcard" href="' . $url . '" target="' . esc_attr( $target ) . '"' . $rel . '>';
 			echo '<span class="ds-mcard-bg"' . ( $img ? ' style="background-image:url(' . esc_url( $img ) . ')"' : '' ) . ' aria-hidden="true"></span>';
 			echo '<span class="ds-mcard-tint" aria-hidden="true"></span>';
@@ -999,7 +1006,7 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 			'mcard' => array(
 				'title'  => __( 'Motion Card', 'ds-toolkit' ),
 				'fields' => array(
-					'mc_cols'   => array( 'type' => 'unit', 'label' => __( 'Columns', 'ds-toolkit' ), 'default' => '3', 'slider' => array( 'min' => 1, 'max' => 5, 'step' => 1 ) ),
+					'mc_cols'   => array( 'type' => 'unit', 'label' => __( 'Columns', 'ds-toolkit' ), 'default' => '3', 'responsive' => true, 'slider' => array( 'min' => 1, 'max' => 5, 'step' => 1 ), 'help' => __( 'Responsive: set per-device values with the device icon. Blank smaller sizes keep the automatic fallback (max 2 columns on tablet, 1 on phone).', 'ds-toolkit' ) ),
 					'mc_gap'    => array( 'type' => 'unit', 'label' => __( 'Gap', 'ds-toolkit' ), 'default' => '24', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 60, 'step' => 1 ) ),
 					'mc_ratio'  => array( 'type' => 'select', 'label' => __( 'Card Ratio', 'ds-toolkit' ), 'default' => '4 / 5', 'options' => array( '4 / 5' => '4:5', '3 / 4' => '3:4', '1 / 1' => '1:1', '4 / 3' => '4:3', '16 / 10' => '16:10' ) ),
 					'mc_radius' => array( 'type' => 'unit', 'label' => __( 'Corner Radius', 'ds-toolkit' ), 'default' => '14', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 40, 'step' => 1 ), 'preview' => array( 'type' => 'css', 'selector' => '.ds-mcard', 'property' => 'border-radius', 'unit' => 'px' ) ),

--- a/modules/ds-cta/includes/frontend.css.php
+++ b/modules/ds-cta/includes/frontend.css.php
@@ -286,8 +286,25 @@ if ( 'style3' === $style ) {
 	$cols = max( 1, (int) ( $settings->mc_cols ?? 3 ) );
 	$gap  = $u( $settings->mc_gap ?? '', 24 );
 	echo "$node .ds-mcard-grid{grid-template-columns:repeat({$cols},1fr);gap:{$gap}px;}\n";
-	echo "@media(max-width:1024px){ $node .ds-mcard-grid{grid-template-columns:repeat(" . min( $cols, 2 ) . ",1fr);} }\n";
-	echo "@media(max-width:600px){ $node .ds-mcard-grid{grid-template-columns:1fr;} }\n";
+	$cl = $settings->mc_cols_large ?? '';
+	$cm = $settings->mc_cols_medium ?? '';
+	$cr = $settings->mc_cols_responsive ?? '';
+	if ( '' === "{$cl}{$cm}{$cr}" ) {
+		// Legacy fixed breakpoints (pre-GH #88): unchanged rendering when no overrides set.
+		echo "@media(max-width:1024px){ $node .ds-mcard-grid{grid-template-columns:repeat(" . min( $cols, 2 ) . ",1fr);} }\n";
+		echo "@media(max-width:600px){ $node .ds-mcard-grid{grid-template-columns:1fr;} }\n";
+	} else {
+		// Responsive Columns (GH #88) at the site's builder breakpoints; unset
+		// tiers keep the legacy defaults (2 on medium, 1 on small).
+		if ( '' !== $cl ) {
+			$bp_lg = (int) ( FLBuilderModel::get_global_settings()->large_breakpoint ?? 1200 );
+			echo "@media(max-width:{$bp_lg}px){ $node .ds-mcard-grid{grid-template-columns:repeat(" . max( 1, (int) $cl ) . ",1fr);} }\n";
+		}
+		$cmv = '' !== $cm ? max( 1, (int) $cm ) : min( $cols, 2 );
+		echo "@media(max-width:{$bpm}px){ $node .ds-mcard-grid{grid-template-columns:repeat({$cmv},1fr);} }\n";
+		$crv = '' !== $cr ? max( 1, (int) $cr ) : 1;
+		echo "@media(max-width:{$bpr}px){ $node .ds-mcard-grid{grid-template-columns:repeat({$crv},1fr);} }\n";
+	}
 
 	$ratio = preg_replace( '#[^0-9/ ]#', '', (string) ( $settings->mc_ratio ?? '4 / 5' ) ); if ( '' === trim( $ratio ) ) { $ratio = '4 / 5'; }
 	$rad   = $u( $settings->mc_radius ?? '', 14 );


### PR DESCRIPTION
Closes #88. Closes #89.

## #88 — Responsive Columns

`mc_cols` is now a responsive unit control (base / Large / Medium / Small), matching the standard DSToolkit responsive editing interface. Emission uses the site's builder breakpoints (Large/Medium/Responsive from the global settings). **Backward compatible:** with no overrides set, the exact legacy hardcoded rules (max 2 columns ≤1024px, 1 column ≤600px) are emitted, so every existing module renders byte-identically until an editor opts in; when overrides are used, unset tiers fall back to the same legacy defaults.

## #89 — Empty space below the layout

Reproduced: a stray blank row in the Cards repeater (an extremely common editor artifact) rendered as a full-size `.ds-mcard` — invisible content, but sized by the aspect ratio — so with card count ≤ columns it minted an entire phantom grid row below the real cards: the reported blank band. The render loop now skips entries with no image, no logo, no title, no eyebrow, and no link (note: `link_parts()` maps an empty link to `'#'`, which counts as no-link).

## Verified on the ds-launchpad-6 Local blueprint (Playwright)

- Test page with a 4-card Style 5 module + 2 injected blank repeater rows: before the fix 6 cards rendered (2 empty); after, exactly 4.
- Responsive columns with base 4 / L 3 / M 2 / S 1 on breakpoints 1200/992/768: computed grid = 4 cols @1440px, 3 @1100px, 2 @900px, 1 @500px.
- Legacy path (no overrides): unchanged 3/2/1 behaviour at 1440/900/500px.
- `php -l` clean on both files.
