### PR TITLE
fix: Commitment filter pills need literal fallbacks for --fl-global-* (1.9.69)

### DIFF
--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.68
+ * Version:           1.9.69
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.68' );
+define( 'DS_TOOLKIT_VERSION', '1.9.69' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-post-loop/css/frontend.css
+++ b/modules/ds-post-loop/css/frontend.css
@@ -114,10 +114,13 @@
 /* ---- Commitments: front-end filter bar (pills) ---- */
 .ds-commit-filter{display:flex;align-items:center;gap:16px;flex-wrap:wrap;margin-bottom:26px;}
 .ds-commit-tabs{display:inline-flex;flex-wrap:wrap;gap:8px;}
-.fl-builder-content .ds-commit-tab{appearance:none;-webkit-appearance:none;border:1px solid rgba(0,0,0,.14) !important;background:transparent !important;box-shadow:none;padding:9px 20px;border-radius:999px;font-size:.85rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;line-height:1.2;cursor:pointer;color:var(--fl-global-headings) !important;clip-path:none;-webkit-clip-path:none;transition:background-color .18s ease,color .18s ease,border-color .18s ease;}
-.fl-builder-content .ds-commit-tab:hover{border-color:var(--fl-global-accent) !important;color:var(--fl-global-accent) !important;}
-.fl-builder-content .ds-commit-tab.is-active{background:var(--fl-global-accent) !important;border-color:var(--fl-global-accent) !important;color:var(--fl-global-white) !important;}
-.fl-builder-content .ds-commit-tab:focus-visible{outline:2px solid var(--fl-global-accent);outline-offset:2px;}
+/* Every --fl-global-* reference carries a literal fallback: older Launchpad builds
+   (e.g. 495 Lacrosse) never emit those custom properties, and an unresolved var()
+   silently drops the whole declaration — which left the active pill unstyled. */
+.fl-builder-content .ds-commit-tab{appearance:none;-webkit-appearance:none;border:1px solid rgba(0,0,0,.14) !important;background:transparent !important;box-shadow:none;padding:9px 20px;border-radius:999px;font-size:.85rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;line-height:1.2;cursor:pointer;color:var(--fl-global-headings,#1f2937) !important;clip-path:none;-webkit-clip-path:none;transition:background-color .18s ease,color .18s ease,border-color .18s ease;}
+.fl-builder-content .ds-commit-tab:hover{border-color:var(--fl-global-accent,#1f2937) !important;color:var(--fl-global-accent,#1f2937) !important;}
+.fl-builder-content .ds-commit-tab.is-active{background:var(--fl-global-accent,#1f2937) !important;border-color:var(--fl-global-accent,#1f2937) !important;color:var(--fl-global-white,#fff) !important;}
+.fl-builder-content .ds-commit-tab:focus-visible{outline:2px solid var(--fl-global-accent,#1f2937);outline-offset:2px;}
 .ds-commit-count{font-size:.82rem;font-weight:600;letter-spacing:.04em;text-transform:uppercase;opacity:.65;}
 .ds-commit-none{margin:18px 0 0;opacity:.7;}
 .ds-commit--filter .ds-people-grid > *{animation:ds-commit-in .28s ease both;}


### PR DESCRIPTION
Follow-up to #100, found while verifying the feature live on 495lacrosse.com.

## The bug

Older Launchpad builds never emit the `--fl-global-accent` / `--fl-global-white` custom properties. CSS drops an entire declaration when its `var()` is unresolvable, so on those sites the active pill lost **both** its background and its text colour and rendered as a plain black-on-white outline — barely distinguishable from the idle pills.

Confirmed on 495lacrosse.com: `getComputedStyle(document.documentElement).getPropertyValue('--fl-global-accent')` returns an empty string, and the active pill computed to `background: rgba(0,0,0,0); color: rgb(0,0,0)`.

## The fix

Every `--fl-global-*` reference in the pill rules now carries a literal fallback. The active state is always a filled dark pill with white text at minimum, and still picks up the site accent wherever the properties exist. Sites that do emit the variables are unchanged.
