### PR TITLE
fix: sidebar close button overhangs the panel when it has a label (1.9.72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.72] - 2026-08-07
+### Fixed
+- **Menu: the sidebar's close button no longer overhangs the panel.** With a Hamburger Label set (e.g. "MENU"/"CLOSE"), the open-state close button was positioned by offsetting `left` by a fixed icon width, so the labelled button ran past the panel's right edge and sat on top of the page behind it. Its right edge is now anchored to the panel's right edge, which is correct for any label width, any panel width, and any translation. The full-width phone panel resolves to the same 18px inset through the same rule.
+
 ## [1.9.71] - 2026-08-06
 ### Fixed
 - **Post Loop: the Tournament layout now honours its own Taxonomy Filter.** The Tournament Cards layout declares the Taxonomy Filter section in its settings, but `render_tournament()` built its own bare `get_posts()` call (it sorts on the `event_date` ACF field rather than through `WP_Query`, so it never went through the shared query builder). The filter therefore rendered in the builder UI and did nothing: every Tournament loop on a site listed every upcoming event, whatever term was picked. The `tax_query` construction has been lifted out of `run_query()` into a shared `tax_query_args()` helper that both code paths use, so a term selection now scopes the event list. This is what lets two pages off one `event` CPT show two different sets — e.g. a Boys and a Girls tournaments page. No change for loops with no taxonomy filter set, and no change to the event-date ordering or the past-event drop.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.71
+ * Version:           1.9.72
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.71' );
+define( 'DS_TOOLKIT_VERSION', '1.9.72' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/includes/frontend.css.php
+++ b/modules/ds-menu/includes/frontend.css.php
@@ -593,14 +593,21 @@ if ( $is_oc ) {
 
 	/* Close (X) belongs to the panel, not the viewport corner. The base rule pins
 	   it top/right of the screen, which for a LEFT-docked panel would drop it on
-	   top of the page content instead of the menu. Park it inside the panel edge. */
+	   top of the page content instead of the menu.
+	 *
+	 * Anchor its RIGHT edge to the panel's right edge — never its left edge by a
+	 * guessed width. The toggle is as wide as its Hamburger Label ("CLOSE", "MENU",
+	 * a translation, or nothing), so offsetting `left` by a fixed icon width made
+	 * the labelled button overhang the panel and sit on the page behind it. */
 	if ( 'left' === $side ) {
-		echo "$open.ds-menu-wrap--offcanvas .ds-menu-toggle { left: min(" . ( $swide - 58 ) . "px, calc(100vw - 58px)); right: auto; }\n";
-		if ( $smob > 0 ) {
-			echo "@media (max-width: 767px) { $open.ds-menu-wrap--offcanvas .ds-menu-toggle { left: min(" . ( $smob - 58 ) . "px, calc(100vw - 58px)); } }\n";
-		} else {
-			echo "@media (max-width: 767px) { $open.ds-menu-wrap--offcanvas .ds-menu-toggle { left: auto; right: max(18px, env(safe-area-inset-right)); } }\n";
-		}
+		$edge = function ( $w ) {
+			// Distance from the viewport's right edge back to the panel's right edge,
+			// plus the same 18px inset the viewport-corner rule uses.
+			return "calc(100vw - min({$w}px, 100vw) + 18px)";
+		};
+		echo "$open.ds-menu-wrap--offcanvas .ds-menu-toggle { left: auto; right: " . $edge( $swide ) . "; }\n";
+		// Full-width phone panel resolves to the plain 18px inset via the same formula.
+		echo "@media (max-width: 767px) { $open.ds-menu-wrap--offcanvas .ds-menu-toggle { left: auto; right: " . $edge( $smob > 0 ? $smob : 100000 ) . "; } }\n";
 	}
 
 	/* The closed hamburger sits in the header flow. `margin-left:auto` (set by the


### PR DESCRIPTION
Follow-up to #101 / #102, reported on performancevol.

## Problem

The open-state close button was positioned by offsetting `left` by a fixed **58px** icon width:

```
left: min(<panelWidth - 58>px, calc(100vw - 58px));
```

But the toggle is as wide as its **Hamburger Label**. With a label set ("MENU" / "CLOSE" / a translation), the button ran past the panel's right edge and sat on top of the page content behind it. On performancevol — a 360px panel with a "CLOSE" label — it overhung by roughly 60px.

## Fix

Anchor the button's **right edge to the panel's right edge** rather than deriving its left edge from a guessed width:

```
left: auto;
right: calc(100vw - min(<panelWidth>px, 100vw) + 18px);
```

Correct for any label width, any panel width, and any translation — the button can no longer overhang regardless of what the label says. The full-width phone panel resolves to the plain 18px inset through the same expression, so the mobile branch collapses into one rule instead of two.

Scoped to `layout = offcanvas` + left dock, so nothing else changes.