### PR TITLE
fix: Tournament layout ignores its own Taxonomy Filter (1.9.71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.71] - 2026-08-06
+### Fixed
+- **Post Loop: the Tournament layout now honours its own Taxonomy Filter.** The Tournament Cards layout declares the Taxonomy Filter section in its settings, but `render_tournament()` built its own bare `get_posts()` call (it sorts on the `event_date` ACF field rather than through `WP_Query`, so it never went through the shared query builder). The filter therefore rendered in the builder UI and did nothing: every Tournament loop on a site listed every upcoming event, whatever term was picked. The `tax_query` construction has been lifted out of `run_query()` into a shared `tax_query_args()` helper that both code paths use, so a term selection now scopes the event list. This is what lets two pages off one `event` CPT show two different sets — e.g. a Boys and a Girls tournaments page. No change for loops with no taxonomy filter set, and no change to the event-date ordering or the past-event drop.
+
 ## [1.9.70] - 2026-08-06
 ### Added
 - **Menu: Off-canvas Sidebar layout (GH #101).** A new Layout control in the Menu module's General tab offers `Horizontal bar` (unchanged default) or `Off-canvas sidebar`. In sidebar mode the horizontal bar is hidden at every width and the hamburger is always visible; clicking it slides a docked side panel in from the chosen edge over a dimmed page, for partners who want sidebar navigation instead of a top nav. New Sidebar section: Dock Side (left/right), Panel Width (default 340px, capped to the viewport), Panel Width — Mobile (blank = full width), Dim Page Behind, and Dim Color. Every colour, divider, drawer-logo, CTA, and typography control in the existing Mobile Overlay section drives the panel, so a sidebar is fully styleable with the fields partners already know. The panel slides from its docked edge (cross-fade only under `prefers-reduced-motion`), and closes on the hamburger X, the scrim, or Escape.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.70
+ * Version:           1.9.71
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.70' );
+define( 'DS_TOOLKIT_VERSION', '1.9.71' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -186,6 +186,37 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 	 * Item 0 is the featured card; the rest are loop cards.
 	 */
 	/**
+	 * The Taxonomy Filter tab as a `tax_query`, or an empty array when no filter is
+	 * configured. Terms come from the per-taxonomy suggest field `flt_<tax>`
+	 * (comma-separated term IDs), falling back to the legacy `filter_terms` text
+	 * field. Shared so EVERY layout that exposes the Taxonomy Filter section honours
+	 * it — the Tournament layout builds its own query (it sorts by the event_date
+	 * ACF field, not by WP_Query) and silently ignored the filter before this.
+	 */
+	private function tax_query_args() {
+		$s   = $this->settings;
+		$tax = trim( (string) ( $s->filter_tax ?? '' ) );
+		if ( '' === $tax || ! taxonomy_exists( $tax ) ) { return array(); }
+
+		$field_key = 'flt_' . str_replace( '-', '_', $tax );
+		$raw       = $s->$field_key ?? '';
+		if ( is_array( $raw ) ) { $raw = implode( ',', $raw ); }
+		if ( '' === trim( (string) $raw ) && isset( $s->filter_terms ) ) { $raw = (string) $s->filter_terms; }
+
+		$list = array_filter( array_map( 'trim', explode( ',', (string) $raw ) ) );
+		if ( empty( $list ) ) { return array(); }
+
+		$numeric = count( $list ) === count( array_filter( $list, 'is_numeric' ) );
+		return array(
+			array(
+				'taxonomy' => $tax,
+				'field'    => $numeric ? 'term_id' : 'slug',
+				'terms'    => $list,
+			),
+		);
+	}
+
+	/**
 	 * The ONE query: built entirely from the Query tab (Post Type + number + order +
 	 * offset + taxonomy filter). Single source of truth for WHAT the loop fetches.
 	 */
@@ -230,26 +261,8 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			if ( '' !== $mk ) { $args['meta_key'] = $mk; } else { $args['orderby'] = 'date'; }
 		}
 
-		// Taxonomy filter: terms come from the per-taxonomy suggest field flt_<tax>
-		// (comma-separated term IDs). Falls back to the legacy filter_terms text field.
-		$tax = trim( (string) ( $s->filter_tax ?? '' ) );
-		if ( '' !== $tax && taxonomy_exists( $tax ) ) {
-			$field_key = 'flt_' . str_replace( '-', '_', $tax );
-			$raw       = $s->$field_key ?? '';
-			if ( is_array( $raw ) ) { $raw = implode( ',', $raw ); }
-			if ( '' === trim( (string) $raw ) && isset( $s->filter_terms ) ) { $raw = (string) $s->filter_terms; }
-			$list = array_filter( array_map( 'trim', explode( ',', (string) $raw ) ) );
-			if ( ! empty( $list ) ) {
-				$numeric = count( $list ) === count( array_filter( $list, 'is_numeric' ) );
-				$args['tax_query'] = array(
-					array(
-						'taxonomy' => $tax,
-						'field'    => $numeric ? 'term_id' : 'slug',
-						'terms'    => $list,
-					),
-				);
-			}
-		}
+		$tq = $this->tax_query_args();
+		if ( ! empty( $tq ) ) { $args['tax_query'] = $tq; }
 
 		// Date-range filter (GH #46). Bounds parse via strtotime, so absolute
 		// dates (2026-01-01) and relative windows (-30 days) both work; only
@@ -1030,7 +1043,13 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		$ptype = preg_replace( '/[^a-z0-9_-]/', '', (string) ( $s->post_type ?? 'event' ) );
 		if ( '' === $ptype || 'post' === $ptype ) { $ptype = 'event'; }
 		$limit = (int) ( $s->posts_per_page ?? 6 ); if ( $limit <= 0 ) { $limit = 6; }
-		$posts = get_posts( array( 'post_type' => $ptype, 'post_status' => 'publish', 'posts_per_page' => 200, 'orderby' => 'date', 'order' => 'DESC' ) );
+		// Pull wide (ordering + the past-event drop happen below, on event_date), but
+		// still scope to the Taxonomy Filter so two pages can list two different sets
+		// of events (e.g. a Boys and a Girls tournaments page off one CPT).
+		$q_args = array( 'post_type' => $ptype, 'post_status' => 'publish', 'posts_per_page' => 200, 'orderby' => 'date', 'order' => 'DESC' );
+		$tq     = $this->tax_query_args();
+		if ( ! empty( $tq ) ) { $q_args['tax_query'] = $tq; }
+		$posts = get_posts( $q_args );
 		$today = strtotime( 'today' );
 		$items = array();
 		foreach ( $posts as $p ) {


### PR DESCRIPTION
## The bug

The Post Loop **Tournament Cards** layout declares the Taxonomy Filter section in its settings:

```php
'tournament' => array( 'sections' => array( 'header', 'query', 'query_filter', ... ) ),
```

…but `render_tournament()` never goes through `run_query()`. It orders on the `event_date` ACF field rather than through `WP_Query`, so it built its own bare call:

```php
$posts = get_posts( array( 'post_type' => $ptype, 'post_status' => 'publish', 'posts_per_page' => 200, 'orderby' => 'date', 'order' => 'DESC' ) );
```

No `tax_query`. The Taxonomy Filter control renders in the builder UI, a partner picks a term, and nothing happens: every Tournament loop on the site lists every upcoming event. Two pages driven by one `event` CPT cannot show two different lists.

Found while building the Boys and Girls Tournaments pages on the NEO Lax install (`northeastohio`), where each page has to list only its own events.

## The fix

Lift the `tax_query` construction out of `run_query()` into a shared `tax_query_args()` helper, and call it from both paths. Pure extraction: the term-parsing behaviour (per-taxonomy `flt_<tax>` suggest field, legacy `filter_terms` fallback, numeric term IDs vs slugs) is byte-for-byte what `run_query()` already did.

## Blast radius

- Loops with **no** taxonomy filter set: no change (the helper returns an empty array).
- Non-Tournament layouts: no change (same code, same call site, now via the helper).
- Tournament loops **with** a filter set: they now filter, which is what the control always claimed to do. A site that set a term and silently got everything will start showing only that term's events.
- Event-date ordering and the past-event drop are untouched.

## Test plan

- [x] `php -l` clean on both changed files
- [ ] Tournament loop, no filter, unchanged full list
- [ ] Tournament loop, `event-category` = Boys, only Boys events
- [ ] Two loops on two pages, different terms, different lists
- [ ] News / Program / Sponsor layouts still filter as before
