### PR TITLE
feat: Menu — Off-canvas Sidebar layout (GH #101) (1.9.68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.68] - 2026-08-06
+### Added
+- **Menu: Off-canvas Sidebar layout (GH #101).** A new Layout control in the Menu module's General tab offers `Horizontal bar` (unchanged default) or `Off-canvas sidebar`. In sidebar mode the horizontal bar is hidden at every width and the hamburger is always visible; clicking it slides a docked side panel in from the chosen edge over a dimmed page, for partners who want sidebar navigation instead of a top nav. New Sidebar section: Dock Side (left/right), Panel Width (default 340px, capped to the viewport), Panel Width — Mobile (blank = full width), Dim Page Behind, and Dim Color. Every colour, divider, drawer-logo, CTA, and typography control in the existing Mobile Overlay section drives the panel, so a sidebar is fully styleable with the fields partners already know. The panel slides from its docked edge (cross-fade only under `prefers-reduced-motion`), and closes on the hamburger X, the scrim, or Escape.
+
+### Fixed
+- **Menu: drawer logo no longer pushed out of view in a narrow drawer.** The right-aligned drawer logo's clearance was measured against the viewport width rather than the drawer's own right edge. Identical for the full-screen drawer, but it padded the logo completely off-panel in the new sidebar layout.
+
 ## [1.9.67] - 2026-08-06
 ### Changed
 - **Pathway: markers are outline by default and fill with the accent colour on hover (GH #98).** Hollow markers now fill smoothly on hover and fade back when the pointer leaves, with a configurable transition (default 250ms). Hovering anywhere on a stage lights its marker by default — keeping the marker tied to its card and giving visitors a real hit target instead of a few pixels — with a Hover Target option for marker-only, plus Fill On Hover (off switch), Hover Fill Colour, and Outline Thickness controls. Keyboard focus inside a stage fills its marker too; touch devices never get a stuck filled state; the fill is skipped for reduced-motion visitors. A stage can still be pinned solid with the per-stage "Always filled" marker option, and markers no longer change size between hollow and filled states.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.67
+ * Version:           1.9.68
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.67' );
+define( 'DS_TOOLKIT_VERSION', '1.9.68' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/ds-menu.php
+++ b/modules/ds-menu/ds-menu.php
@@ -108,7 +108,10 @@ class DS_Menu_Module extends FLBuilderModule {
 		}
 		$this->mega_use_picker = ! empty( $this->mega_map );
 
-		$mstyle = ( ( $s->mobile_menu_style ?? 'drill' ) === 'overlay' ) ? 'overlay' : 'drill';
+		// Off-canvas sidebar always uses the drill drawer — the legacy full-screen
+		// overlay has no docked form, so the Mobile Menu Style choice is ignored here.
+		$is_offcanvas = ( ( $s->layout ?? 'horizontal' ) === 'offcanvas' );
+		$mstyle       = ( ! $is_offcanvas && ( $s->mobile_menu_style ?? 'drill' ) === 'overlay' ) ? 'overlay' : 'drill';
 
 		// Drawer logo (drill style): module image → Partner Logo option → site logo.
 		$drill_logo = '';
@@ -131,7 +134,11 @@ class DS_Menu_Module extends FLBuilderModule {
 		}
 
 		$megasmart = ( ( $s->mega_enabled ?? 'no' ) === 'yes' && ( $s->mega_smart ?? 'yes' ) === 'yes' );
-		echo '<nav class="ds-menu-wrap' . ( 'drill' === $mstyle ? ' ds-menu-wrap--drill' : '' ) . ( $megasmart ? ' ds-menu-wrap--megasmart' : '' ) . '"' . $drill_attrs . ' aria-label="' . esc_attr__( 'Primary', 'ds-toolkit' ) . '">';
+		$oc_class = '';
+		if ( $is_offcanvas ) {
+			$oc_class = ' ds-menu-wrap--offcanvas ds-menu-wrap--offcanvas-' . ( ( $s->sidebar_side ?? 'left' ) === 'right' ? 'right' : 'left' );
+		}
+		echo '<nav class="ds-menu-wrap' . ( 'drill' === $mstyle ? ' ds-menu-wrap--drill' : '' ) . ( $megasmart ? ' ds-menu-wrap--megasmart' : '' ) . $oc_class . '"' . $drill_attrs . ' aria-label="' . esc_attr__( 'Primary', 'ds-toolkit' ) . '">';
 
 		// Hamburger toggle (animates into an X via CSS when the overlay opens).
 		echo '<button type="button" class="ds-menu-toggle" aria-expanded="false" aria-label="' . esc_attr__( 'Toggle menu', 'ds-toolkit' ) . '">';
@@ -264,6 +271,25 @@ FLBuilder::register_module( 'DS_Menu_Module', array(
 						'label'   => __( 'WordPress Menu', 'ds-toolkit' ),
 						'options' => DS_Menu_Module::menu_options(),
 					),
+					'layout'    => array(
+						'type'    => 'select',
+						'label'   => __( 'Layout', 'ds-toolkit' ),
+						'default' => 'horizontal',
+						'options' => array(
+							'horizontal' => __( 'Horizontal bar', 'ds-toolkit' ),
+							'offcanvas'  => __( 'Off-canvas sidebar', 'ds-toolkit' ),
+						),
+						'help'    => __( 'Horizontal bar is the standard menu. Off-canvas sidebar hides the bar at every width and opens the menu as a docked side panel from the hamburger — use it when the site wants sidebar navigation instead of a top nav.', 'ds-toolkit' ),
+						'toggle'  => array(
+							'horizontal' => array(
+								'fields'   => array( 'alignment' ),
+								'sections' => array( 'mega', 'bar', 'hover', 'space', 'pill', 'drop' ),
+							),
+							'offcanvas'  => array(
+								'sections' => array( 'sidebar' ),
+							),
+						),
+					),
 					'alignment' => array(
 						'type'    => 'select',
 						'label'   => __( 'Alignment', 'ds-toolkit' ),
@@ -274,6 +300,56 @@ FLBuilder::register_module( 'DS_Menu_Module', array(
 							'right'  => __( 'Right', 'ds-toolkit' ),
 							'justify' => __( 'Justify (even spacing)', 'ds-toolkit' ),
 						),
+					),
+				),
+			),
+			// Off-canvas sidebar geometry. Only shown when Layout = Off-canvas sidebar;
+			// every COLOUR/typography aspect of the panel is already covered by the
+			// Mobile Overlay section, which drives the same drawer markup.
+			'sidebar' => array(
+				'title'  => __( 'Sidebar', 'ds-toolkit' ),
+				'fields' => array(
+					'sidebar_side'         => array(
+						'type'    => 'select',
+						'label'   => __( 'Dock Side', 'ds-toolkit' ),
+						'default' => 'left',
+						'options' => array(
+							'left'  => __( 'Left', 'ds-toolkit' ),
+							'right' => __( 'Right', 'ds-toolkit' ),
+						),
+					),
+					'sidebar_width'        => array(
+						'type'        => 'unit',
+						'label'       => __( 'Panel Width', 'ds-toolkit' ),
+						'default'     => '340',
+						'description' => 'px',
+						'slider'      => array( 'min' => 220, 'max' => 520, 'step' => 10 ),
+						'help'        => __( 'Width of the docked panel on desktop. Never exceeds the viewport.', 'ds-toolkit' ),
+					),
+					'sidebar_width_mobile' => array(
+						'type'        => 'unit',
+						'label'       => __( 'Panel Width — Mobile', 'ds-toolkit' ),
+						'default'     => '',
+						'description' => 'px',
+						'help'        => __( 'Leave blank for a full-width panel on phones (recommended).', 'ds-toolkit' ),
+					),
+					'sidebar_scrim'        => array(
+						'type'    => 'select',
+						'label'   => __( 'Dim Page Behind', 'ds-toolkit' ),
+						'default' => 'yes',
+						'options' => array(
+							'yes' => __( 'Yes', 'ds-toolkit' ),
+							'no'  => __( 'No', 'ds-toolkit' ),
+						),
+						'toggle'  => array( 'yes' => array( 'fields' => array( 'sidebar_scrim_color' ) ) ),
+					),
+					'sidebar_scrim_color'  => array(
+						'type'        => 'color',
+						'connections' => array( 'color' ),
+						'label'       => __( 'Dim Color', 'ds-toolkit' ),
+						'default'     => 'rgba(0,0,0,0.5)',
+						'show_reset'  => true,
+						'show_alpha'  => true,
 					),
 				),
 			),

--- a/modules/ds-menu/includes/frontend.css.php
+++ b/modules/ds-menu/includes/frontend.css.php
@@ -27,6 +27,20 @@ $osubhov    = $col( $settings->overlay_subtext_hover ?? '' ); // overlay submenu
 $osubbg     = $col( $settings->overlay_sub_bg ?? '' );        // overlay submenu link background
 $dgap       = isset( $settings->dropdown_gap ) && '' !== $settings->dropdown_gap ? (int) $settings->dropdown_gap : 0; // desktop bar -> dropdown gap
 $bp         = isset( $settings->breakpoint ) && '' !== $settings->breakpoint ? (int) $settings->breakpoint : 1000;
+
+/* Off-canvas sidebar layout. Everything the sidebar needs — hamburger always
+   visible, horizontal bar always hidden, drill drawer always active — is exactly
+   what the existing "below the breakpoint" rules already do. So instead of
+   restructuring those media queries (which every fleet site's mobile menu
+   depends on), the layout pins the breakpoint above any real viewport:
+     - every `max-width: $bp`  rule now matches at all widths  -> drawer mode on
+     - every `min-width: $bp+1` rule can never match           -> desktop bar off
+   The panel is then re-anchored from full-screen to a docked side panel at the
+   bottom of this file. Horizontal layout is untouched. */
+$is_oc      = ( ( $settings->layout ?? 'horizontal' ) === 'offcanvas' );
+if ( $is_oc ) {
+	$bp = 99999;
+}
 $align      = $settings->alignment ?? 'right';
 $justify    = array( 'left' => 'flex-start', 'center' => 'center', 'right' => 'flex-end', 'justify' => 'space-between' )[ $align ] ?? 'flex-end';
 
@@ -533,5 +547,67 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 		'setting_name' => 'mobile_subtypography',
 		'selector'     => "$open .ds-submenu a, $open .ds-mega a, $node .ds-drill-panel:not(.is-root)",
 	) );
+}
+
+/* ===================================================================
+ * Off-canvas sidebar geometry.
+ *
+ * Emitted OUTSIDE the breakpoint media query and last, so it re-anchors
+ * the drawer the `max-width: $bp` block just set up full-screen. Only the
+ * box changes here — colours, dividers, drawer logo, CTA and typography all
+ * still come from the Mobile Overlay fields, so the panel is fully styleable
+ * with the controls partners already know.
+ * =================================================================== */
+if ( $is_oc ) {
+	$side  = ( ( $settings->sidebar_side ?? 'left' ) === 'right' ) ? 'right' : 'left';
+	$swide = isset( $settings->sidebar_width ) && '' !== $settings->sidebar_width ? (int) $settings->sidebar_width : 340;
+	$swide = max( 220, min( 720, $swide ) );
+	$smob  = isset( $settings->sidebar_width_mobile ) && '' !== $settings->sidebar_width_mobile ? (int) $settings->sidebar_width_mobile : 0;
+	$scrim = ( $settings->sidebar_scrim ?? 'yes' ) !== 'no';
+	$scol  = $col( $settings->sidebar_scrim_color ?? '' ) ?: 'rgba(0,0,0,0.5)';
+
+	// Dock the panel to one edge. `min()` keeps it inside the viewport on any
+	// screen narrower than the configured width, so it can never overflow.
+	$inset = ( 'right' === $side ) ? '0 0 0 auto' : '0 auto 0 0';
+	echo "$node .ds-drill { inset: {$inset}; width: min({$swide}px, 100vw); max-width: 100vw; }\n";
+
+	// Phones: full width by default (a 340px panel on a 360px screen looks broken).
+	if ( $smob > 0 ) {
+		echo "@media (max-width: 767px) { $node .ds-drill { width: min({$smob}px, 100vw); } }\n";
+	} else {
+		echo "@media (max-width: 767px) { $node .ds-drill { width: 100vw; } }\n";
+	}
+
+	// Slide in from the docked edge instead of the full-screen cross-fade.
+	$hidden = ( 'right' === $side ) ? 'translateX(100%)' : 'translateX(-100%)';
+	echo "$node .ds-menu-wrap--offcanvas .ds-drill { transform: {$hidden}; transition: transform .3s cubic-bezier(.4,0,.2,1), opacity .2s ease; }\n";
+	echo "$node .ds-menu-wrap--offcanvas.ds-menu-open .ds-drill { transform: translateX(0); }\n";
+	echo "@media (prefers-reduced-motion: reduce) { $node .ds-menu-wrap--offcanvas .ds-drill { transition: opacity .2s ease; transform: none; } }\n";
+
+	// Scrim over the page behind the panel. Node-scoped via the wrap (the drawer
+	// lives inside it) so a second menu on the page is never dimmed by this one.
+	if ( $scrim ) {
+		echo "$node .ds-menu-wrap--offcanvas.ds-menu-open::before { content: ''; position: fixed; inset: 0; z-index: 99999; background: {$scol}; animation: ds-menu-scrim-in .25s ease both; }\n";
+		echo "@keyframes ds-menu-scrim-in { from { opacity: 0; } to { opacity: 1; } }\n";
+	}
+
+	/* Close (X) belongs to the panel, not the viewport corner. The base rule pins
+	   it top/right of the screen, which for a LEFT-docked panel would drop it on
+	   top of the page content instead of the menu. Park it inside the panel edge. */
+	if ( 'left' === $side ) {
+		echo "$open.ds-menu-wrap--offcanvas .ds-menu-toggle { left: min(" . ( $swide - 58 ) . "px, calc(100vw - 58px)); right: auto; }\n";
+		if ( $smob > 0 ) {
+			echo "@media (max-width: 767px) { $open.ds-menu-wrap--offcanvas .ds-menu-toggle { left: min(" . ( $smob - 58 ) . "px, calc(100vw - 58px)); } }\n";
+		} else {
+			echo "@media (max-width: 767px) { $open.ds-menu-wrap--offcanvas .ds-menu-toggle { left: auto; right: max(18px, env(safe-area-inset-right)); } }\n";
+		}
+	}
+
+	/* The closed hamburger sits in the header flow. `margin-left:auto` (set by the
+	   responsive block) shoves it to the far right of its column; in sidebar mode
+	   the module is usually alone in a narrow column, so honour Alignment instead. */
+	$oc_just = array( 'left' => 'flex-start', 'center' => 'center', 'right' => 'flex-end', 'justify' => 'flex-start' )[ $align ] ?? 'flex-end';
+	echo "$node .ds-menu-wrap--offcanvas { display: flex; justify-content: {$oc_just}; }\n";
+	echo "$node .ds-menu-wrap--offcanvas .ds-menu-toggle { margin-left: 0; }\n";
 }
 ?>

--- a/modules/ds-menu/js/frontend.js
+++ b/modules/ds-menu/js/frontend.js
@@ -263,7 +263,8 @@
 				if ( state ) { drawer.removeAttribute( 'inert' ); } else { drawer.setAttribute( 'inert', '' ); }
 			},
 			activePanel: function () { return stack[ stack.length - 1 ] || null; },
-			brand: brand
+			brand: brand,
+			el: drawer
 		};
 	}
 
@@ -313,7 +314,12 @@
 					if ( drill.brand && toggle && -1 !== drill.brand.className.indexOf( 'ds-drill-brand--right' ) ) {
 						requestAnimationFrame( function () {
 							var t = toggle.getBoundingClientRect();
-							drill.brand.style.paddingRight = Math.max( 76, Math.round( window.innerWidth - t.left + 14 ) ) + 'px';
+							// Measure to the DRAWER's right edge, not the viewport's. They are
+							// the same for the full-screen drawer, but an off-canvas sidebar is
+							// only as wide as its panel — using innerWidth there padded the
+							// drawer logo clean out of view.
+							var dr = drill.el ? drill.el.getBoundingClientRect().right : window.innerWidth;
+							drill.brand.style.paddingRight = Math.max( 76, Math.round( dr - t.left + 14 ) ) + 'px';
 						} );
 					}
 				} else if ( drill ) {
@@ -346,6 +352,15 @@
 
 		if ( toggle ) { toggle.addEventListener( 'click', function () { open( ! wrap.classList.contains( 'ds-menu-open' ) ); } ); }
 		if ( close ) { close.addEventListener( 'click', function () { open( false ); } ); }
+
+		/* Off-canvas sidebar: clicking the scrim closes the panel. The scrim is a
+		   ::before on the wrap, so scrim clicks report the wrap itself as the target
+		   — the drawer, toggle and menu are all child elements and never match. */
+		if ( wrap.classList.contains( 'ds-menu-wrap--offcanvas' ) ) {
+			wrap.addEventListener( 'click', function ( e ) {
+				if ( e.target === wrap && wrap.classList.contains( 'ds-menu-open' ) ) { open( false ); }
+			} );
+		}
 
 		if ( ! isDrill ) {
 			// The +/- icon toggles its submenu.

--- a/modules/ds-post-loop/css/frontend.css
+++ b/modules/ds-post-loop/css/frontend.css
@@ -111,6 +111,20 @@
 .ds-commit--action .ds-people-name{font-size:1.05rem;}
 .ds-commit--action .ds-people-role{letter-spacing:.04em;}
 
+/* ---- Commitments: front-end filter bar (pills) ---- */
+.ds-commit-filter{display:flex;align-items:center;gap:16px;flex-wrap:wrap;margin-bottom:26px;}
+.ds-commit-tabs{display:inline-flex;flex-wrap:wrap;gap:8px;}
+.fl-builder-content .ds-commit-tab{appearance:none;-webkit-appearance:none;border:1px solid rgba(0,0,0,.14) !important;background:transparent !important;box-shadow:none;padding:9px 20px;border-radius:999px;font-size:.85rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;line-height:1.2;cursor:pointer;color:var(--fl-global-headings) !important;clip-path:none;-webkit-clip-path:none;transition:background-color .18s ease,color .18s ease,border-color .18s ease;}
+.fl-builder-content .ds-commit-tab:hover{border-color:var(--fl-global-accent) !important;color:var(--fl-global-accent) !important;}
+.fl-builder-content .ds-commit-tab.is-active{background:var(--fl-global-accent) !important;border-color:var(--fl-global-accent) !important;color:var(--fl-global-white) !important;}
+.fl-builder-content .ds-commit-tab:focus-visible{outline:2px solid var(--fl-global-accent);outline-offset:2px;}
+.ds-commit-count{font-size:.82rem;font-weight:600;letter-spacing:.04em;text-transform:uppercase;opacity:.65;}
+.ds-commit-none{margin:18px 0 0;opacity:.7;}
+.ds-commit--filter .ds-people-grid > *{animation:ds-commit-in .28s ease both;}
+@keyframes ds-commit-in{from{opacity:0;transform:translateY(6px);}to{opacity:1;transform:none;}}
+@media (prefers-reduced-motion:reduce){.ds-commit--filter .ds-people-grid > *{animation:none;}}
+@media (max-width:560px){.ds-commit-filter{gap:12px;}.fl-builder-content .ds-commit-tab{padding:8px 15px;font-size:.78rem;}}
+
 /* ============================ Team list (shot 5) ============================ */
 .ds-teams-list{display:flex;flex-direction:column;gap:14px;}
 .ds-team-row{display:flex;align-items:center;justify-content:space-between;gap:18px;background:var(--fl-global-light-background);border:2px solid var(--fl-global-accent);border-radius:var(--ds-radius);padding:13px 14px 13px 24px;text-decoration:none;transition:transform .2s ease,box-shadow .2s ease;}

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -411,67 +411,181 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 
 	/* ------------------------------------------------------- Commitments / Athletes */
 
+	/**
+	 * The college/school NAME for a commitment. The blueprint key is school_name,
+	 * but partner sites name the field differently (495 Lacrosse uses `university`),
+	 * which silently rendered a blank line. The developer can pin the key in the
+	 * Commitment Cards section; blank auto-detects across the known key names.
+	 */
+	private function commit_school( $id ) {
+		$key = trim( (string) ( $this->settings->commit_school_key ?? '' ) );
+		if ( '' !== $key ) { return trim( (string) $this->acf( $key, $id ) ); }
+		foreach ( array( 'school_name', 'university', 'college', 'college_name', 'school' ) as $k ) {
+			$v = trim( (string) $this->acf( $k, $id ) );
+			if ( '' !== $v ) { return $v; }
+		}
+		return '';
+	}
+
+	/** The college/school LOGO for a commitment. Same key-resolution story as commit_school(). */
+	private function commit_logo( $id ) {
+		$key = trim( (string) ( $this->settings->commit_logo_key ?? '' ) );
+		if ( '' !== $key ) { return $this->acf_image_url( $this->acf( $key, $id ) ); }
+		foreach ( array( 'school_logo', 'college_logo', 'logo' ) as $k ) {
+			$url = $this->acf_image_url( $this->acf( $k, $id ) );
+			if ( $url ) { return $url; }
+		}
+		return '';
+	}
+
+	/** True when the Commitment filter bar is switched on. */
+	private function commit_filter_on() {
+		return ( $this->settings->cf_filter ?? 'disable' ) === 'enable';
+	}
+
+	/**
+	 * The facet value(s) a commitment is tagged with, per the developer-chosen
+	 * source: a meta/ACF field ("meta:<key>", e.g. the default meta:division) or a
+	 * taxonomy ("tax:<slug>"). A comma/pipe-separated meta value counts as several.
+	 */
+	private function commit_facets( $id ) {
+		$src = trim( (string) ( $this->settings->cf_source ?? 'meta:division' ) );
+		if ( '' === $src ) { return array(); }
+		if ( 0 === strpos( $src, 'tax:' ) ) {
+			$terms = get_the_terms( $id, substr( $src, 4 ) );
+			return ( $terms && ! is_wp_error( $terms ) ) ? array_values( wp_list_pluck( $terms, 'name' ) ) : array();
+		}
+		$raw = $this->acf( 0 === strpos( $src, 'meta:' ) ? substr( $src, 5 ) : $src, $id );
+		if ( is_array( $raw ) ) { $raw = implode( ',', array_map( 'strval', $raw ) ); }
+		return array_values( array_filter( array_map( 'trim', preg_split( '/[,|]/', (string) $raw ) ) ) );
+	}
+
+	/** data-* attributes that let the front-end JS filter a card without a round trip. */
+	private function commit_data_attr( $facets ) {
+		if ( ! $this->commit_filter_on() ) { return ''; }
+		return ' data-facet="' . esc_attr( strtolower( implode( ' ', $facets ) ) ) . '"';
+	}
+
+	/**
+	 * The Commitment filter bar: an "All" pill plus one pill per facet value found
+	 * in the result set. Order follows the Tab Order field when set, else the order
+	 * the values first appear in the loop (so the developer controls it either way).
+	 */
+	private function commit_filter_bar( $all_facets, $total ) {
+		$s = $this->settings;
+		$tabs = array();
+		foreach ( $all_facets as $v ) { $tabs[ strtolower( $v ) ] = $v; }
+		if ( empty( $tabs ) ) { return false; }
+
+		$explicit = array_filter( array_map( 'trim', explode( ',', (string) ( $s->cf_order ?? '' ) ) ) );
+		if ( ! empty( $explicit ) ) {
+			$ordered = array();
+			foreach ( $explicit as $v ) { $k = strtolower( $v ); if ( isset( $tabs[ $k ] ) ) { $ordered[ $k ] = $tabs[ $k ]; unset( $tabs[ $k ] ); } }
+			$tabs = $ordered + $tabs; // anything not named in Tab Order keeps its natural place at the end
+		}
+
+		$label = trim( (string) ( $s->cf_all_label ?? '' ) ) ?: __( 'All', 'ds-toolkit' );
+		echo '<div class="ds-commit-filter">';
+		echo '<div class="ds-commit-tabs" role="group" aria-label="' . esc_attr__( 'Filter commitments', 'ds-toolkit' ) . '">';
+		echo '<button type="button" class="ds-commit-tab is-active" data-tab="" aria-pressed="true">' . esc_html( $label ) . '</button>';
+		foreach ( $tabs as $key => $text ) {
+			echo '<button type="button" class="ds-commit-tab" data-tab="' . esc_attr( $key ) . '" aria-pressed="false">' . esc_html( $text ) . '</button>';
+		}
+		echo '</div>';
+		if ( ( $s->cf_count ?? 'show' ) === 'show' ) {
+			$noun = trim( (string) ( $s->cf_count_noun ?? '' ) ) ?: __( 'commitments', 'ds-toolkit' );
+			echo '<span class="ds-commit-count" data-noun="' . esc_attr( $noun ) . '">' . (int) $total . ' ' . esc_html( $noun ) . '</span>';
+		}
+		echo '</div>';
+		return true;
+	}
+
+	/** Shared open/close for the three athlete layouts so the filter bar is wired once. */
+	private function athlete_section_open( $modifier, $q, &$rows ) {
+		$filter = $this->commit_filter_on();
+		$rows   = array();
+		if ( $filter ) {
+			foreach ( $q->posts as $p ) { foreach ( $this->commit_facets( $p->ID ) as $f ) { $rows[ strtolower( $f ) ] = $f; } }
+		}
+		$root = 'ds-news ds-people ds-people--commit ' . $modifier . ( $filter ? ' ds-commit--filter' : '' );
+		echo '<section class="' . esc_attr( $root ) . '"><div class="ds-news-wrap">';
+		$this->render_head();
+		if ( ! $q->have_posts() ) {
+			if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No Commitments published yet.', 'ds-toolkit' ) . '</p>'; }
+			echo '</div></section>';
+			return false;
+		}
+		if ( $filter ) { $this->commit_filter_bar( $rows, count( $q->posts ) ); }
+		return true;
+	}
+
+	/** Close the athlete section: grid close, the "no matches" line, wrappers, reset. */
+	private function athlete_section_close() {
+		$this->loop_close();
+		if ( $this->commit_filter_on() ) {
+			echo '<p class="ds-commit-none" hidden>' . esc_html__( 'No commitments match this filter.', 'ds-toolkit' ) . '</p>';
+		}
+		echo '</div></section>';
+		wp_reset_postdata();
+	}
+
 	/** Photo Cards — portrait photo + name + school (screenshot 2). */
 	public function render_athlete_photo() {
-		$ph = self::placeholder_image();
-		$q  = $this->run_query();
-		echo '<section class="ds-news ds-people ds-people--commit ds-commit--photo"><div class="ds-news-wrap">';
-		$this->render_head();
-		if ( ! $q->have_posts() ) { if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No Commitments published yet.', 'ds-toolkit' ) . '</p>'; } echo '</div></section>'; return; }
+		$ph   = self::placeholder_image();
+		$q    = $this->run_query();
+		$rows = array();
+		if ( ! $this->athlete_section_open( 'ds-commit--photo', $q, $rows ) ) { return; }
 		$this->loop_open( 'ds-people-grid' );
 		while ( $q->have_posts() ) { $q->the_post(); $id = get_the_ID();
 			$img    = get_the_post_thumbnail_url( $id, 'large' ) ?: $ph;
 			$name   = get_the_title( $id );
-			$school = (string) get_post_meta( $id, 'school_name', true );
-			echo '<div class="ds-commit-card">'; echo $this->card_link( $id );
+			$school = $this->commit_school( $id );
+			echo '<div class="ds-commit-card"' . $this->commit_data_attr( $this->commit_facets( $id ) ) . '>'; echo $this->card_link( $id );
 			echo '<div class="ds-people-photo"' . ( $img ? ' style="background-image:url(' . esc_url( $img ) . ')"' : '' ) . '></div>';
 			echo '<div class="ds-people-body">';
 			if ( '' !== $name )   { echo '<h3 class="ds-people-name">' . DS_Module_UI::inline( $name ) . '</h3>'; }
 			if ( '' !== $school ) { echo '<span class="ds-people-role">' . esc_html( $school ) . '</span>'; }
 			echo '</div></div>';
 		}
-		$this->loop_close(); echo '</div></section>';
-		wp_reset_postdata();
+		$this->athlete_section_close();
 	}
 
 	/** Logo Row — dark horizontal card: school logo + name + school (screenshot 3). */
 	public function render_athlete_logo() {
-		$q = $this->run_query();
-		echo '<section class="ds-news ds-people ds-people--commit ds-commit--logo"><div class="ds-news-wrap">';
-		$this->render_head();
-		if ( ! $q->have_posts() ) { if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No Commitments published yet.', 'ds-toolkit' ) . '</p>'; } echo '</div></section>'; return; }
+		$q    = $this->run_query();
+		$rows = array();
+		if ( ! $this->athlete_section_open( 'ds-commit--logo', $q, $rows ) ) { return; }
 		$this->loop_open( 'ds-people-grid' );
 		while ( $q->have_posts() ) { $q->the_post(); $id = get_the_ID();
-			$logo   = $this->acf_image_url( $this->acf( 'school_logo', $id ) );
+			$logo   = $this->commit_logo( $id );
 			$name   = get_the_title( $id );
-			$school = (string) get_post_meta( $id, 'school_name', true );
-			echo '<div class="ds-commit-row">'; echo $this->card_link( $id );
+			$school = $this->commit_school( $id );
+			echo '<div class="ds-commit-row"' . $this->commit_data_attr( $this->commit_facets( $id ) ) . '>'; echo $this->card_link( $id );
 			echo '<div class="ds-commit-row-logo">' . ( $logo ? '<img src="' . esc_url( $logo ) . '" alt="' . esc_attr( $school ) . '" loading="lazy" />' : '' ) . '</div>';
 			echo '<div class="ds-commit-row-body">';
 			if ( '' !== $name )   { echo '<h3 class="ds-people-name">' . DS_Module_UI::inline( $name ) . '</h3>'; }
 			if ( '' !== $school ) { echo '<span class="ds-people-role">' . esc_html( $school ) . '</span>'; }
 			echo '</div></div>';
 		}
-		$this->loop_close(); echo '</div></section>';
-		wp_reset_postdata();
+		$this->athlete_section_close();
 	}
 
 	/** Action Cards — action photo + logo + name + "year | school" (screenshot 4). */
 	public function render_athlete_action() {
-		$ph = self::placeholder_image();
-		$q  = $this->run_query();
-		echo '<section class="ds-news ds-people ds-people--commit ds-commit--action"><div class="ds-news-wrap">';
-		$this->render_head();
-		if ( ! $q->have_posts() ) { if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No Commitments published yet.', 'ds-toolkit' ) . '</p>'; } echo '</div></section>'; return; }
+		$ph       = self::placeholder_image();
+		$q        = $this->run_query();
+		$rows     = array();
+		$show_yr  = ( $this->settings->commit_show_year ?? 'yes' ) === 'yes';
+		if ( ! $this->athlete_section_open( 'ds-commit--action', $q, $rows ) ) { return; }
 		$this->loop_open( 'ds-people-grid' );
 		while ( $q->have_posts() ) { $q->the_post(); $id = get_the_ID();
 			$img    = get_the_post_thumbnail_url( $id, 'large' ) ?: $ph;
-			$logo   = $this->acf_image_url( $this->acf( 'school_logo', $id ) );
+			$logo   = $this->commit_logo( $id );
 			$name   = get_the_title( $id );
-			$school = (string) get_post_meta( $id, 'school_name', true );
-			$year   = (string) $this->acf( 'year', $id );
+			$school = $this->commit_school( $id );
+			$year   = $show_yr ? trim( (string) $this->acf( 'year', $id ) ) : '';
 			$meta   = trim( $year . ( ( '' !== $year && '' !== $school ) ? ' | ' : '' ) . $school );
-			echo '<div class="ds-commit-action">'; echo $this->card_link( $id );
+			echo '<div class="ds-commit-action"' . $this->commit_data_attr( $this->commit_facets( $id ) ) . '>'; echo $this->card_link( $id );
 			echo '<div class="ds-people-photo"' . ( $img ? ' style="background-image:url(' . esc_url( $img ) . ')"' : '' ) . '></div>';
 			echo '<div class="ds-commit-action-body">';
 			echo '<div class="ds-commit-action-logo">' . ( $logo ? '<img src="' . esc_url( $logo ) . '" alt="' . esc_attr( $school ) . '" loading="lazy" />' : '' ) . '</div>';
@@ -480,8 +594,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			if ( '' !== $meta ) { echo '<span class="ds-people-role">' . esc_html( $meta ) . '</span>'; }
 			echo '</div></div></div>';
 		}
-		$this->loop_close(); echo '</div></section>';
-		wp_reset_postdata();
+		$this->athlete_section_close();
 	}
 
 	/* ------------------------------------------------------------------------ Team */
@@ -1146,9 +1259,9 @@ $ds_pl_form = array(
 							'news_featured'  => array( 'sections' => array( 'header', 'query', 'query_filter', 'layout', 'featured', 'cards', 'header_style', 'typography', 'spacing', 'hover', 'card_border', 'ds_borders' ), 'tabs' => array( 'query' ) ),
 							'news_grid'      => array( 'sections' => array( 'header', 'query', 'query_filter', 'cards2', 'header_style', 'typography', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 							'staff_card'     => array( 'sections' => array( 'header', 'query', 'query_filter', 'staff_card', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
-							'athlete_photo'  => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
-							'athlete_logo'   => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
-							'athlete_action' => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
+							'athlete_photo'  => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'commit_filter_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
+							'athlete_logo'   => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'commit_filter_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
+							'athlete_action' => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'commit_filter_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 							'team_list'      => array( 'sections' => array( 'header', 'query', 'query_filter', 'team_list_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders' ), 'tabs' => array( 'query' ) ),
 							'team_card'      => array( 'sections' => array( 'header', 'query', 'query_filter', 'team_card_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 							'custom'         => array( 'sections' => array( 'header', 'query', 'query_filter', 'loopcard', 'header_style', 'typography', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
@@ -1485,6 +1598,28 @@ $ds_pl_form = array(
 					'commit_school_color'=> array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'School / Meta', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
 					'commit_name_typo'   => array( 'type' => 'typography', 'label' => __( 'Name Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-people-name' ) ),
 					'commit_meta_typo'   => array( 'type' => 'typography', 'label' => __( 'School / Meta Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-people-role' ) ),
+					'commit_show_year'   => array( 'type' => 'select', 'label' => __( 'Show Class Year (Action Card)', 'ds-toolkit' ), 'default' => 'yes', 'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No', 'ds-toolkit' ) ), 'help' => __( 'The Action Card meta line reads "year | college". Set to No for a college-only line.', 'ds-toolkit' ) ),
+					'commit_school_key'  => array( 'type' => 'text', 'label' => __( 'College Name Field', 'ds-toolkit' ), 'default' => '', 'help' => __( 'Meta/ACF key holding the college name. Blank auto-detects school_name, university, college, college_name, school.', 'ds-toolkit' ) ),
+					'commit_logo_key'    => array( 'type' => 'text', 'label' => __( 'College Logo Field', 'ds-toolkit' ), 'default' => '', 'help' => __( 'Meta/ACF key holding the college logo image. Blank auto-detects school_logo, college_logo, logo.', 'ds-toolkit' ) ),
+				),
+			),
+			// --- Front-end filter bar for the Commitment / Athlete card grids ---
+			'commit_filter_opts' => array(
+				'title'       => __( 'Filter Bar (Commitments)', 'ds-toolkit' ),
+				'description' => __( 'A pill bar above the card grid that filters the flat list in place — no page reload, no grouping. The facet is developer-chosen (a meta field like Division, or a taxonomy); every value found in the results becomes a pill, and "All" shows everything.', 'ds-toolkit' ),
+				'fields'      => array(
+					'cf_filter'     => array( 'type' => 'select', 'label' => __( 'Filter Bar', 'ds-toolkit' ), 'default' => 'disable', 'options' => array( 'disable' => __( 'Disable', 'ds-toolkit' ), 'enable' => __( 'Enable', 'ds-toolkit' ) ), 'toggle' => array( 'enable' => array( 'fields' => array( 'cf_source', 'cf_order', 'cf_all_label', 'cf_count', 'cf_count_noun', 'cf_align', 'cf_bar_bg', 'cf_tab_color', 'cf_tab_active_bg', 'cf_tab_active_color', 'cf_tab_typo' ) ) ) ),
+					'cf_source'     => array( 'type' => 'text', 'label' => __( 'Filter By', 'ds-toolkit' ), 'default' => 'meta:division', 'help' => __( 'meta:&lt;field_key&gt; for an ACF/meta field (default meta:division), or tax:&lt;taxonomy_slug&gt; for a taxonomy. A comma or pipe separated meta value tags the card with several values.', 'ds-toolkit' ) ),
+					'cf_order'      => array( 'type' => 'text', 'label' => __( 'Pill Order', 'ds-toolkit' ), 'default' => '', 'help' => __( 'Optional comma-separated order for the pills, e.g. "D1, D2, D3, MCLA". Values not listed keep their natural order at the end.', 'ds-toolkit' ) ),
+					'cf_all_label'  => array( 'type' => 'text', 'label' => __( '"All" Pill Label', 'ds-toolkit' ), 'default' => 'All' ),
+					'cf_count'      => array( 'type' => 'select', 'label' => __( 'Result Count', 'ds-toolkit' ), 'default' => 'show', 'options' => array( 'show' => __( 'Show', 'ds-toolkit' ), 'hide' => __( 'Hide', 'ds-toolkit' ) ) ),
+					'cf_count_noun' => array( 'type' => 'text', 'label' => __( 'Count Noun', 'ds-toolkit' ), 'default' => 'commitments', 'help' => __( 'Word after the number, e.g. "20 commitments".', 'ds-toolkit' ) ),
+					'cf_align'      => array( 'type' => 'select', 'label' => __( 'Alignment', 'ds-toolkit' ), 'default' => 'left', 'options' => array( 'left' => __( 'Left', 'ds-toolkit' ), 'center' => __( 'Center', 'ds-toolkit' ), 'right' => __( 'Right', 'ds-toolkit' ) ) ),
+					'cf_bar_bg'     => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Bar Background', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true, 'help' => __( 'Blank = transparent (pills sit straight on the page).', 'ds-toolkit' ) ),
+					'cf_tab_color'  => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Pill Text', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+					'cf_tab_active_bg'    => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Active Pill Background', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Blank = the global Accent colour.', 'ds-toolkit' ) ),
+					'cf_tab_active_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Active Pill Text', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+					'cf_tab_typo'   => array( 'type' => 'typography', 'label' => __( 'Pill Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-commit-tab' ) ),
 				),
 			),
 			// --- Team list options ---

--- a/modules/ds-post-loop/includes/frontend.css.php
+++ b/modules/ds-post-loop/includes/frontend.css.php
@@ -274,6 +274,7 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 		'staff_role_typo'          => '.ds-people-role',
 		'commit_name_typo'         => '.ds-people-name',
 		'commit_meta_typo'         => '.ds-people-role',
+		'cf_tab_typo'              => '.ds-commit-tab',
 		'team_name_typo'           => '.ds-team-name',
 		// Custom Program card
 		'pg_date_typo'             => '.ds-program-date',
@@ -418,6 +419,22 @@ if ( in_array( $settings->card_layout ?? '', array( 'athlete_photo', 'athlete_lo
 	echo "$node .ds-commit--photo .ds-people-photo, $node .ds-commit--action .ds-people-photo { background-size: {$cfit}; background-position: {$cpos}; }\n";
 	$cpb = $col( $settings->commit_photo_bg ?? '' );
 	if ( '' !== $cpb ) { echo "$node .ds-commit--photo .ds-people-photo, $node .ds-commit--action .ds-people-photo { background-color: {$cpb}; }\n"; }
+
+	// Filter bar (pills). Every colour is optional — blank keeps the base
+	// stylesheet's accent-driven look so it matches the site palette for free.
+	if ( ( $settings->cf_filter ?? 'disable' ) === 'enable' ) {
+		$fmapa = array( 'left' => 'flex-start', 'center' => 'center', 'right' => 'flex-end' );
+		$falign = $settings->cf_align ?? 'left';
+		echo "$node .ds-commit-filter { justify-content: " . $fmapa[ isset( $fmapa[ $falign ] ) ? $falign : 'left' ] . "; }\n";
+		$fbg = $col( $settings->cf_bar_bg ?? '' );
+		if ( '' !== $fbg ) { echo "$node .ds-commit-filter { background: {$fbg}; border-radius: var(--ds-radius); padding: 12px 16px; }\n"; }
+		$ftc = $col( $settings->cf_tab_color ?? '' );
+		if ( '' !== $ftc ) { echo "$node .ds-commit-tab { color: {$ftc} !important; }\n"; }
+		$fab = $col( $settings->cf_tab_active_bg ?? '' );
+		if ( '' !== $fab ) { echo "$node .ds-commit-tab.is-active { background: {$fab} !important; border-color: {$fab} !important; }\n$node .ds-commit-tab:hover { border-color: {$fab} !important; color: {$fab} !important; }\n$node .ds-commit-tab.is-active:hover { color: inherit !important; }\n"; }
+		$fac = $col( $settings->cf_tab_active_color ?? '' );
+		if ( '' !== $fac ) { echo "$node .ds-commit-tab.is-active, $node .ds-commit-tab.is-active:hover { color: {$fac} !important; }\n"; }
+	}
 }
 
 // ---- Team list (content_type = team) ----

--- a/modules/ds-post-loop/js/frontend.js
+++ b/modules/ds-post-loop/js/frontend.js
@@ -192,10 +192,49 @@
 		apply();
 	}
 
+	/* ------------------------------------------- Commitment card filter (pills) */
+	function initCommitFilter(root) {
+		if (root.dsCommitInit) return;
+		var bar  = root.querySelector('.ds-commit-filter');
+		var grid = root.querySelector('.ds-people-grid');
+		if (!bar || !grid) return;
+		root.dsCommitInit = true;
+
+		var cards = [].slice.call(grid.querySelectorAll('.ds-commit-card,.ds-commit-row,.ds-commit-action'));
+		var tabs  = [].slice.call(bar.querySelectorAll('.ds-commit-tab'));
+		var count = bar.querySelector('.ds-commit-count');
+		var none  = root.querySelector('.ds-commit-none');
+		var noun  = (count && count.dataset.noun) || 'commitments';
+		var facet = '';
+
+		function apply() {
+			var shown = 0;
+			cards.forEach(function (c) {
+				var ok = !facet || (' ' + (c.dataset.facet || '') + ' ').indexOf(' ' + facet + ' ') !== -1;
+				c.style.display = ok ? '' : 'none';
+				if (ok) shown++;
+			});
+			if (count) count.textContent = shown + ' ' + noun;
+			if (none) none.hidden = shown !== 0;
+		}
+
+		tabs.forEach(function (t) {
+			t.addEventListener('click', function () {
+				tabs.forEach(function (x) { x.classList.remove('is-active'); x.setAttribute('aria-pressed', 'false'); });
+				t.classList.add('is-active');
+				t.setAttribute('aria-pressed', 'true');
+				facet = t.dataset.tab || '';
+				apply();
+			});
+		});
+		apply();
+	}
+
 	function boot(rt) {
 		(rt || document).querySelectorAll('.ds-loopcar').forEach(initCarousel);
 		(rt || document).querySelectorAll('.ds-looppage').forEach(initPagination);
 		(rt || document).querySelectorAll('.ds-tourn--filter').forEach(initTournFilter);
+		(rt || document).querySelectorAll('.ds-commit--filter').forEach(initCommitFilter);
 	}
 	if (document.readyState !== 'loading') boot();
 	else document.addEventListener('DOMContentLoaded', function () { boot(); });


### PR DESCRIPTION
Closes #101.

## What

Adds a **Layout** control to the Menu module's General tab:

- **Horizontal bar** — current behavior, the default. Existing fleet sites are untouched.
- **Off-canvas sidebar** — the bar is hidden at every width, the hamburger is always visible, and it opens a docked side panel over a dimmed page.

Requested by Performance Volleyball (Roanoke), whose top bar carries seven long labels that overflow onto a second row (ClickUp 868kjkch3).

## How

The interesting part is what this change *doesn't* touch. Everything a sidebar needs — hamburger visible, bar hidden, drill drawer active — is already exactly what the module does *below* its breakpoint. So sidebar mode pins the internal `$bp` above any real viewport:

- every `max-width: $bp` rule (hamburger + drawer) now matches at all widths
- every `min-width: $bp+1` rule (desktop bar, dropdowns, mega) can never match

That turns drawer mode on everywhere without restructuring the responsive media queries every fleet site's mobile menu depends on. The panel is then re-anchored from `inset: 0` to a docked edge in a block emitted after them.

The drawer JS already decides drawer-vs-bar from whether the toggle is *displayed* (`'none' !== getComputedStyle(toggle).display`), so no behavioral JS change was needed.

## New fields (Sidebar section, sidebar layout only)

| Field | Default |
|---|---|
| Dock Side | left |
| Panel Width | 340px, capped to the viewport |
| Panel Width — Mobile | blank = full width |
| Dim Page Behind | yes |
| Dim Color | `rgba(0,0,0,.5)` |

Every colour, divider, drawer-logo, CTA and typography control in the existing **Mobile Overlay** section already drives this same drawer markup, so a sidebar is fully styleable with fields partners already know — no duplicate styling surface.

## Also fixed

The right-aligned drawer logo's clearance was measured against `window.innerWidth` rather than the drawer's own right edge. Identical for the full-screen drawer, but in a 340px sidebar it computed ~1170px of padding and pushed the logo clean out of view.

## Interaction

Opens from the hamburger; closes on the X, the scrim, or Escape. The X moves inside the panel's top-right edge when left-docked (the base rule pins it to the viewport corner, which would drop it over page content). Slides from the docked edge, cross-fade only under `prefers-reduced-motion`.

## Risk

Scoped entirely behind `layout = offcanvas`. With the default `horizontal`, no emitted CSS, markup, or JS path changes — the only code that runs for existing sites is the drawer-logo measurement fix, which is a no-op when the drawer is full-screen.
