### PR TITLE
feat: Pathway module — stage cards with a dynamic progress line (GH #96) (1.9.66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.66] - 2026-08-06
+### Added
+- **New module: Pathway (GH #96).** Stage cards (auto-numbered eyebrow, title, description, optional link) connected by a progress line with one marker per stage. Markers and line segments are generated per card, so adding, removing, or reordering stages automatically re-fits the line, which ends at the final stage with a gradient fade and never continues past the last card. Per-stage Filled/Outline markers (upcoming stages), diamond or circle shapes, line/marker colours synced to the global accent, optional thin stage dividers, responsive gap and typography controls, and a configurable stack breakpoint below which the pathway becomes a vertical left-rail timeline so markers, spacing, and the line stay aligned on small screens. Pure CSS, no JS. Registered like every LeagueApps module (Features toggle; default on for blueprint 6+).
+
 ## [1.9.65] - 2026-08-04
 ### Added
 - **Hero Banner: responsive Buttons Alignment (GH #94).** A new Buttons Alignment control (Content → Buttons) positions the CTA button group Left / Center / Right independently of the module Alignment, with per-device values via the standard responsive control. Blank (the default) keeps following the module Alignment, so existing heroes render unchanged. Text, stats, typography, and button styling are unaffected; on phones the buttons remain full-width by design.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.65
+ * Version:           1.9.66
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.65' );
+define( 'DS_TOOLKIT_VERSION', '1.9.66' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-pathway.php
+++ b/features/class-ds-pathway.php
@@ -1,0 +1,25 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Registers the in-house "LeagueApps Pathway" Beaver Builder module
+ * (modules/ds-pathway/). Blueprint generation 6+. GH #96.
+ */
+class DS_Pathway {
+
+	private $settings;
+
+	public function __construct( $settings = array() ) {
+		$this->settings = $settings;
+	}
+
+	public function init() {
+		add_action( 'init', array( $this, 'register_module' ), 20 );
+	}
+
+	public function register_module() {
+		if ( class_exists( 'FLBuilder' ) && class_exists( 'FLBuilderModule' ) ) {
+			require_once DS_TOOLKIT_PATH . 'modules/ds-pathway/ds-pathway.php';
+		}
+	}
+}

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -112,6 +112,11 @@ class DS_Toolkit {
             'class'         => 'DS_Marquee',
             'min_blueprint' => 6,
         ),
+        'ds_pathway_module_enabled' => array(
+            'file'          => 'features/class-ds-pathway.php',
+            'class'         => 'DS_Pathway',
+            'min_blueprint' => 6,
+        ),
         'ds_post_loop_module_enabled' => array(
             'file'          => 'features/class-ds-post-loop.php',
             'class'         => 'DS_Post_Loop',
@@ -237,6 +242,7 @@ class DS_Toolkit {
             'ds_carousel_module_enabled'       => array( 'label' => 'Images/Videos Carousel', 'desc' => 'A stacked-deck slider or a multi-column reels strip of images and videos.' ),
             'ds_orgstats_module_enabled'       => array( 'label' => 'Org Stats',       'desc' => 'Headline stat figures (the record) as plain figures or photo cards.' ),
             'ds_marquee_module_enabled'        => array( 'label' => 'Marquee',         'desc' => 'A scrolling announcement ticker with a pinned label.' ),
+            'ds_pathway_module_enabled'        => array( 'label' => 'Pathway',         'desc' => 'Stage cards connected by a progress line: per-stage markers, a fading end, and a vertical timeline on small screens.' ),
             'ds_info_list_module_enabled'      => array( 'label' => 'Post Details',    'desc' => 'Icon-and-text rows from the current post\'s ACF fields, for Themer single templates (staff, events); empty rows hide.' ),
             'ds_cta_module_enabled'            => array( 'label' => 'CTA',             'desc' => 'A call-to-action band with a heading, text, and buttons.' ),
             'ds_heading_module_enabled'        => array( 'label' => 'Heading',         'desc' => 'A styled section heading with an eyebrow line and accent options.' ),
@@ -328,6 +334,7 @@ class DS_Toolkit {
             $defaults['ds_hero_module_enabled']       = 1;
             $defaults['ds_cta_module_enabled']        = 1;
             $defaults['ds_marquee_module_enabled']    = 1;
+            $defaults['ds_pathway_module_enabled']    = 1;
             $defaults['ds_post_loop_module_enabled']  = 1;
             $defaults['ds_orgstats_module_enabled']   = 1;
             $defaults['ds_carousel_module_enabled']   = 1;

--- a/modules/ds-pathway/css/frontend.css
+++ b/modules/ds-pathway/css/frontend.css
@@ -1,0 +1,31 @@
+/* LeagueApps Pathway — static base styles. Dynamic values in includes/frontend.css.php.
+   The track is per-stage: each stage's segment runs from its marker's right edge to
+   the next marker's left edge (spanning the grid gap); the LAST stage draws a
+   gradient fade tail instead, so the line ends with the final card. */
+
+.ds-pathway-wrap{width:100%;max-width:1280px;margin:0 auto;}
+.ds-pathway-grid{display:grid;grid-template-columns:repeat(var(--ds-path-n,4),1fr);column-gap:var(--ds-path-gap,32px);}
+.ds-path-stage{position:relative;min-width:0;}
+
+/* ---- Track row (horizontal mode) ---- */
+.ds-path-track{position:relative;display:block;height:var(--ds-path-msize,14px);margin-bottom:var(--ds-path-trackgap,26px);}
+.ds-path-track::before{content:"";position:absolute;top:50%;transform:translateY(-50%);left:var(--ds-path-msize,14px);right:calc(-1 * var(--ds-path-gap,32px));height:var(--ds-path-line,2px);background:var(--ds-path-line-c,var(--fl-global-accent,#f26a21));}
+/* Fade tail: the line ends WITH the last stage and never continues past it. */
+.ds-path-stage--last .ds-path-track::before{right:auto;width:min(160px,75%);background:linear-gradient(to right,var(--ds-path-line-c,var(--fl-global-accent,#f26a21)),transparent);}
+
+/* ---- Markers ---- */
+.ds-path-marker{position:absolute;top:50%;left:0;width:var(--ds-path-msize,14px);height:var(--ds-path-msize,14px);background:var(--ds-path-marker-c,var(--ds-path-line-c,var(--fl-global-accent,#f26a21)));transform:translateY(-50%) rotate(45deg);z-index:1;}
+.ds-pathway--m-circle .ds-path-marker{transform:translateY(-50%);border-radius:50%;}
+.ds-path-stage--outline .ds-path-marker{background:transparent;border:2px solid var(--ds-path-marker-c,var(--ds-path-line-c,var(--fl-global-accent,#f26a21)));}
+
+/* ---- Stage content ---- */
+.ds-path-eyebrow{display:block;font-size:.72rem;font-weight:700;letter-spacing:.28em;text-transform:uppercase;color:var(--fl-global-accent,#f26a21);margin:0 0 12px;}
+.ds-path-title{font-size:1.35rem;line-height:1.15;font-weight:800;text-transform:uppercase;color:var(--fl-global-headings,inherit);margin:0 0 12px;}
+.ds-path-title a{color:inherit;text-decoration:none;}
+.ds-path-title a:hover{text-decoration:underline;}
+.ds-path-text{font-size:.95rem;line-height:1.55;color:var(--fl-global-body,inherit);}
+.ds-path-text p{margin:0 0 .6em;}
+.ds-path-text p:last-child{margin-bottom:0;}
+
+/* ---- Optional thin dividers between stages (horizontal mode only) ---- */
+.ds-pathway--dividers .ds-path-stage:not(.ds-path-stage--last)::after{content:"";position:absolute;top:calc(var(--ds-path-msize,14px) + var(--ds-path-trackgap,26px));bottom:0;right:calc(-0.5 * var(--ds-path-gap,32px));width:1px;background:var(--ds-path-divider-c,rgba(255,255,255,.12));}

--- a/modules/ds-pathway/ds-pathway.php
+++ b/modules/ds-pathway/ds-pathway.php
@@ -1,0 +1,256 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * LeagueApps Pathway — an in-house Beaver Builder module (GH #96).
+ *
+ * A row of stage cards (eyebrow, title, description) connected by a progress
+ * line that runs through one marker per stage. Markers and segments are
+ * generated per card, so adding/removing stages automatically re-fits the
+ * line; it ends at the final stage with a gradient fade tail and never
+ * continues past the last card. Below the configurable stack breakpoint the
+ * row becomes a vertical timeline (markers down a left rail) so the line and
+ * cards stay aligned on small screens.
+ *
+ * The track is pure CSS: every stage owns its own segment (marker edge to the
+ * next marker's edge, spanning the grid gap), the last stage owns the fade
+ * tail. No JS.
+ *
+ * @class DS_Pathway_Module
+ */
+class DS_Pathway_Module extends FLBuilderModule {
+
+	public function __construct() {
+		parent::__construct( array(
+			'name'            => __( 'Pathway', 'ds-toolkit' ),
+			'description'     => __( 'Stage cards connected by a progress line with per-stage markers and a fading end.', 'ds-toolkit' ),
+			'category'        => __( 'LeagueApps', 'ds-toolkit' ),
+			'dir'             => DS_TOOLKIT_PATH . 'modules/ds-pathway/',
+			'url'             => DS_TOOLKIT_URL . 'modules/ds-pathway/',
+			'partial_refresh' => true,
+			'editor_export'   => false,
+		) );
+	}
+
+	/** Normalise a BB link field (string URL or {url,target} object/array). */
+	private function link_parts( $link ) {
+		$url = ''; $target = '_self';
+		if ( is_array( $link ) )      { $url = $link['url'] ?? ''; $target = $link['target'] ?? '_self'; }
+		elseif ( is_object( $link ) ) { $url = $link->url ?? '';  $target = $link->target ?? '_self'; }
+		else { $url = (string) $link; }
+		return array( esc_url( $url ), '_blank' === $target ? '_blank' : '_self' );
+	}
+
+	/**
+	 * Normalised stages. Blank repeater rows are skipped so markers, segments,
+	 * and the fade tail always agree with what actually renders.
+	 */
+	private function stages() {
+		$out = array();
+		$raw = $this->settings->stages ?? array();
+		if ( ! is_array( $raw ) ) { return $out; }
+		foreach ( $raw as $stage ) {
+			$stage   = (object) $stage;
+			$title   = trim( (string) ( $stage->title ?? '' ) );
+			$text    = trim( (string) ( $stage->text ?? '' ) );
+			$eyebrow = trim( (string) ( $stage->eyebrow ?? '' ) );
+			list( $url, $target ) = $this->link_parts( $stage->link ?? '' );
+			if ( '' === $title && '' === $text && '' === $eyebrow ) { continue; }
+			$out[] = array(
+				'eyebrow' => $eyebrow,
+				'title'   => $title,
+				'text'    => $text,
+				'url'     => $url,
+				'target'  => $target,
+				'marker'  => ( $stage->marker ?? 'fill' ) === 'outline' ? 'outline' : 'fill',
+			);
+		}
+		return $out;
+	}
+
+	public function render_pathway() {
+		$s      = $this->settings;
+		$stages = $this->stages();
+
+		if ( empty( $stages ) ) {
+			if ( FLBuilderModel::is_builder_active() ) {
+				echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'Add stages in the module settings.', 'ds-toolkit' ) . '</p>';
+			}
+			return;
+		}
+
+		$shape = ( $s->marker_shape ?? 'diamond' ) === 'circle' ? 'circle' : 'diamond';
+		$mods  = 'ds-pathway ds-pathway--m-' . $shape;
+		if ( ( $s->dividers ?? 'no' ) === 'yes' ) { $mods .= ' ds-pathway--dividers'; }
+
+		echo '<section class="' . esc_attr( $mods ) . '"><div class="ds-pathway-wrap">';
+		echo '<div class="ds-pathway-grid" style="--ds-path-n:' . count( $stages ) . '">';
+
+		$n = 1;
+		$last = count( $stages );
+		foreach ( $stages as $i => $stage ) {
+			$cls = 'ds-path-stage ds-path-stage--' . $stage['marker'];
+			if ( $i + 1 === $last ) { $cls .= ' ds-path-stage--last'; }
+			echo '<div class="' . esc_attr( $cls ) . '">';
+			echo '<span class="ds-path-track" aria-hidden="true"><span class="ds-path-marker"></span></span>';
+
+			$eyebrow = '' !== $stage['eyebrow'] ? $stage['eyebrow'] : sprintf( __( 'Stage %02d', 'ds-toolkit' ), $n );
+			if ( ( $s->show_eyebrow ?? 'yes' ) === 'yes' ) {
+				echo '<span class="ds-path-eyebrow">' . DS_Module_UI::inline( $eyebrow ) . '</span>';
+			}
+			if ( '' !== $stage['title'] ) {
+				$title = DS_Module_UI::inline( $stage['title'] );
+				if ( '' !== $stage['url'] ) {
+					$rel = '_blank' === $stage['target'] ? ' rel="noopener noreferrer"' : '';
+					$title = '<a href="' . esc_url( $stage['url'] ) . '" target="' . esc_attr( $stage['target'] ) . '"' . $rel . '>' . $title . '</a>';
+				}
+				echo '<h3 class="ds-path-title">' . $title . '</h3>';
+			}
+			if ( '' !== $stage['text'] ) {
+				echo '<div class="ds-path-text">' . wpautop( wp_kses_post( $stage['text'] ) ) . '</div>';
+			}
+			echo '</div>';
+			$n++;
+		}
+
+		echo '</div></div></section>';
+	}
+}
+
+/* --------------------------------------------------------------- Stage sub-form */
+
+FLBuilder::register_settings_form( 'ds_pathway_stage_form', array(
+	'title' => __( 'Stage', 'ds-toolkit' ),
+	'tabs'  => array(
+		'general' => array(
+			'title'    => __( 'Stage', 'ds-toolkit' ),
+			'sections' => array(
+				'general' => array(
+					'title'  => '',
+					'fields' => array(
+						'eyebrow' => array(
+							'type'        => 'text',
+							'label'       => __( 'Eyebrow', 'ds-toolkit' ),
+							'default'     => '',
+							'connections' => array( 'string' ),
+							'help'        => __( 'Small label above the title. Blank = automatic "Stage 01", "Stage 02", … numbering.', 'ds-toolkit' ),
+						),
+						'title'   => array( 'type' => 'text', 'label' => __( 'Title', 'ds-toolkit' ), 'default' => '', 'connections' => array( 'string' ) ),
+						'text'    => array( 'type' => 'editor', 'media_buttons' => false, 'wpautop' => false, 'rows' => 3, 'label' => __( 'Description', 'ds-toolkit' ), 'connections' => array( 'string' ) ),
+						'link'    => array( 'type' => 'link', 'label' => __( 'Link', 'ds-toolkit' ), 'show_target' => true, 'connections' => array( 'url' ), 'help' => __( 'Optional. Makes the stage title a link.', 'ds-toolkit' ) ),
+						'marker'  => array(
+							'type'    => 'select',
+							'label'   => __( 'Marker', 'ds-toolkit' ),
+							'default' => 'fill',
+							'options' => array( 'fill' => __( 'Filled', 'ds-toolkit' ), 'outline' => __( 'Outline (hollow)', 'ds-toolkit' ) ),
+							'help'    => __( 'Outline reads as an upcoming / future stage, like the reference design.', 'ds-toolkit' ),
+						),
+					),
+				),
+			),
+		),
+	),
+) );
+
+FLBuilder::register_module( 'DS_Pathway_Module', array(
+	'content' => array(
+		'title'    => __( 'Content', 'ds-toolkit' ),
+		'sections' => array(
+			'stages' => array(
+				'title'       => __( 'Stages', 'ds-toolkit' ),
+				'description' => __( 'The pathway steps, left to right. Markers and the connecting line adjust automatically when stages are added, removed, or reordered.', 'ds-toolkit' ),
+				'fields'      => array(
+					'stages' => array(
+						'type'         => 'form',
+						'label'        => __( 'Stage', 'ds-toolkit' ),
+						'form'         => 'ds_pathway_stage_form',
+						'preview_text' => 'title',
+						'multiple'     => true,
+						'default'      => array(
+							array( 'title' => 'Lorem Ipsum', 'text' => 'Dolor sit amet, consectetur adipiscing elit.' ),
+							array( 'title' => 'Dolor Sit', 'text' => 'Sed do eiusmod tempor incididunt ut labore.' ),
+							array( 'title' => 'Consectetur', 'text' => 'Ut enim ad minim veniam, quis nostrud.', 'marker' => 'outline' ),
+						),
+					),
+					'show_eyebrow' => array(
+						'type'    => 'select',
+						'label'   => __( 'Eyebrows', 'ds-toolkit' ),
+						'default' => 'yes',
+						'options' => array( 'yes' => __( 'Show (auto-numbered when blank)', 'ds-toolkit' ), 'no' => __( 'Hide', 'ds-toolkit' ) ),
+					),
+				),
+			),
+		),
+	),
+	'style'   => array(
+		'title'    => __( 'Style', 'ds-toolkit' ),
+		'sections' => array(
+			'track' => array(
+				'title'  => __( 'Progress Line', 'ds-toolkit' ),
+				'fields' => array(
+					'marker_shape'   => array( 'type' => 'select', 'label' => __( 'Marker Shape', 'ds-toolkit' ), 'default' => 'diamond', 'options' => array( 'diamond' => __( 'Diamond', 'ds-toolkit' ), 'circle' => __( 'Circle', 'ds-toolkit' ) ) ),
+					'marker_size'    => array( 'type' => 'unit', 'label' => __( 'Marker Size', 'ds-toolkit' ), 'default' => '14', 'description' => 'px', 'slider' => array( 'min' => 8, 'max' => 28, 'step' => 1 ) ),
+					'line_color'     => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Line Colour', 'ds-toolkit' ), 'default' => 'var(--fl-global-accent)', 'show_reset' => true ),
+					'marker_color'   => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Marker Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Blank = the Line Colour.', 'ds-toolkit' ) ),
+					'line_thickness' => array( 'type' => 'unit', 'label' => __( 'Line Thickness', 'ds-toolkit' ), 'default' => '2', 'description' => 'px', 'slider' => array( 'min' => 1, 'max' => 6, 'step' => 1 ) ),
+					'track_gap'      => array( 'type' => 'unit', 'label' => __( 'Space Below Line', 'ds-toolkit' ), 'default' => '26', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 80, 'step' => 1 ) ),
+					'stack_at'       => array(
+						'type'    => 'select',
+						'label'   => __( 'Stack Below', 'ds-toolkit' ),
+						'default' => 'medium',
+						'options' => array(
+							'large'  => __( 'Large breakpoint', 'ds-toolkit' ),
+							'medium' => __( 'Medium breakpoint', 'ds-toolkit' ),
+							'small'  => __( 'Small breakpoint', 'ds-toolkit' ),
+							'never'  => __( 'Never (always one row)', 'ds-toolkit' ),
+						),
+						'help'    => __( 'Below this breakpoint the pathway becomes a vertical timeline: markers run down a left rail with the line between them, so everything stays aligned on small screens.', 'ds-toolkit' ),
+					),
+				),
+			),
+			'cards' => array(
+				'title'  => __( 'Stages', 'ds-toolkit' ),
+				'fields' => array(
+					'gap'           => array( 'type' => 'unit', 'label' => __( 'Gap Between Stages', 'ds-toolkit' ), 'default' => '32', 'description' => 'px', 'responsive' => true, 'slider' => array( 'min' => 0, 'max' => 80, 'step' => 1 ) ),
+					'dividers'      => array( 'type' => 'select', 'label' => __( 'Stage Dividers', 'ds-toolkit' ), 'default' => 'no', 'options' => array( 'no' => __( 'None', 'ds-toolkit' ), 'yes' => __( 'Thin vertical lines between stages', 'ds-toolkit' ) ) ),
+					'divider_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Divider Colour', 'ds-toolkit' ), 'default' => 'rgba(255,255,255,0.12)', 'show_reset' => true ),
+				),
+			),
+			'colors' => array(
+				'title'  => __( 'Colours', 'ds-toolkit' ),
+				'fields' => array(
+					'eyebrow_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Eyebrow', 'ds-toolkit' ), 'default' => 'var(--fl-global-accent)', 'show_reset' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-path-eyebrow', 'property' => 'color' ) ),
+					'title_color'   => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Title', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-path-title', 'property' => 'color' ) ),
+					'text_color'    => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Description', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-path-text', 'property' => 'color' ) ),
+				),
+			),
+			'typography' => array(
+				'title'  => __( 'Typography', 'ds-toolkit' ),
+				'fields' => array(
+					'eyebrow_typography' => array( 'type' => 'typography', 'label' => __( 'Eyebrow', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-path-eyebrow' ) ),
+					'title_typography'   => array( 'type' => 'typography', 'label' => __( 'Title', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-path-title' ) ),
+					'text_typography'    => array( 'type' => 'typography', 'label' => __( 'Description', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-path-text' ) ),
+				),
+			),
+			'spacing' => array(
+				'title'  => __( 'Spacing', 'ds-toolkit' ),
+				'fields' => array(
+					'content_width'     => array(
+						'type'    => 'select',
+						'label'   => __( 'Content Width', 'ds-toolkit' ),
+						'default' => 'boxed',
+						'options' => array(
+							'boxed'  => __( 'Boxed (max 1280px)', 'ds-toolkit' ),
+							'full'   => __( 'Full width (fill container)', 'ds-toolkit' ),
+							'custom' => __( 'Custom max-width', 'ds-toolkit' ),
+						),
+						'toggle'  => array( 'custom' => array( 'fields' => array( 'content_max_width' ) ) ),
+					),
+					'content_max_width' => array( 'type' => 'unit', 'label' => __( 'Max Width', 'ds-toolkit' ), 'default' => '1280', 'description' => 'px', 'slider' => array( 'min' => 480, 'max' => 1920, 'step' => 10 ) ),
+					'padding' => array( 'type' => 'dimension', 'label' => __( 'Padding', 'ds-toolkit' ), 'default' => '0', 'units' => array( 'px' ), 'slider' => true, 'responsive' => true ),
+					'margin'  => array( 'type' => 'dimension', 'label' => __( 'Margin', 'ds-toolkit' ), 'default' => '0', 'units' => array( 'px' ), 'slider' => true, 'responsive' => true ),
+				),
+			),
+		),
+	),
+) );

--- a/modules/ds-pathway/icon.svg
+++ b/modules/ds-pathway/icon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+<path d="M2 7h20" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" opacity=".55"/>
+<rect x="3.1" y="4.6" width="4.8" height="4.8" rx=".6" transform="rotate(45 5.5 7)" fill="currentColor"/>
+<rect x="9.6" y="4.6" width="4.8" height="4.8" rx=".6" transform="rotate(45 12 7)" fill="currentColor"/>
+<rect x="16.1" y="4.6" width="4.8" height="4.8" rx=".6" transform="rotate(45 18.5 7)" fill="none" stroke="currentColor" stroke-width="1.4"/>
+<rect x="3" y="13" width="5" height="2" rx="1" fill="currentColor"/>
+<rect x="9.5" y="13" width="5" height="2" rx="1" fill="currentColor"/>
+<rect x="16" y="13" width="5" height="2" rx="1" fill="currentColor"/>
+<rect x="3" y="17" width="5" height="1.4" rx=".7" fill="currentColor" opacity=".5"/>
+<rect x="9.5" y="17" width="5" height="1.4" rx=".7" fill="currentColor" opacity=".5"/>
+<rect x="16" y="17" width="5" height="1.4" rx=".7" fill="currentColor" opacity=".5"/>
+</svg>

--- a/modules/ds-pathway/includes/frontend.css.php
+++ b/modules/ds-pathway/includes/frontend.css.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * LeagueApps Pathway — dynamic CSS. $module, $settings, $id in scope.
+ */
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+$node = ".fl-node-$id";
+$col  = array( 'DS_Module_UI', 'color' );
+$u    = array( 'DS_Module_UI', 'u' );
+list( $bpm, $bpr ) = DS_Module_UI::breakpoints();
+
+// ---- Content width (boxed / full / custom) ----
+$cw = $settings->content_width ?? 'boxed';
+if ( 'full' === $cw ) {
+	echo "$node .ds-pathway-wrap { max-width: none; margin: 0; }\n";
+} elseif ( 'custom' === $cw ) {
+	$cmw = ( isset( $settings->content_max_width ) && '' !== $settings->content_max_width ) ? (int) $settings->content_max_width : 1280;
+	echo "$node .ds-pathway-wrap { max-width: {$cmw}px; margin: 0 auto; }\n";
+}
+
+// ---- Track / marker custom properties on the section ----
+$vars   = array();
+$vars[] = '--ds-path-msize:' . $u( $settings->marker_size ?? '', 14 ) . 'px';
+$vars[] = '--ds-path-line:' . $u( $settings->line_thickness ?? '', 2 ) . 'px';
+$vars[] = '--ds-path-trackgap:' . $u( $settings->track_gap ?? '', 26 ) . 'px';
+$vars[] = '--ds-path-gap:' . $u( $settings->gap ?? '', 32 ) . 'px';
+$lc = $col( $settings->line_color ?? '' );
+if ( '' !== $lc ) { $vars[] = '--ds-path-line-c:' . $lc; }
+$mc = $col( $settings->marker_color ?? '' );
+if ( '' !== $mc ) { $vars[] = '--ds-path-marker-c:' . $mc; }
+$dc = $col( $settings->divider_color ?? '' );
+if ( '' !== $dc ) { $vars[] = '--ds-path-divider-c:' . $dc; }
+echo "$node .ds-pathway { " . implode( '; ', $vars ) . "; }\n";
+
+// Responsive gap overrides.
+if ( '' !== ( $settings->gap_medium ?? '' ) ) { echo "@media (max-width:{$bpm}px){ $node .ds-pathway { --ds-path-gap: " . (int) $settings->gap_medium . "px; } }\n"; }
+if ( '' !== ( $settings->gap_responsive ?? '' ) ) { echo "@media (max-width:{$bpr}px){ $node .ds-pathway { --ds-path-gap: " . (int) $settings->gap_responsive . "px; } }\n"; }
+
+// ---- Colours ----
+$c = $col( $settings->eyebrow_color ?? '' ); if ( '' !== $c ) { echo "$node .ds-path-eyebrow { color: {$c}; }\n"; }
+$c = $col( $settings->title_color ?? '' );   if ( '' !== $c ) { echo "$node .ds-path-title { color: {$c}; }\n"; }
+$c = $col( $settings->text_color ?? '' );    if ( '' !== $c ) { echo "$node .ds-path-text { color: {$c}; }\n"; }
+
+// ---- Vertical timeline below the stack breakpoint (GH #96 responsive) ----
+// Markers run down a left rail; each stage's segment drops to the next marker;
+// the last stage fades downward. Dividers are a horizontal-mode treatment.
+$stack_map = array( 'large' => 0, 'medium' => $bpm, 'small' => $bpr );
+$stack_at  = $settings->stack_at ?? 'medium';
+if ( isset( $stack_map[ $stack_at ] ) ) {
+	$bp_lg    = (int) ( FLBuilderModel::get_global_settings()->large_breakpoint ?? 1200 );
+	$stack_bp = 'large' === $stack_at ? $bp_lg : $stack_map[ $stack_at ];
+	echo "@media (max-width:{$stack_bp}px){\n";
+	echo "\t$node .ds-pathway-grid { grid-template-columns: 1fr; row-gap: 30px; }\n";
+	echo "\t$node .ds-path-stage { padding-left: calc(var(--ds-path-msize,14px) + 20px); }\n";
+	echo "\t$node .ds-path-track { position: absolute; left: 0; top: 4px; bottom: -30px; height: auto; width: var(--ds-path-msize,14px); margin: 0; }\n";
+	echo "\t$node .ds-path-track::before { left: 50%; right: auto; top: calc(var(--ds-path-msize,14px) + 4px); bottom: 4px; height: auto; width: var(--ds-path-line,2px); transform: translateX(-50%); }\n";
+	echo "\t$node .ds-path-marker { top: 0; transform: rotate(45deg); }\n";
+	echo "\t$node .ds-pathway--m-circle .ds-path-marker { transform: none; }\n";
+	echo "\t$node .ds-path-stage--last .ds-path-track { bottom: auto; height: calc(var(--ds-path-msize,14px) + 90px); }\n";
+	echo "\t$node .ds-path-stage--last .ds-path-track::before { width: var(--ds-path-line,2px); background: linear-gradient(to bottom, var(--ds-path-line-c,var(--fl-global-accent,#f26a21)), transparent); }\n";
+	echo "\t$node .ds-pathway--dividers .ds-path-stage::after { display: none; }\n";
+	echo "}\n";
+}
+
+// ---- Spacing: padding on the wrap, margin on the section (deferred) ----
+if ( class_exists( 'FLBuilderCSS' ) ) {
+	FLBuilderCSS::dimension_field_rule( array(
+		'settings'     => $settings,
+		'setting_name' => 'padding',
+		'selector'     => "$node .ds-pathway-wrap",
+		'unit'         => 'px',
+		'props'        => array( 'padding-top' => 'padding_top', 'padding-right' => 'padding_right', 'padding-bottom' => 'padding_bottom', 'padding-left' => 'padding_left' ),
+	) );
+	FLBuilderCSS::dimension_field_rule( array(
+		'settings'     => $settings,
+		'setting_name' => 'margin',
+		'selector'     => "$node .ds-pathway",
+		'unit'         => 'px',
+		'props'        => array( 'margin-top' => 'margin_top', 'margin-right' => 'margin_right', 'margin-bottom' => 'margin_bottom', 'margin-left' => 'margin_left' ),
+	) );
+}
+
+// ---- Typography (deferred; flushed by FLBuilderCSS::render()) ----
+// Every typography field is in this map ON PURPOSE (GH #87 lesson).
+if ( class_exists( 'FLBuilderCSS' ) ) {
+	$typo = array(
+		'eyebrow_typography' => '.ds-path-eyebrow',
+		'title_typography'   => '.ds-path-title',
+		'text_typography'    => '.ds-path-text',
+	);
+	foreach ( $typo as $key => $sel ) {
+		if ( ! empty( $settings->{$key} ) ) {
+			FLBuilderCSS::typography_field_rule( array( 'settings' => $settings, 'setting_name' => $key, 'selector' => "$node $sel" ) );
+		}
+	}
+}

--- a/modules/ds-pathway/includes/frontend.php
+++ b/modules/ds-pathway/includes/frontend.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * LeagueApps Pathway — frontend markup. $module, $settings, $id in scope.
+ */
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+$module->render_pathway();


### PR DESCRIPTION
Closes #96.

## What

New **LeagueApps Pathway** Beaver Builder module (`modules/ds-pathway/`): a row of stage cards connected by a progress line, built to the reference design.

- **Stages repeater** — eyebrow (auto-numbers "Stage 01…" when blank), title, description, optional link, and a per-stage **Filled / Outline** marker (outline reads as an upcoming stage, as in the reference). Blank rows are skipped (GH #89 lesson) so the line always matches what renders.
- **Dynamic line, pure CSS, no JS** — each stage owns its own segment (its marker's right edge to the next marker's left edge, spanning the grid gap), so adding/removing/reordering stages automatically re-fits markers and line. The **last stage renders a gradient fade tail** instead of a segment: the line ends with the final card and never continues past it. Since segments stop at marker edges, the line never draws through hollow markers.
- **Responsive** — configurable **Stack Below** breakpoint (Large / Medium / Small / never, default Medium): below it the pathway becomes a **vertical left-rail timeline** (markers down the rail, vertical segments, downward fade after the last stage) so markers, spacing, and line stay aligned instead of breaking across wrapped rows. Gap is responsive; typography (eyebrow/title/description) responsive with live previews.
- **Style controls** — marker shape (diamond/circle) + size, line colour/thickness (defaults to `var(--fl-global-accent)`), marker colour, optional thin stage dividers, colour fields with global-colour connections, content width, padding/margin.
- **Wiring** — `features/class-ds-pathway.php` loader, registry entry, blueprint-6 default-on, `module_features()` toggle entry (so it's switchable on any blueprint).

## Verified (static render harness + Playwright — Local blueprint is currently stopped)

Rendered the real module class + real dynamic CSS through a WP/BB stub harness with the reference's 5 stages (3 filled + 2 outline) + 1 injected blank row:

- Desktop (1280px): 5 stages (blank skipped), 5 markers aligned to their cards, 4 solid segments + gradient fade tail on the last, 2 outline markers, 4 dividers — screenshot is a near-exact match to the reference design.
- Mobile (480px): single column, track becomes a vertical rail, last stage fades downward.
- `php -l` clean on all files; both version lines at 1.9.66; changelog added.

In-builder smoke test to follow when the Local blueprint is next running (module registration follows the identical pattern as the other 15 modules).
