### PR TITLE
feat: Pathway markers outline by default, fill with accent on hover (GH #98) (1.9.67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.67] - 2026-08-06
+### Changed
+- **Pathway: markers are outline by default and fill with the accent colour on hover (GH #98).** Hollow markers now fill smoothly on hover and fade back when the pointer leaves, with a configurable transition (default 250ms). Hovering anywhere on a stage lights its marker by default — keeping the marker tied to its card and giving visitors a real hit target instead of a few pixels — with a Hover Target option for marker-only, plus Fill On Hover (off switch), Hover Fill Colour, and Outline Thickness controls. Keyboard focus inside a stage fills its marker too; touch devices never get a stuck filled state; the fill is skipped for reduced-motion visitors. A stage can still be pinned solid with the per-stage "Always filled" marker option, and markers no longer change size between hollow and filled states.
+
 ## [1.9.66] - 2026-08-06
 ### Added
 - **New module: Pathway (GH #96).** Stage cards (auto-numbered eyebrow, title, description, optional link) connected by a progress line with one marker per stage. Markers and line segments are generated per card, so adding, removing, or reordering stages automatically re-fits the line, which ends at the final stage with a gradient fade and never continues past the last card. Per-stage Filled/Outline markers (upcoming stages), diamond or circle shapes, line/marker colours synced to the global accent, optional thin stage dividers, responsive gap and typography controls, and a configurable stack breakpoint below which the pathway becomes a vertical left-rail timeline so markers, spacing, and the line stay aligned on small screens. Pure CSS, no JS. Registered like every LeagueApps module (Features toggle; default on for blueprint 6+).

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.66
+ * Version:           1.9.67
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.66' );
+define( 'DS_TOOLKIT_VERSION', '1.9.67' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-pathway/css/frontend.css
+++ b/modules/ds-pathway/css/frontend.css
@@ -14,9 +14,28 @@
 .ds-path-stage--last .ds-path-track::before{right:auto;width:min(160px,75%);background:linear-gradient(to right,var(--ds-path-line-c,var(--fl-global-accent,#f26a21)),transparent);}
 
 /* ---- Markers ---- */
-.ds-path-marker{position:absolute;top:50%;left:0;width:var(--ds-path-msize,14px);height:var(--ds-path-msize,14px);background:var(--ds-path-marker-c,var(--ds-path-line-c,var(--fl-global-accent,#f26a21)));transform:translateY(-50%) rotate(45deg);z-index:1;}
+/* box-sizing pinned so a hollow marker's border can never make it larger than a
+   filled one (the segment starts at exactly --ds-path-msize). */
+.ds-path-marker{position:absolute;top:50%;left:0;box-sizing:border-box;width:var(--ds-path-msize,14px);height:var(--ds-path-msize,14px);background:var(--ds-path-marker-c,var(--ds-path-line-c,var(--fl-global-accent,#f26a21)));border:var(--ds-path-mborder,2px) solid transparent;transform:translateY(-50%) rotate(45deg);z-index:1;transition:background-color var(--ds-path-mspeed,.25s) ease,border-color var(--ds-path-mspeed,.25s) ease;}
 .ds-pathway--m-circle .ds-path-marker{transform:translateY(-50%);border-radius:50%;}
-.ds-path-stage--outline .ds-path-marker{background:transparent;border:2px solid var(--ds-path-marker-c,var(--ds-path-line-c,var(--fl-global-accent,#f26a21)));}
+.ds-path-stage--outline .ds-path-marker{background:transparent;border-color:var(--ds-path-marker-c,var(--ds-path-line-c,var(--fl-global-accent,#f26a21)));}
+
+/* ---- Hover: hollow marker fills with the accent colour, then returns (GH #98) ----
+   The border stays the same colour as the fill, so nothing shifts or resizes.
+   Hover rules are pointer-only so touch devices never get a stuck filled state;
+   :focus-within covers keyboard users (a stage title can be a link). */
+@media (hover:hover){
+  .ds-pathway--hoverstage .ds-path-stage--outline:hover .ds-path-marker,
+  .ds-pathway--hovermarker .ds-path-stage--outline .ds-path-marker:hover{background:var(--ds-path-hover-c,var(--ds-path-marker-c,var(--ds-path-line-c,var(--fl-global-accent,#f26a21))));border-color:var(--ds-path-hover-c,var(--ds-path-marker-c,var(--ds-path-line-c,var(--fl-global-accent,#f26a21))));}
+}
+.ds-pathway--hoverstage .ds-path-stage--outline:focus-within .ds-path-marker,
+.ds-pathway--hovermarker .ds-path-stage--outline:focus-within .ds-path-marker{background:var(--ds-path-hover-c,var(--ds-path-marker-c,var(--ds-path-line-c,var(--fl-global-accent,#f26a21))));border-color:var(--ds-path-hover-c,var(--ds-path-marker-c,var(--ds-path-line-c,var(--fl-global-accent,#f26a21))));}
+/* Marker-only mode: the tiny marker is the hit target, so give it a pointer. */
+.ds-pathway--hovermarker .ds-path-stage--outline .ds-path-marker{cursor:pointer;}
+
+@media (prefers-reduced-motion:reduce){
+  .ds-path-marker{transition:none;}
+}
 
 /* ---- Stage content ---- */
 .ds-path-eyebrow{display:block;font-size:.72rem;font-weight:700;letter-spacing:.28em;text-transform:uppercase;color:var(--fl-global-accent,#f26a21);margin:0 0 12px;}

--- a/modules/ds-pathway/ds-pathway.php
+++ b/modules/ds-pathway/ds-pathway.php
@@ -62,7 +62,9 @@ class DS_Pathway_Module extends FLBuilderModule {
 				'text'    => $text,
 				'url'     => $url,
 				'target'  => $target,
-				'marker'  => ( $stage->marker ?? 'fill' ) === 'outline' ? 'outline' : 'fill',
+				// Outline is the default state (GH #98): hollow at rest, filling
+				// with the accent on hover. 'fill' pins a stage permanently solid.
+				'marker'  => ( $stage->marker ?? 'outline' ) === 'fill' ? 'fill' : 'outline',
 			);
 		}
 		return $out;
@@ -82,6 +84,11 @@ class DS_Pathway_Module extends FLBuilderModule {
 		$shape = ( $s->marker_shape ?? 'diamond' ) === 'circle' ? 'circle' : 'diamond';
 		$mods  = 'ds-pathway ds-pathway--m-' . $shape;
 		if ( ( $s->dividers ?? 'no' ) === 'yes' ) { $mods .= ' ds-pathway--dividers'; }
+		// Hover fill target: the whole stage (default — a 14px marker is a poor
+		// hit target) or the marker alone. 'no' disables the hover fill (GH #98).
+		if ( ( $s->marker_hover ?? 'yes' ) !== 'no' ) {
+			$mods .= ( $s->marker_hover_target ?? 'stage' ) === 'marker' ? ' ds-pathway--hovermarker' : ' ds-pathway--hoverstage';
+		}
 
 		echo '<section class="' . esc_attr( $mods ) . '"><div class="ds-pathway-wrap">';
 		echo '<div class="ds-pathway-grid" style="--ds-path-n:' . count( $stages ) . '">';
@@ -141,9 +148,9 @@ FLBuilder::register_settings_form( 'ds_pathway_stage_form', array(
 						'marker'  => array(
 							'type'    => 'select',
 							'label'   => __( 'Marker', 'ds-toolkit' ),
-							'default' => 'fill',
-							'options' => array( 'fill' => __( 'Filled', 'ds-toolkit' ), 'outline' => __( 'Outline (hollow)', 'ds-toolkit' ) ),
-							'help'    => __( 'Outline reads as an upcoming / future stage, like the reference design.', 'ds-toolkit' ),
+							'default' => 'outline',
+							'options' => array( 'outline' => __( 'Outline (fills on hover)', 'ds-toolkit' ), 'fill' => __( 'Always filled', 'ds-toolkit' ) ),
+							'help'    => __( 'Outline is the default: hollow at rest, filling with the accent colour on hover. Choose Always filled to pin a stage solid (e.g. a completed or current stage).', 'ds-toolkit' ),
 						),
 					),
 				),
@@ -169,7 +176,7 @@ FLBuilder::register_module( 'DS_Pathway_Module', array(
 						'default'      => array(
 							array( 'title' => 'Lorem Ipsum', 'text' => 'Dolor sit amet, consectetur adipiscing elit.' ),
 							array( 'title' => 'Dolor Sit', 'text' => 'Sed do eiusmod tempor incididunt ut labore.' ),
-							array( 'title' => 'Consectetur', 'text' => 'Ut enim ad minim veniam, quis nostrud.', 'marker' => 'outline' ),
+							array( 'title' => 'Consectetur', 'text' => 'Ut enim ad minim veniam, quis nostrud.' ),
 						),
 					),
 					'show_eyebrow' => array(
@@ -190,6 +197,27 @@ FLBuilder::register_module( 'DS_Pathway_Module', array(
 				'fields' => array(
 					'marker_shape'   => array( 'type' => 'select', 'label' => __( 'Marker Shape', 'ds-toolkit' ), 'default' => 'diamond', 'options' => array( 'diamond' => __( 'Diamond', 'ds-toolkit' ), 'circle' => __( 'Circle', 'ds-toolkit' ) ) ),
 					'marker_size'    => array( 'type' => 'unit', 'label' => __( 'Marker Size', 'ds-toolkit' ), 'default' => '14', 'description' => 'px', 'slider' => array( 'min' => 8, 'max' => 28, 'step' => 1 ) ),
+					'marker_border'  => array( 'type' => 'unit', 'label' => __( 'Outline Thickness', 'ds-toolkit' ), 'default' => '2', 'description' => 'px', 'slider' => array( 'min' => 1, 'max' => 5, 'step' => 1 ), 'help' => __( 'Border weight of a hollow marker.', 'ds-toolkit' ) ),
+					'marker_hover'   => array(
+						'type'    => 'select',
+						'label'   => __( 'Fill On Hover', 'ds-toolkit' ),
+						'default' => 'yes',
+						'options' => array( 'yes' => __( 'Yes — hollow markers fill with the accent', 'ds-toolkit' ), 'no' => __( 'No — markers never change', 'ds-toolkit' ) ),
+						'toggle'  => array( 'yes' => array( 'fields' => array( 'marker_hover_target', 'marker_hover_color', 'marker_speed' ) ) ),
+						'help'    => __( 'Hollow markers fill with the accent colour on hover and fade back when the pointer leaves. Keyboard focus inside a stage does the same. Always-filled stages are unaffected.', 'ds-toolkit' ),
+					),
+					'marker_hover_target' => array(
+						'type'    => 'select',
+						'label'   => __( 'Hover Target', 'ds-toolkit' ),
+						'default' => 'stage',
+						'options' => array(
+							'stage'  => __( 'Whole stage (recommended)', 'ds-toolkit' ),
+							'marker' => __( 'The marker only', 'ds-toolkit' ),
+						),
+						'help'    => __( 'Whole stage keeps the marker visually tied to its card and gives visitors a real hit target; the marker alone is only a few pixels wide.', 'ds-toolkit' ),
+					),
+					'marker_hover_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Hover Fill Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Blank = the Marker Colour (or the Line Colour).', 'ds-toolkit' ) ),
+					'marker_speed'   => array( 'type' => 'unit', 'label' => __( 'Hover Transition', 'ds-toolkit' ), 'default' => '250', 'description' => 'ms', 'slider' => array( 'min' => 0, 'max' => 800, 'step' => 10 ), 'help' => __( 'How smoothly the marker fills and empties. Ignored for reduced-motion visitors.', 'ds-toolkit' ) ),
 					'line_color'     => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Line Colour', 'ds-toolkit' ), 'default' => 'var(--fl-global-accent)', 'show_reset' => true ),
 					'marker_color'   => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Marker Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Blank = the Line Colour.', 'ds-toolkit' ) ),
 					'line_thickness' => array( 'type' => 'unit', 'label' => __( 'Line Thickness', 'ds-toolkit' ), 'default' => '2', 'description' => 'px', 'slider' => array( 'min' => 1, 'max' => 6, 'step' => 1 ) ),

--- a/modules/ds-pathway/includes/frontend.css.php
+++ b/modules/ds-pathway/includes/frontend.css.php
@@ -21,6 +21,8 @@ if ( 'full' === $cw ) {
 // ---- Track / marker custom properties on the section ----
 $vars   = array();
 $vars[] = '--ds-path-msize:' . $u( $settings->marker_size ?? '', 14 ) . 'px';
+$vars[] = '--ds-path-mborder:' . max( 1, $u( $settings->marker_border ?? '', 2 ) ) . 'px';
+$vars[] = '--ds-path-mspeed:' . max( 0, $u( $settings->marker_speed ?? '', 250 ) ) . 'ms';
 $vars[] = '--ds-path-line:' . $u( $settings->line_thickness ?? '', 2 ) . 'px';
 $vars[] = '--ds-path-trackgap:' . $u( $settings->track_gap ?? '', 26 ) . 'px';
 $vars[] = '--ds-path-gap:' . $u( $settings->gap ?? '', 32 ) . 'px';
@@ -28,6 +30,8 @@ $lc = $col( $settings->line_color ?? '' );
 if ( '' !== $lc ) { $vars[] = '--ds-path-line-c:' . $lc; }
 $mc = $col( $settings->marker_color ?? '' );
 if ( '' !== $mc ) { $vars[] = '--ds-path-marker-c:' . $mc; }
+$hc = $col( $settings->marker_hover_color ?? '' );
+if ( '' !== $hc ) { $vars[] = '--ds-path-hover-c:' . $hc; }
 $dc = $col( $settings->divider_color ?? '' );
 if ( '' !== $dc ) { $vars[] = '--ds-path-divider-c:' . $dc; }
 echo "$node .ds-pathway { " . implode( '; ', $vars ) . "; }\n";


### PR DESCRIPTION
Closes #98.

## What

Pathway markers are now **outline by default** and **fill with the accent colour on hover**, fading back to hollow when the pointer leaves.

- **Per-stage marker default flipped to Outline** (was Filled). The option remains as *Outline (fills on hover)* vs *Always filled*, so a completed/current stage can still be pinned solid.
- **Smooth transition** on `background-color` + `border-color`, duration configurable (**Hover Transition**, default 250ms), skipped under `prefers-reduced-motion`.
- **Hover Target** (new): *Whole stage* (default) or *The marker only*. Default is the whole stage for two reasons — it keeps the marker visually tied to its card, which the issue asks for, and a 14px diamond is not a realistic hit target. Marker-only is there for a literal reading and gets a `cursor:pointer`.
- **Fill On Hover** off switch and **Hover Fill Colour** (blank = marker/line colour), plus **Outline Thickness**.
- **No size jump:** the marker now has `box-sizing:border-box` and a permanent transparent border, so hollow and filled markers are pixel-identical (previously a hollow marker was 4px larger under a content-box theme, nudging the line).
- **A11y / touch:** `:focus-within` fills the marker when a keyboard user tabs into a stage; hover rules are wrapped in `@media (hover:hover)` so touch devices never get a stuck filled marker after a tap.

## Verified (real module + real dynamic CSS through a stub harness, driven by Playwright)

| check | result |
|---|---|
| Rest state | transparent fill, accent border ✓ |
| Hover a card body (stage mode) | marker fills accent, border matches ✓ |
| Neighbouring stage during hover | unchanged ✓ |
| Pointer leaves | returns to hollow ✓ |
| Marker-only mode, hover card body | does **not** fill ✓ |
| Marker-only mode, hover marker | fills ✓ |
| Keyboard focus inside a stage | fills ✓ |
| iPhone 13 after tap | stays hollow (no sticky hover) ✓ |
| Pinned "Always filled" stage | stays solid throughout ✓ |
| Transition duration | 0.25s on both properties ✓ |
| Marker size hollow vs filled | identical ✓ |

`php -l` clean; both version lines at 1.9.67; changelog added.
