### PR TITLE
fix: restore released ds-post-loop code, renumber Menu sidebar to 1.9.70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
-## [1.9.68] - 2026-08-06
+## [1.9.70] - 2026-08-06
 ### Added
 - **Menu: Off-canvas Sidebar layout (GH #101).** A new Layout control in the Menu module's General tab offers `Horizontal bar` (unchanged default) or `Off-canvas sidebar`. In sidebar mode the horizontal bar is hidden at every width and the hamburger is always visible; clicking it slides a docked side panel in from the chosen edge over a dimmed page, for partners who want sidebar navigation instead of a top nav. New Sidebar section: Dock Side (left/right), Panel Width (default 340px, capped to the viewport), Panel Width — Mobile (blank = full width), Dim Page Behind, and Dim Color. Every colour, divider, drawer-logo, CTA, and typography control in the existing Mobile Overlay section drives the panel, so a sidebar is fully styleable with the fields partners already know. The panel slides from its docked edge (cross-fade only under `prefers-reduced-motion`), and closes on the hamburger X, the scrim, or Escape.
 

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.69
+ * Version:           1.9.70
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.69' );
+define( 'DS_TOOLKIT_VERSION', '1.9.70' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-post-loop/css/frontend.css
+++ b/modules/ds-post-loop/css/frontend.css
@@ -111,6 +111,23 @@
 .ds-commit--action .ds-people-name{font-size:1.05rem;}
 .ds-commit--action .ds-people-role{letter-spacing:.04em;}
 
+/* ---- Commitments: front-end filter bar (pills) ---- */
+.ds-commit-filter{display:flex;align-items:center;gap:16px;flex-wrap:wrap;margin-bottom:26px;}
+.ds-commit-tabs{display:inline-flex;flex-wrap:wrap;gap:8px;}
+/* Every --fl-global-* reference carries a literal fallback: older Launchpad builds
+   (e.g. 495 Lacrosse) never emit those custom properties, and an unresolved var()
+   silently drops the whole declaration — which left the active pill unstyled. */
+.fl-builder-content .ds-commit-tab{appearance:none;-webkit-appearance:none;border:1px solid rgba(0,0,0,.14) !important;background:transparent !important;box-shadow:none;padding:9px 20px;border-radius:999px;font-size:.85rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;line-height:1.2;cursor:pointer;color:var(--fl-global-headings,#1f2937) !important;clip-path:none;-webkit-clip-path:none;transition:background-color .18s ease,color .18s ease,border-color .18s ease;}
+.fl-builder-content .ds-commit-tab:hover{border-color:var(--fl-global-accent,#1f2937) !important;color:var(--fl-global-accent,#1f2937) !important;}
+.fl-builder-content .ds-commit-tab.is-active{background:var(--fl-global-accent,#1f2937) !important;border-color:var(--fl-global-accent,#1f2937) !important;color:var(--fl-global-white,#fff) !important;}
+.fl-builder-content .ds-commit-tab:focus-visible{outline:2px solid var(--fl-global-accent,#1f2937);outline-offset:2px;}
+.ds-commit-count{font-size:.82rem;font-weight:600;letter-spacing:.04em;text-transform:uppercase;opacity:.65;}
+.ds-commit-none{margin:18px 0 0;opacity:.7;}
+.ds-commit--filter .ds-people-grid > *{animation:ds-commit-in .28s ease both;}
+@keyframes ds-commit-in{from{opacity:0;transform:translateY(6px);}to{opacity:1;transform:none;}}
+@media (prefers-reduced-motion:reduce){.ds-commit--filter .ds-people-grid > *{animation:none;}}
+@media (max-width:560px){.ds-commit-filter{gap:12px;}.fl-builder-content .ds-commit-tab{padding:8px 15px;font-size:.78rem;}}
+
 /* ============================ Team list (shot 5) ============================ */
 .ds-teams-list{display:flex;flex-direction:column;gap:14px;}
 .ds-team-row{display:flex;align-items:center;justify-content:space-between;gap:18px;background:var(--fl-global-light-background);border:2px solid var(--fl-global-accent);border-radius:var(--ds-radius);padding:13px 14px 13px 24px;text-decoration:none;transition:transform .2s ease,box-shadow .2s ease;}

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -411,67 +411,181 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 
 	/* ------------------------------------------------------- Commitments / Athletes */
 
+	/**
+	 * The college/school NAME for a commitment. The blueprint key is school_name,
+	 * but partner sites name the field differently (495 Lacrosse uses `university`),
+	 * which silently rendered a blank line. The developer can pin the key in the
+	 * Commitment Cards section; blank auto-detects across the known key names.
+	 */
+	private function commit_school( $id ) {
+		$key = trim( (string) ( $this->settings->commit_school_key ?? '' ) );
+		if ( '' !== $key ) { return trim( (string) $this->acf( $key, $id ) ); }
+		foreach ( array( 'school_name', 'university', 'college', 'college_name', 'school' ) as $k ) {
+			$v = trim( (string) $this->acf( $k, $id ) );
+			if ( '' !== $v ) { return $v; }
+		}
+		return '';
+	}
+
+	/** The college/school LOGO for a commitment. Same key-resolution story as commit_school(). */
+	private function commit_logo( $id ) {
+		$key = trim( (string) ( $this->settings->commit_logo_key ?? '' ) );
+		if ( '' !== $key ) { return $this->acf_image_url( $this->acf( $key, $id ) ); }
+		foreach ( array( 'school_logo', 'college_logo', 'logo' ) as $k ) {
+			$url = $this->acf_image_url( $this->acf( $k, $id ) );
+			if ( $url ) { return $url; }
+		}
+		return '';
+	}
+
+	/** True when the Commitment filter bar is switched on. */
+	private function commit_filter_on() {
+		return ( $this->settings->cf_filter ?? 'disable' ) === 'enable';
+	}
+
+	/**
+	 * The facet value(s) a commitment is tagged with, per the developer-chosen
+	 * source: a meta/ACF field ("meta:<key>", e.g. the default meta:division) or a
+	 * taxonomy ("tax:<slug>"). A comma/pipe-separated meta value counts as several.
+	 */
+	private function commit_facets( $id ) {
+		$src = trim( (string) ( $this->settings->cf_source ?? 'meta:division' ) );
+		if ( '' === $src ) { return array(); }
+		if ( 0 === strpos( $src, 'tax:' ) ) {
+			$terms = get_the_terms( $id, substr( $src, 4 ) );
+			return ( $terms && ! is_wp_error( $terms ) ) ? array_values( wp_list_pluck( $terms, 'name' ) ) : array();
+		}
+		$raw = $this->acf( 0 === strpos( $src, 'meta:' ) ? substr( $src, 5 ) : $src, $id );
+		if ( is_array( $raw ) ) { $raw = implode( ',', array_map( 'strval', $raw ) ); }
+		return array_values( array_filter( array_map( 'trim', preg_split( '/[,|]/', (string) $raw ) ) ) );
+	}
+
+	/** data-* attributes that let the front-end JS filter a card without a round trip. */
+	private function commit_data_attr( $facets ) {
+		if ( ! $this->commit_filter_on() ) { return ''; }
+		return ' data-facet="' . esc_attr( strtolower( implode( ' ', $facets ) ) ) . '"';
+	}
+
+	/**
+	 * The Commitment filter bar: an "All" pill plus one pill per facet value found
+	 * in the result set. Order follows the Tab Order field when set, else the order
+	 * the values first appear in the loop (so the developer controls it either way).
+	 */
+	private function commit_filter_bar( $all_facets, $total ) {
+		$s = $this->settings;
+		$tabs = array();
+		foreach ( $all_facets as $v ) { $tabs[ strtolower( $v ) ] = $v; }
+		if ( empty( $tabs ) ) { return false; }
+
+		$explicit = array_filter( array_map( 'trim', explode( ',', (string) ( $s->cf_order ?? '' ) ) ) );
+		if ( ! empty( $explicit ) ) {
+			$ordered = array();
+			foreach ( $explicit as $v ) { $k = strtolower( $v ); if ( isset( $tabs[ $k ] ) ) { $ordered[ $k ] = $tabs[ $k ]; unset( $tabs[ $k ] ); } }
+			$tabs = $ordered + $tabs; // anything not named in Tab Order keeps its natural place at the end
+		}
+
+		$label = trim( (string) ( $s->cf_all_label ?? '' ) ) ?: __( 'All', 'ds-toolkit' );
+		echo '<div class="ds-commit-filter">';
+		echo '<div class="ds-commit-tabs" role="group" aria-label="' . esc_attr__( 'Filter commitments', 'ds-toolkit' ) . '">';
+		echo '<button type="button" class="ds-commit-tab is-active" data-tab="" aria-pressed="true">' . esc_html( $label ) . '</button>';
+		foreach ( $tabs as $key => $text ) {
+			echo '<button type="button" class="ds-commit-tab" data-tab="' . esc_attr( $key ) . '" aria-pressed="false">' . esc_html( $text ) . '</button>';
+		}
+		echo '</div>';
+		if ( ( $s->cf_count ?? 'show' ) === 'show' ) {
+			$noun = trim( (string) ( $s->cf_count_noun ?? '' ) ) ?: __( 'commitments', 'ds-toolkit' );
+			echo '<span class="ds-commit-count" data-noun="' . esc_attr( $noun ) . '">' . (int) $total . ' ' . esc_html( $noun ) . '</span>';
+		}
+		echo '</div>';
+		return true;
+	}
+
+	/** Shared open/close for the three athlete layouts so the filter bar is wired once. */
+	private function athlete_section_open( $modifier, $q, &$rows ) {
+		$filter = $this->commit_filter_on();
+		$rows   = array();
+		if ( $filter ) {
+			foreach ( $q->posts as $p ) { foreach ( $this->commit_facets( $p->ID ) as $f ) { $rows[ strtolower( $f ) ] = $f; } }
+		}
+		$root = 'ds-news ds-people ds-people--commit ' . $modifier . ( $filter ? ' ds-commit--filter' : '' );
+		echo '<section class="' . esc_attr( $root ) . '"><div class="ds-news-wrap">';
+		$this->render_head();
+		if ( ! $q->have_posts() ) {
+			if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No Commitments published yet.', 'ds-toolkit' ) . '</p>'; }
+			echo '</div></section>';
+			return false;
+		}
+		if ( $filter ) { $this->commit_filter_bar( $rows, count( $q->posts ) ); }
+		return true;
+	}
+
+	/** Close the athlete section: grid close, the "no matches" line, wrappers, reset. */
+	private function athlete_section_close() {
+		$this->loop_close();
+		if ( $this->commit_filter_on() ) {
+			echo '<p class="ds-commit-none" hidden>' . esc_html__( 'No commitments match this filter.', 'ds-toolkit' ) . '</p>';
+		}
+		echo '</div></section>';
+		wp_reset_postdata();
+	}
+
 	/** Photo Cards — portrait photo + name + school (screenshot 2). */
 	public function render_athlete_photo() {
-		$ph = self::placeholder_image();
-		$q  = $this->run_query();
-		echo '<section class="ds-news ds-people ds-people--commit ds-commit--photo"><div class="ds-news-wrap">';
-		$this->render_head();
-		if ( ! $q->have_posts() ) { if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No Commitments published yet.', 'ds-toolkit' ) . '</p>'; } echo '</div></section>'; return; }
+		$ph   = self::placeholder_image();
+		$q    = $this->run_query();
+		$rows = array();
+		if ( ! $this->athlete_section_open( 'ds-commit--photo', $q, $rows ) ) { return; }
 		$this->loop_open( 'ds-people-grid' );
 		while ( $q->have_posts() ) { $q->the_post(); $id = get_the_ID();
 			$img    = get_the_post_thumbnail_url( $id, 'large' ) ?: $ph;
 			$name   = get_the_title( $id );
-			$school = (string) get_post_meta( $id, 'school_name', true );
-			echo '<div class="ds-commit-card">'; echo $this->card_link( $id );
+			$school = $this->commit_school( $id );
+			echo '<div class="ds-commit-card"' . $this->commit_data_attr( $this->commit_facets( $id ) ) . '>'; echo $this->card_link( $id );
 			echo '<div class="ds-people-photo"' . ( $img ? ' style="background-image:url(' . esc_url( $img ) . ')"' : '' ) . '></div>';
 			echo '<div class="ds-people-body">';
 			if ( '' !== $name )   { echo '<h3 class="ds-people-name">' . DS_Module_UI::inline( $name ) . '</h3>'; }
 			if ( '' !== $school ) { echo '<span class="ds-people-role">' . esc_html( $school ) . '</span>'; }
 			echo '</div></div>';
 		}
-		$this->loop_close(); echo '</div></section>';
-		wp_reset_postdata();
+		$this->athlete_section_close();
 	}
 
 	/** Logo Row — dark horizontal card: school logo + name + school (screenshot 3). */
 	public function render_athlete_logo() {
-		$q = $this->run_query();
-		echo '<section class="ds-news ds-people ds-people--commit ds-commit--logo"><div class="ds-news-wrap">';
-		$this->render_head();
-		if ( ! $q->have_posts() ) { if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No Commitments published yet.', 'ds-toolkit' ) . '</p>'; } echo '</div></section>'; return; }
+		$q    = $this->run_query();
+		$rows = array();
+		if ( ! $this->athlete_section_open( 'ds-commit--logo', $q, $rows ) ) { return; }
 		$this->loop_open( 'ds-people-grid' );
 		while ( $q->have_posts() ) { $q->the_post(); $id = get_the_ID();
-			$logo   = $this->acf_image_url( $this->acf( 'school_logo', $id ) );
+			$logo   = $this->commit_logo( $id );
 			$name   = get_the_title( $id );
-			$school = (string) get_post_meta( $id, 'school_name', true );
-			echo '<div class="ds-commit-row">'; echo $this->card_link( $id );
+			$school = $this->commit_school( $id );
+			echo '<div class="ds-commit-row"' . $this->commit_data_attr( $this->commit_facets( $id ) ) . '>'; echo $this->card_link( $id );
 			echo '<div class="ds-commit-row-logo">' . ( $logo ? '<img src="' . esc_url( $logo ) . '" alt="' . esc_attr( $school ) . '" loading="lazy" />' : '' ) . '</div>';
 			echo '<div class="ds-commit-row-body">';
 			if ( '' !== $name )   { echo '<h3 class="ds-people-name">' . DS_Module_UI::inline( $name ) . '</h3>'; }
 			if ( '' !== $school ) { echo '<span class="ds-people-role">' . esc_html( $school ) . '</span>'; }
 			echo '</div></div>';
 		}
-		$this->loop_close(); echo '</div></section>';
-		wp_reset_postdata();
+		$this->athlete_section_close();
 	}
 
 	/** Action Cards — action photo + logo + name + "year | school" (screenshot 4). */
 	public function render_athlete_action() {
-		$ph = self::placeholder_image();
-		$q  = $this->run_query();
-		echo '<section class="ds-news ds-people ds-people--commit ds-commit--action"><div class="ds-news-wrap">';
-		$this->render_head();
-		if ( ! $q->have_posts() ) { if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No Commitments published yet.', 'ds-toolkit' ) . '</p>'; } echo '</div></section>'; return; }
+		$ph       = self::placeholder_image();
+		$q        = $this->run_query();
+		$rows     = array();
+		$show_yr  = ( $this->settings->commit_show_year ?? 'yes' ) === 'yes';
+		if ( ! $this->athlete_section_open( 'ds-commit--action', $q, $rows ) ) { return; }
 		$this->loop_open( 'ds-people-grid' );
 		while ( $q->have_posts() ) { $q->the_post(); $id = get_the_ID();
 			$img    = get_the_post_thumbnail_url( $id, 'large' ) ?: $ph;
-			$logo   = $this->acf_image_url( $this->acf( 'school_logo', $id ) );
+			$logo   = $this->commit_logo( $id );
 			$name   = get_the_title( $id );
-			$school = (string) get_post_meta( $id, 'school_name', true );
-			$year   = (string) $this->acf( 'year', $id );
+			$school = $this->commit_school( $id );
+			$year   = $show_yr ? trim( (string) $this->acf( 'year', $id ) ) : '';
 			$meta   = trim( $year . ( ( '' !== $year && '' !== $school ) ? ' | ' : '' ) . $school );
-			echo '<div class="ds-commit-action">'; echo $this->card_link( $id );
+			echo '<div class="ds-commit-action"' . $this->commit_data_attr( $this->commit_facets( $id ) ) . '>'; echo $this->card_link( $id );
 			echo '<div class="ds-people-photo"' . ( $img ? ' style="background-image:url(' . esc_url( $img ) . ')"' : '' ) . '></div>';
 			echo '<div class="ds-commit-action-body">';
 			echo '<div class="ds-commit-action-logo">' . ( $logo ? '<img src="' . esc_url( $logo ) . '" alt="' . esc_attr( $school ) . '" loading="lazy" />' : '' ) . '</div>';
@@ -480,8 +594,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			if ( '' !== $meta ) { echo '<span class="ds-people-role">' . esc_html( $meta ) . '</span>'; }
 			echo '</div></div></div>';
 		}
-		$this->loop_close(); echo '</div></section>';
-		wp_reset_postdata();
+		$this->athlete_section_close();
 	}
 
 	/* ------------------------------------------------------------------------ Team */
@@ -1146,9 +1259,9 @@ $ds_pl_form = array(
 							'news_featured'  => array( 'sections' => array( 'header', 'query', 'query_filter', 'layout', 'featured', 'cards', 'header_style', 'typography', 'spacing', 'hover', 'card_border', 'ds_borders' ), 'tabs' => array( 'query' ) ),
 							'news_grid'      => array( 'sections' => array( 'header', 'query', 'query_filter', 'cards2', 'header_style', 'typography', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 							'staff_card'     => array( 'sections' => array( 'header', 'query', 'query_filter', 'staff_card', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
-							'athlete_photo'  => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
-							'athlete_logo'   => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
-							'athlete_action' => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
+							'athlete_photo'  => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'commit_filter_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
+							'athlete_logo'   => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'commit_filter_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
+							'athlete_action' => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'commit_filter_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 							'team_list'      => array( 'sections' => array( 'header', 'query', 'query_filter', 'team_list_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders' ), 'tabs' => array( 'query' ) ),
 							'team_card'      => array( 'sections' => array( 'header', 'query', 'query_filter', 'team_card_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 							'custom'         => array( 'sections' => array( 'header', 'query', 'query_filter', 'loopcard', 'header_style', 'typography', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
@@ -1485,6 +1598,28 @@ $ds_pl_form = array(
 					'commit_school_color'=> array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'School / Meta', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
 					'commit_name_typo'   => array( 'type' => 'typography', 'label' => __( 'Name Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-people-name' ) ),
 					'commit_meta_typo'   => array( 'type' => 'typography', 'label' => __( 'School / Meta Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-people-role' ) ),
+					'commit_show_year'   => array( 'type' => 'select', 'label' => __( 'Show Class Year (Action Card)', 'ds-toolkit' ), 'default' => 'yes', 'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No', 'ds-toolkit' ) ), 'help' => __( 'The Action Card meta line reads "year | college". Set to No for a college-only line.', 'ds-toolkit' ) ),
+					'commit_school_key'  => array( 'type' => 'text', 'label' => __( 'College Name Field', 'ds-toolkit' ), 'default' => '', 'help' => __( 'Meta/ACF key holding the college name. Blank auto-detects school_name, university, college, college_name, school.', 'ds-toolkit' ) ),
+					'commit_logo_key'    => array( 'type' => 'text', 'label' => __( 'College Logo Field', 'ds-toolkit' ), 'default' => '', 'help' => __( 'Meta/ACF key holding the college logo image. Blank auto-detects school_logo, college_logo, logo.', 'ds-toolkit' ) ),
+				),
+			),
+			// --- Front-end filter bar for the Commitment / Athlete card grids ---
+			'commit_filter_opts' => array(
+				'title'       => __( 'Filter Bar (Commitments)', 'ds-toolkit' ),
+				'description' => __( 'A pill bar above the card grid that filters the flat list in place — no page reload, no grouping. The facet is developer-chosen (a meta field like Division, or a taxonomy); every value found in the results becomes a pill, and "All" shows everything.', 'ds-toolkit' ),
+				'fields'      => array(
+					'cf_filter'     => array( 'type' => 'select', 'label' => __( 'Filter Bar', 'ds-toolkit' ), 'default' => 'disable', 'options' => array( 'disable' => __( 'Disable', 'ds-toolkit' ), 'enable' => __( 'Enable', 'ds-toolkit' ) ), 'toggle' => array( 'enable' => array( 'fields' => array( 'cf_source', 'cf_order', 'cf_all_label', 'cf_count', 'cf_count_noun', 'cf_align', 'cf_bar_bg', 'cf_tab_color', 'cf_tab_active_bg', 'cf_tab_active_color', 'cf_tab_typo' ) ) ) ),
+					'cf_source'     => array( 'type' => 'text', 'label' => __( 'Filter By', 'ds-toolkit' ), 'default' => 'meta:division', 'help' => __( 'meta:&lt;field_key&gt; for an ACF/meta field (default meta:division), or tax:&lt;taxonomy_slug&gt; for a taxonomy. A comma or pipe separated meta value tags the card with several values.', 'ds-toolkit' ) ),
+					'cf_order'      => array( 'type' => 'text', 'label' => __( 'Pill Order', 'ds-toolkit' ), 'default' => '', 'help' => __( 'Optional comma-separated order for the pills, e.g. "D1, D2, D3, MCLA". Values not listed keep their natural order at the end.', 'ds-toolkit' ) ),
+					'cf_all_label'  => array( 'type' => 'text', 'label' => __( '"All" Pill Label', 'ds-toolkit' ), 'default' => 'All' ),
+					'cf_count'      => array( 'type' => 'select', 'label' => __( 'Result Count', 'ds-toolkit' ), 'default' => 'show', 'options' => array( 'show' => __( 'Show', 'ds-toolkit' ), 'hide' => __( 'Hide', 'ds-toolkit' ) ) ),
+					'cf_count_noun' => array( 'type' => 'text', 'label' => __( 'Count Noun', 'ds-toolkit' ), 'default' => 'commitments', 'help' => __( 'Word after the number, e.g. "20 commitments".', 'ds-toolkit' ) ),
+					'cf_align'      => array( 'type' => 'select', 'label' => __( 'Alignment', 'ds-toolkit' ), 'default' => 'left', 'options' => array( 'left' => __( 'Left', 'ds-toolkit' ), 'center' => __( 'Center', 'ds-toolkit' ), 'right' => __( 'Right', 'ds-toolkit' ) ) ),
+					'cf_bar_bg'     => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Bar Background', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true, 'help' => __( 'Blank = transparent (pills sit straight on the page).', 'ds-toolkit' ) ),
+					'cf_tab_color'  => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Pill Text', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+					'cf_tab_active_bg'    => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Active Pill Background', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Blank = the global Accent colour.', 'ds-toolkit' ) ),
+					'cf_tab_active_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Active Pill Text', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+					'cf_tab_typo'   => array( 'type' => 'typography', 'label' => __( 'Pill Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-commit-tab' ) ),
 				),
 			),
 			// --- Team list options ---

--- a/modules/ds-post-loop/includes/frontend.css.php
+++ b/modules/ds-post-loop/includes/frontend.css.php
@@ -274,6 +274,7 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 		'staff_role_typo'          => '.ds-people-role',
 		'commit_name_typo'         => '.ds-people-name',
 		'commit_meta_typo'         => '.ds-people-role',
+		'cf_tab_typo'              => '.ds-commit-tab',
 		'team_name_typo'           => '.ds-team-name',
 		// Custom Program card
 		'pg_date_typo'             => '.ds-program-date',
@@ -418,6 +419,22 @@ if ( in_array( $settings->card_layout ?? '', array( 'athlete_photo', 'athlete_lo
 	echo "$node .ds-commit--photo .ds-people-photo, $node .ds-commit--action .ds-people-photo { background-size: {$cfit}; background-position: {$cpos}; }\n";
 	$cpb = $col( $settings->commit_photo_bg ?? '' );
 	if ( '' !== $cpb ) { echo "$node .ds-commit--photo .ds-people-photo, $node .ds-commit--action .ds-people-photo { background-color: {$cpb}; }\n"; }
+
+	// Filter bar (pills). Every colour is optional — blank keeps the base
+	// stylesheet's accent-driven look so it matches the site palette for free.
+	if ( ( $settings->cf_filter ?? 'disable' ) === 'enable' ) {
+		$fmapa = array( 'left' => 'flex-start', 'center' => 'center', 'right' => 'flex-end' );
+		$falign = $settings->cf_align ?? 'left';
+		echo "$node .ds-commit-filter { justify-content: " . $fmapa[ isset( $fmapa[ $falign ] ) ? $falign : 'left' ] . "; }\n";
+		$fbg = $col( $settings->cf_bar_bg ?? '' );
+		if ( '' !== $fbg ) { echo "$node .ds-commit-filter { background: {$fbg}; border-radius: var(--ds-radius); padding: 12px 16px; }\n"; }
+		$ftc = $col( $settings->cf_tab_color ?? '' );
+		if ( '' !== $ftc ) { echo "$node .ds-commit-tab { color: {$ftc} !important; }\n"; }
+		$fab = $col( $settings->cf_tab_active_bg ?? '' );
+		if ( '' !== $fab ) { echo "$node .ds-commit-tab.is-active { background: {$fab} !important; border-color: {$fab} !important; }\n$node .ds-commit-tab:hover { border-color: {$fab} !important; color: {$fab} !important; }\n$node .ds-commit-tab.is-active:hover { color: inherit !important; }\n"; }
+		$fac = $col( $settings->cf_tab_active_color ?? '' );
+		if ( '' !== $fac ) { echo "$node .ds-commit-tab.is-active, $node .ds-commit-tab.is-active:hover { color: {$fac} !important; }\n"; }
+	}
 }
 
 // ---- Team list (content_type = team) ----

--- a/modules/ds-post-loop/js/frontend.js
+++ b/modules/ds-post-loop/js/frontend.js
@@ -192,10 +192,49 @@
 		apply();
 	}
 
+	/* ------------------------------------------- Commitment card filter (pills) */
+	function initCommitFilter(root) {
+		if (root.dsCommitInit) return;
+		var bar  = root.querySelector('.ds-commit-filter');
+		var grid = root.querySelector('.ds-people-grid');
+		if (!bar || !grid) return;
+		root.dsCommitInit = true;
+
+		var cards = [].slice.call(grid.querySelectorAll('.ds-commit-card,.ds-commit-row,.ds-commit-action'));
+		var tabs  = [].slice.call(bar.querySelectorAll('.ds-commit-tab'));
+		var count = bar.querySelector('.ds-commit-count');
+		var none  = root.querySelector('.ds-commit-none');
+		var noun  = (count && count.dataset.noun) || 'commitments';
+		var facet = '';
+
+		function apply() {
+			var shown = 0;
+			cards.forEach(function (c) {
+				var ok = !facet || (' ' + (c.dataset.facet || '') + ' ').indexOf(' ' + facet + ' ') !== -1;
+				c.style.display = ok ? '' : 'none';
+				if (ok) shown++;
+			});
+			if (count) count.textContent = shown + ' ' + noun;
+			if (none) none.hidden = shown !== 0;
+		}
+
+		tabs.forEach(function (t) {
+			t.addEventListener('click', function () {
+				tabs.forEach(function (x) { x.classList.remove('is-active'); x.setAttribute('aria-pressed', 'false'); });
+				t.classList.add('is-active');
+				t.setAttribute('aria-pressed', 'true');
+				facet = t.dataset.tab || '';
+				apply();
+			});
+		});
+		apply();
+	}
+
 	function boot(rt) {
 		(rt || document).querySelectorAll('.ds-loopcar').forEach(initCarousel);
 		(rt || document).querySelectorAll('.ds-looppage').forEach(initPagination);
 		(rt || document).querySelectorAll('.ds-tourn--filter').forEach(initTournFilter);
+		(rt || document).querySelectorAll('.ds-commit--filter').forEach(initCommitFilter);
 	}
 	if (document.readyState !== 'loading') boot();
 	else document.addEventListener('DOMContentLoaded', function () { boot(); });


### PR DESCRIPTION
## What went wrong

Two sessions worked this checkout at the same time. The **Commitment filter bar** was being written into the shared working tree while the Menu sidebar branch was cut, so `git add -A` on that branch swept a copy of it into PR #102. PR #100 then merged the same work properly and shipped it as **v1.9.68**; PR #103 shipped a follow-up fix as **v1.9.69**.

Reading only PR #102's file list, PR #105 mistook that copy for stale contamination and reverted `modules/ds-post-loop/` to its 1.9.67 state. That also reverted #100 and #103 — **code already released in v1.9.68 and v1.9.69**. Left as-is, the next release cut from `main` would have shipped the Commitment filter bar back *out* of every fleet site that has it.

## What this does

- Restores `modules/ds-post-loop/` **byte-identical to `f6a97d9`**, the released v1.9.69 tree. Verified: `git diff f6a97d9 -- modules/ds-post-loop/` is empty.
- Renumbers the Menu off-canvas sidebar changelog entry from `1.9.68` to `1.9.70`, since 1.9.68 and 1.9.69 are taken by the released Commitment work.
- Bumps `DS_TOOLKIT_VERSION` to `1.9.70` in both places.

The Menu sidebar code itself was never affected — it has been on `main` since #102 and is untouched here.

## Heads up for the Commitment filter author

PR #100 and #103 shipped **without CHANGELOG entries**, so v1.9.68 and v1.9.69 have GitHub release notes but no changelog record. Not guessed at here — worth adding a retroactive entry describing what those two versions contain.
