### PR TITLE
fix: keep Appearance visible for partner / non-LeagueApps users (1.9.64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.64] - 2026-08-04
+### Changed
+- **Admin Menu Tidy: Appearance is visible to partner / non-LeagueApps users again.** The menu tidy hid the whole Appearance menu from any user without a LeagueApps email, locking partners out of Menus, Customize, and Widgets. Appearance now stays in the dashboard menu for every user whose role allows it; ACF and Beaver Builder remain LeagueApps-only, and the Partner role still never gets the in-admin file editors.
+
 ## [1.9.63] - 2026-08-03
 ### Fixed
 - **Plugin header version sync.** The 1.9.61 and 1.9.62 zips shipped with the plugin-header `Version:` still reading 1.9.60 (only the `DS_TOOLKIT_VERSION` define was bumped), so updated sites kept reporting 1.9.60 and re-offering the update every check. Both version lines are back in lockstep from this release; sites on the mismatched builds converge here and the loop ends. No code changes beyond the version lines.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.63
+ * Version:           1.9.64
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.63' );
+define( 'DS_TOOLKIT_VERSION', '1.9.64' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-admin-menu.php
+++ b/features/class-ds-admin-menu.php
@@ -8,8 +8,10 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  *
  *  - Moved under Tools (everyone who can already see them): Defender Pro,
  *    Yoast SEO, Media Library Organizer.
- *  - Left in place but hidden from non-LeagueApps users: ACF, Beaver Builder,
- *    Appearance.
+ *  - Left in place but hidden from non-LeagueApps users: ACF, Beaver Builder.
+ *  - Appearance stays visible to every user whose role allows it (partners
+ *    manage menus/customizer themselves; the risky surfaces stay off because
+ *    the Partner role never gets the file-editor capabilities).
  *  - Left untouched (relocating is not clean): Site Kit (custom menu/screen
  *    system makes a moved entry vanish) and WPMU DEV (whitelabel removes its
  *    top-level menu and its page hook isn't access-registered, so a link errors).
@@ -45,10 +47,12 @@ class DS_Admin_Menu {
         $move = array( 'wp-defender', 'wpseo_dashboard', 'media-library-organizer' );
 
         // Left in their original spot, but visible to LeagueApps users only.
+        // Appearance (themes.php) is deliberately NOT in this list: partner /
+        // non-LeagueApps users need it in the dashboard menu (Menus, Customize,
+        // Widgets). Their role's capabilities still decide what loads there.
         $la_only = array(
             'edit.php?post_type=acf-field-group',     // ACF
             'edit.php?post_type=fl-builder-template', // Beaver Builder (top-level menu slug)
-            'themes.php',                              // Appearance
         );
         if ( ! $is_la ) {
             foreach ( $la_only as $slug ) {


### PR DESCRIPTION
Admin Menu Tidy (blueprint 6+) hid the whole **Appearance** menu from any user without a LeagueApps email, locking partners out of Menus, Customize, and Widgets. The Partner role always had the capabilities (`switch_themes` / `edit_theme_options` are never dropped) — only the menu entry was removed.

## Change

`themes.php` is no longer in the LeagueApps-only hide list, so Appearance shows in the dashboard menu for every user whose role allows it. Unchanged: ACF and Beaver Builder stay hidden from non-LeagueApps users, Defender/Yoast/MLO still relocate under Tools, and the Partner role still never receives the in-admin file-editor capabilities (`edit_themes` / `edit_files`), so the risky surfaces stay off.

## Verified (real code path, live install, no config touched)

Ran the shipped 1.9.63 class and this branch's class through `DS_Admin_Menu::reorganize()` on dslaunchpad5 as a temporary partner-role user with a non-LeagueApps email against a simulated admin menu:

- Old: surviving top-level = `edit.php` only — Appearance removed (the report).
- New: surviving top-level = `edit.php, themes.php` — Appearance visible; ACF hidden ✓, Beaver Builder hidden ✓, Defender→Tools ✓.
- Partner user capabilities confirmed: `switch_themes` = true, `edit_theme_options` = true (pages load once the entry exists).
- Temp user removed after the test; `php -l` clean. Both version lines bumped and matching.
