### PR TITLE
chore: release 1.9.84 — cut a build carrying the Compact Strip layout

### DIFF
--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.83
+ * Version:           1.9.84
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.83' );
+define( 'DS_TOOLKIT_VERSION', '1.9.84' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
PR #121 (Athletes: Compact Strip) squash-merged just after v1.9.83 was cut, and the squash resolved its version bump down to 1.9.83 to match main. The layout is on main but in no released zip, so fleet sites cannot install it.

Bumps the plugin header and `DS_TOOLKIT_VERSION` together so a 1.9.84 release can be cut. No code changes.
