### PR TITLE
feat: Athletes Compact Strip layout + filter matches on data-facet (1.9.70)

### DIFF
--- a/modules/ds-post-loop/css/frontend.css
+++ b/modules/ds-post-loop/css/frontend.css
@@ -111,6 +111,24 @@
 .ds-commit--action .ds-people-name{font-size:1.05rem;}
 .ds-commit--action .ds-people-role{letter-spacing:.04em;}
 
+/* ---- Commitments: Compact Strip — [college logo][name + college][club mark] ----
+   Literal fallbacks throughout: older Launchpad builds emit no --fl-global-* props,
+   and an unresolved var() drops the whole declaration. */
+.ds-commit--strip .ds-commit-strip{position:relative;display:flex;align-items:center;gap:12px;padding:12px;border-radius:4px;background:var(--fl-global-accent,#b32033);min-width:0;overflow:hidden;}
+.ds-commit--strip .ds-commit-strip-logo{flex:0 0 auto;width:44px;height:44px;display:flex;align-items:center;justify-content:center;border-radius:3px;background:var(--fl-global-white,#fff);padding:3px;}
+.ds-commit--strip .ds-commit-strip-logo img{max-width:100%;max-height:100%;object-fit:contain;}
+.ds-commit--strip .ds-commit-strip-body{display:flex;flex-direction:column;gap:1px;text-align:left;min-width:0;flex:1 1 auto;}
+.ds-commit--strip .ds-people-name{margin:0;font-size:1rem;line-height:1.15;color:var(--fl-global-white,#fff);overflow-wrap:anywhere;}
+.ds-commit--strip .ds-people-role{font-size:.72rem;line-height:1.25;letter-spacing:.05em;text-transform:uppercase;color:rgba(255,255,255,.85);overflow-wrap:anywhere;}
+.ds-commit--strip .ds-commit-strip-brand{flex:0 0 auto;width:38px;height:38px;display:flex;align-items:center;justify-content:center;margin-left:auto;}
+.ds-commit--strip .ds-commit-strip-brand img{max-width:100%;max-height:100%;object-fit:contain;}
+.ds-commit--strip .ds-commit-strip{transition:transform .18s ease,box-shadow .18s ease;}
+.ds-commit--strip .ds-commit-strip:hover{transform:translateY(-2px);box-shadow:0 6px 18px rgba(0,0,0,.18);}
+@media (prefers-reduced-motion:reduce){.ds-commit--strip .ds-commit-strip:hover{transform:none;}}
+/* Narrow phones: shrink the club mark rather than drop it — it is a requested part
+   of the strip, so it should survive every breakpoint. */
+@media (max-width:420px){.ds-commit--strip .ds-commit-strip{gap:10px;}.ds-commit--strip .ds-commit-strip-brand{width:30px;height:30px;}}
+
 /* ---- Commitments: front-end filter bar (pills) ---- */
 .ds-commit-filter{display:flex;align-items:center;gap:16px;flex-wrap:wrap;margin-bottom:26px;}
 .ds-commit-tabs{display:inline-flex;flex-wrap:wrap;gap:8px;}

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -95,6 +95,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			'athlete_photo'  => __( 'Athletes: Photo Cards', 'ds-toolkit' ),
 			'athlete_logo'   => __( 'Athletes: Logo Row (dark)', 'ds-toolkit' ),
 			'athlete_action' => __( 'Athletes: Action Cards', 'ds-toolkit' ),
+			'athlete_strip'  => __( 'Athletes: Compact Strip', 'ds-toolkit' ),
 			'team_list'      => __( 'Teams: List', 'ds-toolkit' ),
 			'team_card'      => __( 'Teams: Cards (photo grid)', 'ds-toolkit' ),
 			// Still selectable: it has the same manual-list defect as `program` but no
@@ -341,6 +342,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			'athlete_photo'  => 'render_athlete_photo',
 			'athlete_logo'   => 'render_athlete_logo',
 			'athlete_action' => 'render_athlete_action',
+			'athlete_strip'  => 'render_athlete_strip',
 			'team_list'      => 'render_team_list',
 			'team_card'      => 'render_team_card',
 			'sponsor'        => 'render_sponsor',
@@ -606,6 +608,56 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 			if ( '' !== $name ) { echo '<h3 class="ds-people-name">' . DS_Module_UI::inline( $name ) . '</h3>'; }
 			if ( '' !== $meta ) { echo '<span class="ds-people-role">' . esc_html( $meta ) . '</span>'; }
 			echo '</div></div></div>';
+		}
+		$this->athlete_section_close();
+	}
+
+	/**
+	 * The club/partner mark shown on the right of a Compact Strip. Falls back to the
+	 * site's ACF `partner_logo` option, so the layout is correct on any fleet site with
+	 * zero configuration; the module's own Club Logo field overrides it per instance.
+	 */
+	private function commit_brand_logo() {
+		$own = $this->acf_image_url( $this->settings->cr_brand ?? '' );
+		if ( $own ) { return $own; }
+		if ( function_exists( 'get_field' ) ) {
+			$opt = $this->acf_image_url( get_field( 'partner_logo', 'option' ) );
+			if ( $opt ) { return $opt; }
+		}
+		return '';
+	}
+
+	/**
+	 * Compact Strip — a short, dense row instead of a tall photo card:
+	 * [college logo] [player name + college] [club logo]. Modelled on the 4Leaf
+	 * commitments strip a partner asked us to match. No athlete photo at all, which
+	 * is the point: it stays readable when every athlete shares one placeholder image,
+	 * and it fits three or four across without dominating the page.
+	 */
+	public function render_athlete_strip() {
+		$s     = $this->settings;
+		$q     = $this->run_query();
+		$rows  = array();
+		if ( ! $this->athlete_section_open( 'ds-commit--strip', $q, $rows ) ) { return; }
+
+		$brand      = ( $s->cr_brand_show ?? 'yes' ) === 'yes' ? $this->commit_brand_logo() : '';
+		$show_coll  = ( $s->cr_show_college ?? 'yes' ) === 'yes';
+		$brand_alt  = get_bloginfo( 'name' );
+
+		$this->loop_open( 'ds-people-grid' );
+		while ( $q->have_posts() ) { $q->the_post(); $id = get_the_ID();
+			$logo   = $this->commit_logo( $id );
+			$name   = get_the_title( $id );
+			$school = $show_coll ? $this->commit_school( $id ) : '';
+			echo '<div class="ds-commit-strip"' . $this->commit_data_attr( $this->commit_facets( $id ) ) . '>';
+			echo $this->card_link( $id );
+			echo '<span class="ds-commit-strip-logo">' . ( $logo ? '<img src="' . esc_url( $logo ) . '" alt="' . esc_attr( $school ?: $name ) . '" loading="lazy" />' : '' ) . '</span>';
+			echo '<span class="ds-commit-strip-body">';
+			if ( '' !== $name )   { echo '<h3 class="ds-people-name">' . DS_Module_UI::inline( $name ) . '</h3>'; }
+			if ( '' !== $school ) { echo '<span class="ds-people-role">' . esc_html( $school ) . '</span>'; }
+			echo '</span>';
+			if ( '' !== $brand ) { echo '<span class="ds-commit-strip-brand"><img src="' . esc_url( $brand ) . '" alt="' . esc_attr( $brand_alt ) . '" loading="lazy" /></span>'; }
+			echo '</div>';
 		}
 		$this->athlete_section_close();
 	}
@@ -1281,6 +1333,7 @@ $ds_pl_form = array(
 							'athlete_photo'  => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'commit_filter_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 							'athlete_logo'   => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'commit_filter_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 							'athlete_action' => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_card', 'commit_filter_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
+							'athlete_strip'  => array( 'sections' => array( 'header', 'query', 'query_filter', 'commit_strip_opts', 'commit_filter_opts', 'header_style', 'spacing', 'hover', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 							'team_list'      => array( 'sections' => array( 'header', 'query', 'query_filter', 'team_list_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders' ), 'tabs' => array( 'query' ) ),
 							'team_card'      => array( 'sections' => array( 'header', 'query', 'query_filter', 'team_card_opts', 'header_style', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
 							'custom'         => array( 'sections' => array( 'header', 'query', 'query_filter', 'loopcard', 'header_style', 'typography', 'spacing', 'hover', 'card_border', 'ds_borders', 'ds_display' ), 'tabs' => array( 'query' ) ),
@@ -1620,6 +1673,29 @@ $ds_pl_form = array(
 					'commit_show_year'   => array( 'type' => 'select', 'label' => __( 'Show Class Year (Action Card)', 'ds-toolkit' ), 'default' => 'yes', 'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No', 'ds-toolkit' ) ), 'help' => __( 'The Action Card meta line reads "year | college". Set to No for a college-only line.', 'ds-toolkit' ) ),
 					'commit_school_key'  => array( 'type' => 'text', 'label' => __( 'College Name Field', 'ds-toolkit' ), 'default' => '', 'help' => __( 'Meta/ACF key holding the college name. Blank auto-detects school_name, university, college, college_name, school.', 'ds-toolkit' ) ),
 					'commit_logo_key'    => array( 'type' => 'text', 'label' => __( 'College Logo Field', 'ds-toolkit' ), 'default' => '', 'help' => __( 'Meta/ACF key holding the college logo image. Blank auto-detects school_logo, college_logo, logo.', 'ds-toolkit' ) ),
+				),
+			),
+			// --- Compact Strip (logo | name | club mark) ---
+			'commit_strip_opts' => array(
+				'title'       => __( 'Compact Strip', 'ds-toolkit' ),
+				'description' => __( 'A short dense row per athlete: college logo on the left, name and college in the middle, the club mark on the right. No athlete photo — ideal when athletes share a placeholder image.', 'ds-toolkit' ),
+				'fields'      => array(
+					'cr_cols'         => array( 'type' => 'unit', 'label' => __( 'Columns', 'ds-toolkit' ), 'default' => '3', 'responsive' => true, 'slider' => array( 'min' => 1, 'max' => 5, 'step' => 1 ), 'help' => __( 'Defaults: 2 tablet, 1 mobile.', 'ds-toolkit' ) ),
+					'cr_gap'          => array( 'type' => 'unit', 'label' => __( 'Gap', 'ds-toolkit' ), 'default' => '16', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 40, 'step' => 1 ) ),
+					'card_link'       => array( 'type' => 'select', 'label' => __( 'Link Card to Post', 'ds-toolkit' ), 'default' => 'yes', 'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No', 'ds-toolkit' ) ) ),
+					'cr_show_college' => array( 'type' => 'select', 'label' => __( 'Show College Name', 'ds-toolkit' ), 'default' => 'yes', 'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No', 'ds-toolkit' ) ), 'help' => __( 'Off leaves just the athlete name beside the logo.', 'ds-toolkit' ) ),
+					'cr_bg'           => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Strip Background', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Blank = the global Accent colour.', 'ds-toolkit' ) ),
+					'cr_radius'       => array( 'type' => 'unit', 'label' => __( 'Corner Radius', 'ds-toolkit' ), 'default' => '4', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 24, 'step' => 1 ) ),
+					'cr_pad'          => array( 'type' => 'unit', 'label' => __( 'Padding', 'ds-toolkit' ), 'default' => '12', 'description' => 'px', 'slider' => array( 'min' => 4, 'max' => 32, 'step' => 1 ) ),
+					'cr_name_color'   => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Name Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Blank = white.', 'ds-toolkit' ) ),
+					'cr_meta_color'   => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'College Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true ),
+					'cr_logo_size'    => array( 'type' => 'unit', 'label' => __( 'College Logo Size', 'ds-toolkit' ), 'default' => '44', 'description' => 'px', 'slider' => array( 'min' => 24, 'max' => 90, 'step' => 1 ) ),
+					'cr_logo_bg'      => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'College Logo Backdrop', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true, 'help' => __( 'A light chip behind the logo keeps dark college marks legible on a strong background. Blank = white.', 'ds-toolkit' ) ),
+					'cr_brand_show'   => array( 'type' => 'select', 'label' => __( 'Show Club Logo', 'ds-toolkit' ), 'default' => 'yes', 'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No', 'ds-toolkit' ) ), 'toggle' => array( 'yes' => array( 'fields' => array( 'cr_brand', 'cr_brand_size' ) ) ) ),
+					'cr_brand'        => array( 'type' => 'photo', 'label' => __( 'Club Logo', 'ds-toolkit' ), 'show_remove' => true, 'connections' => array( 'photo' ), 'help' => __( 'Blank = the site\'s Partner Logo setting. Use a version that reads on the strip background (a white mark on a strong colour).', 'ds-toolkit' ) ),
+					'cr_brand_size'   => array( 'type' => 'unit', 'label' => __( 'Club Logo Size', 'ds-toolkit' ), 'default' => '38', 'description' => 'px', 'slider' => array( 'min' => 20, 'max' => 80, 'step' => 1 ) ),
+					'cr_name_typo'    => array( 'type' => 'typography', 'label' => __( 'Name Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-commit-strip .ds-people-name' ) ),
+					'cr_meta_typo'    => array( 'type' => 'typography', 'label' => __( 'College Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-commit-strip .ds-people-role' ) ),
 				),
 			),
 			// --- Front-end filter bar for the Commitment / Athlete card grids ---

--- a/modules/ds-post-loop/includes/frontend.css.php
+++ b/modules/ds-post-loop/includes/frontend.css.php
@@ -275,6 +275,8 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 		'commit_name_typo'         => '.ds-people-name',
 		'commit_meta_typo'         => '.ds-people-role',
 		'cf_tab_typo'              => '.ds-commit-tab',
+		'cr_name_typo'             => '.ds-commit-strip .ds-people-name',
+		'cr_meta_typo'             => '.ds-commit-strip .ds-people-role',
 		'team_name_typo'           => '.ds-team-name',
 		// Custom Program card
 		'pg_date_typo'             => '.ds-program-date',
@@ -381,7 +383,42 @@ if ( ( $settings->card_layout ?? '' ) === 'staff_card' ) {
 }
 
 // ---- Commitments / Athletes (content_type = athlete) ----
-if ( in_array( $settings->card_layout ?? '', array( 'athlete_photo', 'athlete_logo', 'athlete_action' ), true ) ) {
+if ( in_array( $settings->card_layout ?? '', array( 'athlete_photo', 'athlete_logo', 'athlete_action', 'athlete_strip' ), true ) ) {
+$strip = ( $settings->card_layout ?? '' ) === 'athlete_strip';
+if ( $strip ) {
+	// Compact Strip has its own, smaller geometry: it shares the grid and the filter
+	// bar with the photo/action cards but none of their photo-card settings.
+	$rcols = max( 1, $u( $settings->cr_cols ?? '', 3 ) );
+	$rgap  = $u( $settings->cr_gap ?? '', 16 );
+	echo "$node .ds-people-grid { grid-template-columns: repeat({$rcols},1fr); gap: {$rgap}px; }\n";
+	$rcolsM = max( 1, $u( $settings->cr_cols_medium ?? '', min( $rcols, 2 ) ) );
+	echo "@media (max-width:{$bpm}px){ $node .ds-people-grid { grid-template-columns: repeat({$rcolsM},1fr); } }\n";
+	$rcolsR = max( 1, $u( $settings->cr_cols_responsive ?? '', 1 ) );
+	echo "@media (max-width:{$bpr}px){ $node .ds-people-grid { grid-template-columns: repeat({$rcolsR},1fr); } }\n";
+
+	$rrad = $u( $settings->cr_radius ?? '', 4 );
+	$rpad = $u( $settings->cr_pad ?? '', 12 );
+	echo "$node .ds-commit-strip { border-radius: {$rrad}px; padding: {$rpad}px; }\n";
+	$rbg = $col( $settings->cr_bg ?? '' );
+	if ( '' !== $rbg ) { echo "$node .ds-commit-strip { background: {$rbg}; }\n"; }
+	$rnc = $col( $settings->cr_name_color ?? '' );
+	if ( '' !== $rnc ) { echo "$node .ds-commit-strip .ds-people-name { color: {$rnc}; }\n"; }
+	$rmc = $col( $settings->cr_meta_color ?? '' );
+	if ( '' !== $rmc ) { echo "$node .ds-commit-strip .ds-people-role { color: {$rmc}; }\n"; }
+	// Both marks shrink on phones so the name/college keep their width. Emitted here
+	// rather than left to the stylesheet: these node rules match the base rules'
+	// specificity and print after them, so a plain @media in frontend.css would lose.
+	$rls = $u( $settings->cr_logo_size ?? '', 44 );
+	echo "$node .ds-commit-strip-logo { width: {$rls}px; height: {$rls}px; }\n";
+	$rlsm = max( 26, (int) round( $rls * 0.82 ) );
+	echo "@media (max-width:{$bpr}px){ $node .ds-commit-strip-logo { width: {$rlsm}px; height: {$rlsm}px; } }\n";
+	$rlb = $col( $settings->cr_logo_bg ?? '' );
+	if ( '' !== $rlb ) { echo "$node .ds-commit-strip-logo { background: {$rlb}; }\n"; }
+	$rbs = $u( $settings->cr_brand_size ?? '', 38 );
+	echo "$node .ds-commit-strip-brand { width: {$rbs}px; height: {$rbs}px; }\n";
+	$rbsm = max( 22, (int) round( $rbs * 0.75 ) );
+	echo "@media (max-width:{$bpr}px){ $node .ds-commit-strip-brand { width: {$rbsm}px; height: {$rbsm}px; } }\n";
+} else {
 	$ccols = max( 1, $u( $settings->commit_cols ?? '', 4 ) );
 	$cgap  = $u( $settings->commit_gap ?? '', 24 );
 	echo "$node .ds-people-grid { grid-template-columns: repeat({$ccols},1fr); gap: {$cgap}px; }\n";
@@ -419,8 +456,9 @@ if ( in_array( $settings->card_layout ?? '', array( 'athlete_photo', 'athlete_lo
 	echo "$node .ds-commit--photo .ds-people-photo, $node .ds-commit--action .ds-people-photo { background-size: {$cfit}; background-position: {$cpos}; }\n";
 	$cpb = $col( $settings->commit_photo_bg ?? '' );
 	if ( '' !== $cpb ) { echo "$node .ds-commit--photo .ds-people-photo, $node .ds-commit--action .ds-people-photo { background-color: {$cpb}; }\n"; }
+}
 
-	// Filter bar (pills). Every colour is optional — blank keeps the base
+	// Filter bar (pills). Shared by every athlete layout. Every colour is optional — blank keeps the base
 	// stylesheet's accent-driven look so it matches the site palette for free.
 	if ( ( $settings->cf_filter ?? 'disable' ) === 'enable' ) {
 		$fmapa = array( 'left' => 'flex-start', 'center' => 'center', 'right' => 'flex-end' );

--- a/modules/ds-post-loop/js/frontend.js
+++ b/modules/ds-post-loop/js/frontend.js
@@ -200,7 +200,9 @@
 		if (!bar || !grid) return;
 		root.dsCommitInit = true;
 
-		var cards = [].slice.call(grid.querySelectorAll('.ds-commit-card,.ds-commit-row,.ds-commit-action'));
+		// Match on the data-facet contract, not a list of card class names — every
+		// filterable card emits it, so a new card layout works without touching this.
+		var cards = [].slice.call(grid.querySelectorAll('[data-facet]'));
 		var tabs  = [].slice.call(bar.querySelectorAll('.ds-commit-tab'));
 		var count = bar.querySelector('.ds-commit-count');
 		var none  = root.querySelector('.ds-commit-none');


### PR DESCRIPTION
## Why

495 Lacrosse asked for their commitments to render as compact blocks in the style of another club's alumni strip: **college logo on the left, athlete name in the middle, the club logo on the right of the coloured block** (ClickUp 868kdfae1, Zendesk 441707).

There is a structural reason beyond taste. The existing Action Card is a tall 3:4 photo card, and on this site every athlete shares the same placeholder image — twenty identical portraits stacked into a **32,000px** mobile page. The strip carries no athlete photo at all and cuts the same list to **~3,400px**.

## Athletes: Compact Strip

New fifth Athlete layout, `athlete_strip`. Full options section:

- Columns (responsive, default 3 / 2 / 1), Gap, Padding, Corner Radius
- Strip Background (blank = global Accent), Name Colour, College Colour
- College Logo Size + Backdrop chip (keeps dark college marks legible on a strong background)
- **Club Logo**: blank falls back to the site's ACF `partner_logo` option, so the layout is correct on any fleet site with zero configuration; a per-instance photo field overrides it
- Show College Name toggle, Link Card to Post, Name/College typography

Both marks **shrink** at the responsive breakpoint rather than dropping — the club logo is a requested element, so it survives every breakpoint. Those two rules are emitted from the node CSS rather than the stylesheet: node rules match the base rules' specificity and print after them, so a plain `@media` in `frontend.css` would silently lose.

## Fix: filter bar selected cards by class name

`initCommitFilter` collected cards via a hardcoded `.ds-commit-card,.ds-commit-row,.ds-commit-action` list. The strip emits `data-facet` like every other filterable card but was not in that list, so `cards` came back empty: the count rendered **"0 Commitments"** and the empty-state line showed beneath twenty visible cards.

Now it matches on `[data-facet]`, which is the actual contract. Any future card layout that emits the attribute works without touching the JS.

## Verification

`php -l` and `node --check` clean. Verified live on 495lacrosse.com `/commitments/`, desktop and mobile: 20 strips, all 20 college logos and all 20 club marks loading, card links resolving, and All / D2 / D3 / MCLA filtering to 20 / 4 / 14 / 2 with the count tracking correctly at both viewports.

Existing instances are unaffected — this is an additive layout; no current layout's defaults changed.
