### PR TITLE
feat: Page Cards — partners can add their own cards alongside the automatic ones (1.9.82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.82] - 2026-08-08
+### Added
+- **Page Cards: partners can add their own cards alongside the automatic ones (GH request).** A new **Cards From** control offers *Child pages (automatic)* (unchanged default), *Child pages + my own cards*, or *My own cards only*, with a **My Cards** repeater taking a title, link, image, description and optional link text per card, and a control for whether they sit before or after the generated ones. This covers everything that is not a child page: an external registration link, a sponsor, a "Coming Soon" placeholder. Both kinds go through ONE renderer, so every Card Style / Image / Text / Grid setting applies to both and a hand-added card cannot drift away from the generated ones. Details that matter in practice: a card with no link renders as a `div` rather than an anchor to nowhere (styled identically, since the CSS targets the class) and suppresses its link text, so a "Coming Soon" card is not a dead end; a card with no image falls back to the brand social card exactly like a page with no featured image; blank repeater rows are skipped instead of leaving a hole in the grid; and a description typed on a card always shows and is never trimmed, because unlike a page excerpt it was written for that card — honouring "Show Excerpt" there would make a partner's own text vanish with no explanation. Manual cards always use the built-in card design, noted in the field help, so picking a saved layout template does not silently change them.
+
+### Fixed
+- **Page Cards: "Undefined property: order_by" on layouts saved before that field existed.** The value was read a second time in the true branch of its own `in_array()` guard, and since the `??` fallback is itself a valid option that branch is exactly the one an unset property takes. Resolved once now.
+
 ## [1.9.81] - 2026-08-08
 ### Removed
 - **`[ds_footer_nav]` removed.** Footer Style 4 is now built the plain Beaver Builder way — three columns holding a Text Editor, a Photo module bound to the ACF `partner_logo` option, and another Text Editor — so there is nothing for the plugin to render. The shortcode existed to keep a single WP menu splittable around a centred logo, but that bought a PHP feature, a scoped-and-forced CSS block and a shortcode API in exchange for a layout an editor can now open and change directly in the builder. Native modules win: partners edit the links in place, the logo already follows Partner Setting through a normal dynamic-field connection, and the colours come from the row's own Link Color field instead of hand-written CSS. `features/class-ds-footer-nav.php` deleted and dropped from the feature registry and defaults.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.81
+ * Version:           1.9.82
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.81' );
+define( 'DS_TOOLKIT_VERSION', '1.9.82' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -250,7 +250,7 @@ class DS_Toolkit {
             'ds_hero_module_enabled'           => array( 'label' => 'Hero Banner',     'desc' => 'Full-width hero (image, video, or slideshow) with overlay, eyebrow, headline, and call-to-action buttons.' ),
             'ds_menu_module_enabled'           => array( 'label' => 'Menu',            'desc' => 'Responsive navigation bar with dropdowns, mega-menus, and a full-screen mobile overlay.' ),
             'ds_post_loop_module_enabled'      => array( 'label' => 'Post Loop',       'desc' => 'Lists of news, staff, teams, programs, sponsors, or tournaments in a range of card layouts.' ),
-            'ds_page_cards_module_enabled'     => array( 'label' => 'Page Cards',      'desc' => 'A grid of linked cards built from child pages or a manual list.' ),
+            'ds_page_cards_module_enabled'     => array( 'label' => 'Page Cards',      'desc' => 'A grid of linked cards built from child pages, from your own manually added cards, or both together.' ),
             'ds_carousel_module_enabled'       => array( 'label' => 'Images/Videos Carousel', 'desc' => 'A stacked-deck slider or a multi-column reels strip of images and videos.' ),
             'ds_orgstats_module_enabled'       => array( 'label' => 'Org Stats',       'desc' => 'Headline stat figures (the record) as plain figures or photo cards.' ),
             'ds_marquee_module_enabled'        => array( 'label' => 'Marquee',         'desc' => 'A scrolling announcement ticker with a pinned label.' ),

--- a/modules/ds-page-cards/ds-page-cards.php
+++ b/modules/ds-page-cards/ds-page-cards.php
@@ -10,6 +10,13 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  * pick. In both modes the card is rendered with the child as the current post, so
  * the title / permalink / featured image resolve per page.
  *
+ * A partner can also add their OWN cards (title, link, image, description) and
+ * have them sit in the same grid, either alongside the generated ones or on their
+ * own. Both kinds go through one renderer, so every Style setting applies to both
+ * and a hand-added card cannot drift away from the generated ones. This is what
+ * covers everything that is not a child page: an external registration link, a
+ * sponsor, a "Coming Soon" placeholder.
+ *
  * @class DS_Page_Cards_Module
  */
 class DS_Page_Cards_Module extends FLBuilderModule {
@@ -17,7 +24,7 @@ class DS_Page_Cards_Module extends FLBuilderModule {
 	public function __construct() {
 		parent::__construct( array(
 			'name'            => __( 'Page Cards', 'ds-toolkit' ),
-			'description'     => __( 'List child pages as cards, with a styleable built-in card or a saved layout (the module version of [child_pages]).', 'ds-toolkit' ),
+			'description'     => __( 'List child pages as cards, add your own cards, or both. Styleable built-in card or a saved layout (the module version of [child_pages]).', 'ds-toolkit' ),
 			'category'        => __( 'LeagueApps', 'ds-toolkit' ),
 			'dir'             => DS_TOOLKIT_PATH . 'modules/ds-page-cards/',
 			'url'             => DS_TOOLKIT_URL . 'modules/ds-page-cards/',
@@ -51,46 +58,137 @@ class DS_Page_Cards_Module extends FLBuilderModule {
 		return $out;
 	}
 
-	/** The built-in default card for one child page. */
-	private function render_default_card( $child ) {
-		$s     = $this->settings;
-		$pid   = $child->ID;
-		$url   = get_permalink( $pid );
-		$title = get_the_title( $pid );
+	/** Resolve a BB photo field (id, url, or {id,url}) to a URL. */
+	private function photo_url( $val, $size = 'large' ) {
+		if ( is_array( $val ) )      { $val = $val['id'] ?? ( $val['url'] ?? '' ); }
+		elseif ( is_object( $val ) ) { $val = $val->id ?? ( $val->url ?? '' ); }
+		if ( is_numeric( $val ) )    { $u = wp_get_attachment_image_url( (int) $val, $size ); return $u ? $u : ''; }
+		return $val ? esc_url( (string) $val ) : '';
+	}
+
+	/** Normalise a BB link field (string URL or {url,target} object/array). */
+	private function link_parts( $link ) {
+		$url = ''; $target = '_self';
+		if ( is_array( $link ) )      { $url = $link['url'] ?? ''; $target = $link['target'] ?? '_self'; }
+		elseif ( is_object( $link ) ) { $url = $link->url ?? '';  $target = $link->target ?? '_self'; }
+		else { $url = (string) $link; }
+		$url = trim( (string) $url );
+		return array( '' === $url ? '' : esc_url( $url ), '_blank' === $target ? '_blank' : '_self' );
+	}
+
+	/**
+	 * One child page as the shape render_card() consumes.
+	 *
+	 * Auto and manual cards go through the SAME renderer on purpose: every Card
+	 * Style / Image / Text setting on this module then applies to both, so a
+	 * partner's own card is visually indistinguishable from a generated one.
+	 */
+	private function card_from_post( $child ) {
+		$s   = $this->settings;
+		$pid = $child->ID;
+
+		$excerpt = '';
+		if ( ( $s->show_excerpt ?? 'no' ) === 'yes' ) {
+			$raw = trim( (string) $child->post_excerpt ); // manual excerpt only (BB page content isn't excerpt-friendly).
+			if ( '' !== $raw ) {
+				$len     = max( 4, (int) ( $s->excerpt_length ?? 18 ) );
+				$excerpt = esc_html( wp_trim_words( $raw, $len, '&hellip;' ) );
+			}
+		}
+
+		return array(
+			'title_html' => DS_Module_UI::inline( get_the_title( $pid ) ),
+			'aria'       => get_the_title( $pid ),
+			'url'        => esc_url( get_permalink( $pid ) ),
+			'target'     => '_self',
+			'img'        => (string) get_the_post_thumbnail_url( $pid, 'large' ),
+			'excerpt'    => $excerpt,
+			'btn_text'   => '',
+		);
+	}
+
+	/**
+	 * The partner's own cards, from the repeater.
+	 *
+	 * A row with nothing filled in is skipped rather than rendered as an empty
+	 * grid cell, which reads as a broken layout. Note link_parts() maps a blank
+	 * link to '', so "no link" really means no link here.
+	 */
+	private function manual_cards() {
+		$s    = $this->settings;
+		$rows = isset( $s->custom_cards ) && is_array( $s->custom_cards ) ? $s->custom_cards : array();
+		$out  = array();
+
+		foreach ( $rows as $row ) {
+			$row   = is_object( $row ) ? $row : (object) (array) $row;
+			$title = trim( (string) ( $row->title ?? '' ) );
+			$desc  = trim( (string) ( $row->description ?? '' ) );
+			$img   = $this->photo_url( $row->image ?? '', 'large' );
+			list( $url, $target ) = $this->link_parts( $row->link ?? '' );
+
+			if ( '' === $title && '' === $desc && '' === $img && '' === $url ) {
+				continue;
+			}
+
+			$out[] = array(
+				'title_html' => DS_Module_UI::inline( $title ),
+				'aria'       => wp_strip_all_tags( $title ),
+				'url'        => $url,
+				'target'     => $target,
+				'img'        => $img,
+				// Shown whenever it is filled in, and NOT trimmed: unlike a page
+				// excerpt this was typed for this card, so honouring "Show Excerpt"
+				// here would make a partner's own text vanish with no explanation.
+				'excerpt'    => '' === $desc ? '' : nl2br( esc_html( $desc ) ),
+				'btn_text'   => trim( (string) ( $row->button_text ?? '' ) ),
+			);
+		}
+		return $out;
+	}
+
+	/** The built-in card, for a child page or a partner-authored card alike. */
+	private function render_card( array $c ) {
+		$s = $this->settings;
 
 		$cls = 'dst-card';
 		if ( ( $s->show_image ?? 'no' ) === 'yes' && ( $s->image_position ?? 'top' ) === 'left' ) {
 			$cls .= ' dst-card--imgleft'; // image beside the text instead of above it.
 		}
-		$h = '<a class="' . $cls . '" href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $title ) . '">';
+
+		// A manual card with no link must not become an anchor to nowhere. The CSS
+		// targets .dst-card by class, so a div is styled identically.
+		$linked = ( '' !== $c['url'] );
+		$h      = $linked
+			? '<a class="' . $cls . '" href="' . $c['url'] . '"'
+				. ( '_blank' === $c['target'] ? ' target="_blank" rel="noopener"' : '' )
+				. ' aria-label="' . esc_attr( $c['aria'] ) . '">'
+			: '<div class="' . $cls . '">';
 
 		if ( ( $s->show_image ?? 'no' ) === 'yes' ) {
-			$img = get_the_post_thumbnail_url( $pid, 'large' );
+			$img = $c['img'];
 			if ( ! $img && class_exists( 'DS_Social_Card' ) && method_exists( 'DS_Social_Card', 'url' ) ) {
-				$img = DS_Social_Card::url(); // brand placeholder when a page has no featured image.
+				$img = DS_Social_Card::url(); // brand placeholder when a card has no image.
 			}
 			$h .= '<div class="dst-card-img"' . ( $img ? ' style="background-image:url(' . esc_url( $img ) . ')"' : '' ) . '></div>';
 		}
 
 		$h .= '<div class="dst-card-body">';
-		$h .= '<h3 class="dst-card-title">' . DS_Module_UI::inline( $title ) . '</h3>';
+		$h .= '<h3 class="dst-card-title">' . $c['title_html'] . '</h3>';
 
-		if ( ( $s->show_excerpt ?? 'no' ) === 'yes' ) {
-			$ex = trim( (string) $child->post_excerpt ); // manual excerpt only (BB page content isn't excerpt-friendly).
-			if ( '' !== $ex ) {
-				$len = max( 4, (int) ( $s->excerpt_length ?? 18 ) );
-				$h  .= '<p class="dst-card-excerpt">' . esc_html( wp_trim_words( $ex, $len, '&hellip;' ) ) . '</p>';
-			}
+		if ( '' !== $c['excerpt'] ) {
+			$h .= '<p class="dst-card-excerpt">' . $c['excerpt'] . '</p>';
 		}
 
-		if ( ( $s->show_button ?? 'yes' ) === 'yes' ) {
-			$bt = trim( (string) ( $s->button_text ?? '' ) );
+		// A "View page" label under a card that goes nowhere is a dead end, so the
+		// link only renders when there is somewhere to go.
+		if ( ( $s->show_button ?? 'yes' ) === 'yes' && $linked ) {
+			$bt = '' !== $c['btn_text'] ? $c['btn_text'] : trim( (string) ( $s->button_text ?? '' ) );
 			if ( '' === $bt ) { $bt = __( 'View page', 'ds-toolkit' ); }
 			$bs = ( ( $s->button_style ?? 'link' ) === 'button' ) ? 'button' : 'link';
 			$h .= '<span class="dst-card-btn dst-card-btn--' . $bs . '">' . esc_html( $bt ) . '</span>';
 		}
 
-		$h .= '</div></a>';
+		$h .= '</div>' . ( $linked ? '</a>' : '</div>' );
 		return $h;
 	}
 
@@ -105,36 +203,59 @@ class DS_Page_Cards_Module extends FLBuilderModule {
 		$card_source  = (string) ( $s->card_source ?? 'default' );
 		$template_id  = absint( $s->template ?? 0 );
 
-		if ( 'template' === $card_source && ! $template_id ) {
-			if ( $building ) { echo '<p style="padding:18px;opacity:.7;text-align:center">' . esc_html__( 'Page Cards: pick a saved card template, or switch the Card to "Default".', 'ds-toolkit' ) . '</p>'; }
-			return;
+		// Where the cards come from. Defaults to 'children' so every layout saved
+		// before this option existed keeps its exact previous behaviour.
+		$list_source = (string) ( $s->list_source ?? 'children' );
+		$use_pages   = ( 'manual' !== $list_source );
+		$use_manual  = ( 'children' !== $list_source );
+
+		$children = array();
+		if ( $use_pages ) {
+			// Only meaningful for generated cards — manual cards are always the
+			// built-in card, so a missing template must not block them.
+			if ( 'template' === $card_source && ! $template_id ) {
+				if ( $building ) { echo '<p style="padding:18px;opacity:.7;text-align:center">' . esc_html__( 'Page Cards: pick a saved card template, or switch the Card to "Default".', 'ds-toolkit' ) . '</p>'; }
+				return;
+			}
+
+			// Parent page: the current page by default, or a specifically chosen one.
+			if ( 'specific' === (string) ( $s->source ?? 'current' ) && ! empty( $s->parent_page ) ) {
+				$pp        = is_array( $s->parent_page ) ? reset( $s->parent_page ) : $s->parent_page;
+				$parent_id = absint( $pp );
+			} else {
+				$parent_id = (int) get_the_ID();
+			}
+
+			if ( $parent_id ) {
+				$limit      = max( 1, min( 200, absint( $s->limit ?? 50 ) ?: 50 ) );
+				$orderby_ok = array( 'menu_order title', 'menu_order', 'title', 'date', 'modified' );
+				// Resolve the fallback ONCE. Reading $s->order_by again in the true
+				// branch warned "Undefined property" on any layout saved before the
+				// field existed, because the ?? default is itself a valid value.
+				$orderby    = (string) ( $s->order_by ?? 'menu_order title' );
+				if ( ! in_array( $orderby, $orderby_ok, true ) ) { $orderby = 'menu_order title'; }
+				$order      = ( strtoupper( (string) ( $s->order ?? 'ASC' ) ) === 'DESC' ) ? 'DESC' : 'ASC';
+
+				$children = get_posts( array(
+					'post_type'      => 'page',
+					'post_status'    => 'publish',
+					'post_parent'    => $parent_id,
+					'orderby'        => $orderby,
+					'order'          => $order,
+					'posts_per_page' => $limit,
+				) );
+			}
 		}
 
-		// Parent page: the current page by default, or a specifically chosen one.
-		if ( 'specific' === (string) ( $s->source ?? 'current' ) && ! empty( $s->parent_page ) ) {
-			$pp        = is_array( $s->parent_page ) ? reset( $s->parent_page ) : $s->parent_page;
-			$parent_id = absint( $pp );
-		} else {
-			$parent_id = (int) get_the_ID();
-		}
-		if ( ! $parent_id ) { return; }
+		$manual = $use_manual ? $this->manual_cards() : array();
 
-		$limit      = max( 1, min( 200, absint( $s->limit ?? 50 ) ?: 50 ) );
-		$orderby_ok = array( 'menu_order title', 'menu_order', 'title', 'date', 'modified' );
-		$orderby    = in_array( (string) ( $s->order_by ?? 'menu_order title' ), $orderby_ok, true ) ? (string) $s->order_by : 'menu_order title';
-		$order      = ( strtoupper( (string) ( $s->order ?? 'ASC' ) ) === 'DESC' ) ? 'DESC' : 'ASC';
-
-		$children = get_posts( array(
-			'post_type'      => 'page',
-			'post_status'    => 'publish',
-			'post_parent'    => $parent_id,
-			'orderby'        => $orderby,
-			'order'          => $order,
-			'posts_per_page' => $limit,
-		) );
-
-		if ( empty( $children ) ) {
-			if ( $building ) { echo '<p style="padding:18px;opacity:.7;text-align:center">' . esc_html__( 'Page Cards: this parent page has no published child pages.', 'ds-toolkit' ) . '</p>'; }
+		if ( empty( $children ) && empty( $manual ) ) {
+			if ( $building ) {
+				$msg = $use_pages
+					? __( 'Page Cards: this parent page has no published child pages, and no cards of your own have been added.', 'ds-toolkit' )
+					: __( 'Page Cards: add a card under "My Cards".', 'ds-toolkit' );
+				echo '<p style="padding:18px;opacity:.7;text-align:center">' . esc_html( $msg ) . '</p>';
+			}
 			return;
 		}
 
@@ -143,20 +264,31 @@ class DS_Page_Cards_Module extends FLBuilderModule {
 		$colm = max( 1, absint( $s->columns_mobile ?? 1 ) );
 		$gap  = max( 0, absint( $s->gap ?? 24 ) );
 
+		$manual_html = '';
+		foreach ( $manual as $c ) {
+			$manual_html .= '<div class="dst-child-page-item dst-child-page-item--manual">' . $this->render_card( $c ) . '</div>';
+		}
+		$manual_first = ( 'before' === (string) ( $s->manual_position ?? 'after' ) );
+
 		$depth++;
 		global $post;
 		$orig = $post;
-		$out  = '';
-		foreach ( $children as $child ) {
-			$post = $child; // BB reads the child's title / permalink / featured image.
-			setup_postdata( $post );
-			$card = ( 'template' === $card_source )
-				? do_shortcode( '[fl_builder_insert_layout id="' . $template_id . '"]' )
-				: $this->render_default_card( $child );
-			$out .= '<div class="dst-child-page-item">' . $card . '</div>';
+		$out  = $manual_first ? $manual_html : '';
+
+		if ( ! empty( $children ) ) {
+			foreach ( $children as $child ) {
+				$post = $child; // BB reads the child's title / permalink / featured image.
+				setup_postdata( $post );
+				$card = ( 'template' === $card_source )
+					? do_shortcode( '[fl_builder_insert_layout id="' . $template_id . '"]' )
+					: $this->render_card( $this->card_from_post( $child ) );
+				$out .= '<div class="dst-child-page-item">' . $card . '</div>';
+			}
+			wp_reset_postdata();
+			$post = $orig;
 		}
-		wp_reset_postdata();
-		$post = $orig;
+
+		if ( ! $manual_first ) { $out .= $manual_html; }
 		$depth--;
 
 		$style = sprintf( '--dst-cols:%d;--dst-cols-tablet:%d;--dst-cols-mobile:%d;--dst-gap:%dpx;', $cols, $colt, $colm, $gap );
@@ -171,6 +303,22 @@ FLBuilder::register_module( 'DS_Page_Cards_Module', array(
 			'source_sec' => array(
 				'title'  => __( 'Which Pages', 'ds-toolkit' ),
 				'fields' => array(
+					'list_source' => array(
+						'type'    => 'select',
+						'label'   => __( 'Cards From', 'ds-toolkit' ),
+						'default' => 'children',
+						'options' => array(
+							'children' => __( 'Child pages (automatic)', 'ds-toolkit' ),
+							'both'     => __( 'Child pages + my own cards', 'ds-toolkit' ),
+							'manual'   => __( 'My own cards only', 'ds-toolkit' ),
+						),
+						'toggle'  => array(
+							'children' => array( 'fields' => array( 'source', 'limit', 'order_by', 'order' ) ),
+							'both'     => array( 'fields' => array( 'source', 'limit', 'order_by', 'order', 'manual_position' ), 'sections' => array( 'manual_sec' ) ),
+							'manual'   => array( 'sections' => array( 'manual_sec' ) ),
+						),
+						'help'    => __( 'Add your own cards alongside the automatic ones for anything that is not a child page: an external registration link, a sponsor, or a "Coming Soon" placeholder.', 'ds-toolkit' ),
+					),
 					'source'      => array(
 						'type'    => 'select',
 						'label'   => __( 'List Children Of', 'ds-toolkit' ),
@@ -197,6 +345,28 @@ FLBuilder::register_module( 'DS_Page_Cards_Module', array(
 						),
 					),
 					'order'       => array( 'type' => 'select', 'label' => __( 'Order', 'ds-toolkit' ), 'default' => 'ASC', 'options' => array( 'ASC' => __( 'Ascending', 'ds-toolkit' ), 'DESC' => __( 'Descending', 'ds-toolkit' ) ) ),
+				),
+			),
+			'manual_sec' => array(
+				'title'  => __( 'My Cards', 'ds-toolkit' ),
+				'fields' => array(
+					'manual_position' => array(
+						'type'    => 'select',
+						'label'   => __( 'Where To Put Them', 'ds-toolkit' ),
+						'default' => 'after',
+						'options' => array(
+							'after'  => __( 'After the child pages', 'ds-toolkit' ),
+							'before' => __( 'Before the child pages', 'ds-toolkit' ),
+						),
+					),
+					'custom_cards'    => array(
+						'type'         => 'form',
+						'label'        => __( 'Card', 'ds-toolkit' ),
+						'form'         => 'ds_page_card_form',
+						'preview_text' => 'title',
+						'multiple'     => true,
+						'help'         => __( 'Your cards use the same built-in card design and every Style setting below, so they sit in the grid alongside the automatic ones. Blank cards are skipped. If the Card is set to a saved layout template, your cards still use the built-in design.', 'ds-toolkit' ),
+					),
 				),
 			),
 			'card_sec' => array(
@@ -226,7 +396,7 @@ FLBuilder::register_module( 'DS_Page_Cards_Module', array(
 						'help'    => __( 'Each child page is rendered with this saved Beaver Builder template.', 'ds-toolkit' ),
 					),
 					'show_image'     => array( 'type' => 'select', 'label' => __( 'Show Image', 'ds-toolkit' ), 'default' => 'no', 'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No', 'ds-toolkit' ) ), 'toggle' => array( 'yes' => array( 'fields' => array( 'image_position' ) ) ), 'help' => __( 'Uses the page\'s featured image, or the brand social card when it has none.', 'ds-toolkit' ) ),
-					'show_excerpt'   => array( 'type' => 'select', 'label' => __( 'Show Excerpt', 'ds-toolkit' ), 'default' => 'no', 'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No', 'ds-toolkit' ) ), 'toggle' => array( 'yes' => array( 'fields' => array( 'excerpt_length' ) ) ), 'help' => __( 'Shows the page\'s manual excerpt (auto-hides if it has none).', 'ds-toolkit' ) ),
+					'show_excerpt'   => array( 'type' => 'select', 'label' => __( 'Show Excerpt', 'ds-toolkit' ), 'default' => 'no', 'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No', 'ds-toolkit' ) ), 'toggle' => array( 'yes' => array( 'fields' => array( 'excerpt_length' ) ) ), 'help' => __( 'Shows the child page\'s manual excerpt (auto-hides if it has none). Descriptions you type on your own cards always show, whatever this is set to.', 'ds-toolkit' ) ),
 					'excerpt_length' => array( 'type' => 'unit', 'label' => __( 'Excerpt Length', 'ds-toolkit' ), 'default' => '18', 'description' => __( 'words', 'ds-toolkit' ), 'slider' => array( 'min' => 4, 'max' => 60, 'step' => 1 ) ),
 					'show_button'    => array( 'type' => 'select', 'label' => __( 'Show Link', 'ds-toolkit' ), 'default' => 'yes', 'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No', 'ds-toolkit' ) ), 'toggle' => array( 'yes' => array( 'fields' => array( 'button_text', 'button_style' ) ) ) ),
 					'button_text'    => array( 'type' => 'text', 'label' => __( 'Link Text', 'ds-toolkit' ), 'default' => 'View page' ),
@@ -301,6 +471,63 @@ FLBuilder::register_module( 'DS_Page_Cards_Module', array(
 				'fields' => array(
 					'title_color'   => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Title Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Blank inherits the theme heading colour.', 'ds-toolkit' ) ),
 					'excerpt_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Excerpt Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true ),
+				),
+			),
+		),
+	),
+) );
+
+/**
+ * One partner-authored card.
+ *
+ * Deliberately the four things a partner can actually supply for something that
+ * is NOT a child page — a title, where it goes, a picture and a line of text.
+ * Everything else (colours, padding, image ratio, columns) still comes from the
+ * module's Style tab, so these cards cannot drift away from the generated ones.
+ */
+FLBuilder::register_settings_form( 'ds_page_card_form', array(
+	'title' => __( 'Card', 'ds-toolkit' ),
+	'tabs'  => array(
+		'general' => array(
+			'title'    => __( 'Card', 'ds-toolkit' ),
+			'sections' => array(
+				'general' => array(
+					'title'  => '',
+					'fields' => array(
+						'title'       => array(
+							'type'        => 'text',
+							'label'       => __( 'Title', 'ds-toolkit' ),
+							'default'     => '',
+							'connections' => array( 'string' ),
+						),
+						'link'        => array(
+							'type'        => 'link',
+							'label'       => __( 'Link', 'ds-toolkit' ),
+							'show_target' => true,
+							'connections' => array( 'url' ),
+							'help'        => __( 'Any URL, internal or external. Leave blank for a card that is not clickable, e.g. a "Coming Soon" placeholder.', 'ds-toolkit' ),
+						),
+						'image'       => array(
+							'type'        => 'photo',
+							'label'       => __( 'Image', 'ds-toolkit' ),
+							'show_remove' => true,
+							'connections' => array( 'photo' ),
+							'help'        => __( 'Only used when Show Image is on. With no image the card falls back to the brand social card, exactly like a page with no featured image.', 'ds-toolkit' ),
+						),
+						'description' => array(
+							'type'        => 'textarea',
+							'rows'        => 3,
+							'label'       => __( 'Description', 'ds-toolkit' ),
+							'connections' => array( 'string' ),
+							'help'        => __( 'Optional. Shown in full, so keep it to a line or two to match the trimmed page excerpts beside it.', 'ds-toolkit' ),
+						),
+						'button_text' => array(
+							'type'    => 'text',
+							'label'   => __( 'Link Text', 'ds-toolkit' ),
+							'default' => '',
+							'help'    => __( 'Blank uses the Link Text set on the module. Ignored when this card has no link.', 'ds-toolkit' ),
+						),
+					),
 				),
 			),
 		),


### PR DESCRIPTION
Requested: let a partner add a card with a title, link, image and description to Page Cards, combined with the automatic child-page cards rather than instead of them.

## What it does

A new **Cards From** control at the top of the Pages tab:

| Option | Behaviour |
|---|---|
| **Child pages (automatic)** | Unchanged. This is the default, so every existing layout is untouched. |
| **Child pages + my own cards** | Both, in one grid. A **Where To Put Them** control puts yours before or after. |
| **My own cards only** | No page query at all. |

The **My Cards** repeater takes per card: Title, Link (with new-tab option), Image, Description, and an optional Link Text that overrides the module's.

This covers what a child page cannot be: an external registration link, a sponsor, a "Coming Soon" placeholder.

## The design decision

**Auto and manual cards go through one renderer.** Manual cards are normalised into the same shape a child page produces, so every Card Style / Image / Text / Grid setting applies to both and a hand-added card cannot drift away from the generated ones. That is the whole point — a partner's card has to be indistinguishable from a generated one, or the grid looks broken.

Details that matter in practice:

- **A card with no link renders as a `div`, not an anchor to nowhere**, and suppresses its link text. A "Coming Soon" card should not be a dead end offering "View page". The CSS targets `.dst-card` by class, so it is styled identically.
- **A card with no image falls back to the brand social card**, exactly like a page with no featured image.
- **Blank repeater rows are skipped**, not rendered as an empty grid cell (same trap that hit the ds-cta Motion Cards rows).
- **A description typed on a card always shows and is never trimmed.** Unlike a page excerpt it was written for that card, so honouring "Show Excerpt" there would make a partner's own text vanish with no explanation. The Show Excerpt help now says so.
- **Manual cards always use the built-in card design**, stated in the field help, so choosing a saved layout template does not silently change them.

## Also fixed

`Undefined property: order_by` on any layout saved before that field existed. The value was read a second time inside the true branch of its own `in_array()` guard, and the `??` fallback is itself a valid option, so an unset property took exactly that branch. Surfaced by the backward-compatibility test below.

## Verified on ds-launchpad-6

| Check | Result |
|---|---|
| `children` mode | 3 cards, all anchors — identical to before |
| `both` mode | 3 auto + 2 manual, blank row skipped, 4 anchors + 1 unlinked |
| `manual` mode | 2 cards, page query never runs |
| **Layout saved with no `list_source` key at all** | child pages only, zero manual markup |
| Same, with a stray `custom_cards` value | manual cards correctly do **not** appear |
| `manual_position: before` | partner card renders first |
| Manual-only with a template selected but none chosen | still renders (the template guard is scoped to generated cards) |
| Manual-only with no parent context | renders |
| `show_button: no` | no link text on any card |
| Per-card Link Text override | beats the module default |
| Repeater in the builder | 2 rows, preview labels from `title`, wired to `ds_page_card_form` |
| `ds_page_card_form` registration | present, 5 fields, correct types |
| Front end, desktop + mobile | 5 cards, uniform 384px tracks, images painted, no console errors |
| **Blueprint's own Programs page** | 5 cards, 0 unlinked, 0 manual markers, 0 PHP diagnostics |
| PHP lint, all 100 tracked files | clean |

Test pages, the temp user and the orphaned builder history were removed from the Local blueprint afterwards — leaving them would have cloned into every future build via `install_copy`.
