### PR TITLE
fix: sync plugin header Version with DS_TOOLKIT_VERSION (1.9.63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.63] - 2026-08-03
+### Fixed
+- **Plugin header version sync.** The 1.9.61 and 1.9.62 zips shipped with the plugin-header `Version:` still reading 1.9.60 (only the `DS_TOOLKIT_VERSION` define was bumped), so updated sites kept reporting 1.9.60 and re-offering the update every check. Both version lines are back in lockstep from this release; sites on the mismatched builds converge here and the loop ends. No code changes beyond the version lines.
+
 ## [1.9.62] - 2026-08-03
 ### Added
 - **CTA Motion Cards: responsive Columns (GH #88).** The Columns setting now takes independent per-device values (base / Large / Medium / Small) via the standard responsive control, applied at the site's builder breakpoints. Blank smaller sizes keep the previous automatic behaviour (max 2 columns on tablet, 1 on phone), so existing modules render unchanged until an editor sets an override.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.60
+ * Version:           1.9.63
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.62' );
+define( 'DS_TOOLKIT_VERSION', '1.9.63' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
The 1.9.61 and 1.9.62 zips shipped with the plugin-header `Version:` still at 1.9.60 — only the `DS_TOOLKIT_VERSION` define was bumped, but WordPress reads the HEADER as the installed version. Any site that took those builds reports 1.9.60, so the updater re-offers the latest release on every 12h check and reinstalls it in a loop (benign but endless churn, and confusing version reporting).

This PR bumps **both** lines to 1.9.63 with no other code changes. Once released, looping sites see 1.9.63 > 1.9.60, update once, land on a matching header, and the loop ends fleet-wide.
