### PR TITLE
Partner role could not use Beaver Builder (1.9.76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.76] - 2026-08-08
+### Fixed
+- **Partner role had no Beaver Builder access — "Edit with Beaver Builder" was missing everywhere.** Beaver Builder stores editing permission PER ROLE in its own `_fl_builder_user_access` option, and its defaults are `administrator` + `editor` only. **Partner** is a role DS Toolkit invents afterwards, so it was never in that list: a partner account could hold every WordPress capability it needed and still see no builder — no row action on Pages, no admin-bar link, no front-end edit. Granting capabilities on the role was never going to be enough; BB has to be told separately. The User Roles feature now adds Partner to BB's `builder_access` and `unrestricted_editing` on `init` (priority 20, after BB registers its settings). `global_styles` and `builder_admin` are deliberately NOT granted — the palette and typography stay a Design Shop concern, edited from Theme Setting. Reads BB's saved settings first and writes only when a value actually changes, so choices made on BB's own settings screen are preserved and no other role's entry is touched.
+
 ## [1.9.75] - 2026-08-08
 ### Fixed
 - **FATAL on every site running 1.9.73 / 1.9.74 — missing feature file.** 1.9.73 added a feature-registry entry for `ds_global_heading_font_enabled` but the class file it points at, `features/class-ds-global-heading-font.php`, was never included in the release. `DS_Toolkit->run()` `require_once`s each enabled feature, so on any blueprint-6 site the plugin threw `Failed opening required .../class-ds-global-heading-font.php` and took the whole site down with a critical error (front end AND wp-admin). The missing file is now shipped. No settings change is needed — the option key was already being backfilled, so affected sites recover as soon as they update.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.75
+ * Version:           1.9.76
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.75' );
+define( 'DS_TOOLKIT_VERSION', '1.9.76' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-user-roles.php
+++ b/features/class-ds-user-roles.php
@@ -41,10 +41,68 @@ class DS_User_Roles {
 		$this->settings = $settings;
 	}
 
+	/**
+	 * Beaver Builder capabilities the Partner role needs to actually build.
+	 *
+	 * `builder_access` alone only opens the builder; without `unrestricted_editing`
+	 * a partner gets the limited/locked editing mode. `global_styles` is left OUT
+	 * on purpose — the palette and typography are a Design Shop concern, edited
+	 * from Theme Setting, and BB's Global Styles menu is hidden from partners.
+	 */
+	private static function bb_caps() {
+		return array( 'builder_access', 'unrestricted_editing' );
+	}
+
 	public function init() {
 		add_action( 'init', array( $this, 'sync_role' ), 5 );
+		// After Beaver Builder has registered its own settings.
+		add_action( 'init', array( $this, 'sync_builder_access' ), 20 );
 		// Very late, after every plugin has registered its menus.
 		add_action( 'admin_menu', array( $this, 'hide_admin_menus' ), 999999 );
+	}
+
+	/**
+	 * Grant the Partner role access to Beaver Builder.
+	 *
+	 * BB stores editing permission PER ROLE in its own `_fl_builder_user_access`
+	 * option, and its defaults are `administrator` + `editor` only. Partner is a
+	 * role we invent afterwards, so it is never in that list — which meant a
+	 * partner account had every WordPress capability it needed and still saw no
+	 * "Edit with Beaver Builder" anywhere. Granting caps on the role is not
+	 * enough; BB has to be told separately.
+	 *
+	 * Writes only when a value actually changes, so this is safe on every load,
+	 * and it never touches any other role's entry.
+	 */
+	public function sync_builder_access() {
+		if ( ! class_exists( 'FLBuilderUserAccess' ) ) {
+			return;
+		}
+		if ( ! get_role( self::ROLE_SLUG ) ) {
+			return;
+		}
+
+		// get_saved_settings() returns defaults merged with anything stored, so
+		// reading it first preserves choices a dev made on BB's own settings screen.
+		$settings = FLBuilderUserAccess::get_saved_settings();
+		if ( ! is_array( $settings ) ) {
+			return;
+		}
+
+		$changed = false;
+		foreach ( self::bb_caps() as $cap ) {
+			if ( ! isset( $settings[ $cap ] ) || ! is_array( $settings[ $cap ] ) ) {
+				continue;
+			}
+			if ( empty( $settings[ $cap ][ self::ROLE_SLUG ] ) ) {
+				$settings[ $cap ][ self::ROLE_SLUG ] = true;
+				$changed = true;
+			}
+		}
+
+		if ( $changed ) {
+			update_option( '_fl_builder_user_access', $settings );
+		}
 	}
 
 	private function plugin_access_allowed() {


### PR DESCRIPTION
## The bug

A **Partner** account saw no "Edit with Beaver Builder" anywhere — no row action on Pages, no admin-bar link, no front-end edit button. Since partners build their own pages, the role was effectively useless for its main job.

## Why capabilities weren't the problem

The Partner role already had everything WordPress needs:

`edit_posts` `edit_pages` `edit_published_pages` `edit_others_pages` `publish_pages` `upload_files` `manage_options` `edit_theme_options` — all **yes**.

Beaver Builder doesn't gate on those. It keeps its **own per-role permission map** in `_fl_builder_user_access`, and its defaults are:

```php
'builder_access' => [ 'default' => [ 'administrator', 'editor' ] ]
```

Partner is a role we invent *after* those defaults exist, so it is never in the list. Asked directly, BB was unambiguous:

```
builder_access        DENIED
unrestricted_editing  DENIED
```

Granting more capabilities would never have fixed this. BB has to be told separately.

## The fix

`DS_User_Roles` now adds Partner to BB's `builder_access` and `unrestricted_editing` on `init` priority 20 (after BB registers its settings).

- **`global_styles` and `builder_admin` stay denied** — the palette and typography are a Design Shop concern, edited from Theme Setting, and BB's Global Styles menu is already hidden from partners.
- Reads `FLBuilderUserAccess::get_saved_settings()` first, so anything a dev set on BB's own settings screen is preserved.
- Writes only when a value actually changes; **no other role's entry is touched** (verified: administrator/editor yes, author/contributor/wpseo_* still no).

## Verified in a real browser

Logged in as a genuine Partner-role user:

| Check | Before | After |
|---|---|---|
| `builder_access` | DENIED | **ALLOWED** |
| `unrestricted_editing` | DENIED | **ALLOWED** |
| `global_styles` | denied | denied (intended) |
| Pages list row action | — | **present** |
| Front-end admin bar link | — | **present** |

Admin bar as the partner sees it: `… New Edit Page Beaver Builder • Howdy, ds_partner_probe`

Registry-resolution check also run on this branch: 40 files, 0 missing.
