### PR TITLE
feat: Bento Grid flexible cards — treatments, overlay, hover, and the dropped title (GH #123) (1.9.85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.85] - 2026-08-10
+### Fixed
+- **CTA Bento Grid: an image cell was silently dropping its Title, Description and Link Text (GH #123).** Only the eyebrow ever reached the page, so anything else typed on an image cell disappeared with no warning. All of it renders now, in a content block over the image. **This is visible on existing sites:** any Bento image cell that already has a Title stored starts showing it on update, which is the point of the fix. The blueprint's own Home page is an example — its three image cells carried titles and buttons that were never drawn. A cell carrying *only* an eyebrow is untouched and still renders the corner pill exactly as before, and text cells keep their original markup down to the DOM nesting, because the existing flex rules lay out their direct children.
+
+### Added
+- **CTA Bento Grid: per-card treatments, so one grid can mix card styles (GH #123).** A **Treatment** control per card offers Automatic (the existing look, so nothing changes by default), *Dark background / light text*, *Light background / dark text*, and *Brand accent / light text*. One grid can now hold an image card, a light card and a brand-colour feature card without splitting into separate CTA modules. Per-card **Background Colour** and **Text Colour** override the treatment where a build needs something specific, and an **Image Overlay** control (blank = automatic: none for a bare eyebrow pill, 45% once the card carries a title) keeps text readable over a photo. On an accent card the button and badge invert to white so they do not vanish into the background.
+- **CTA Bento Grid: per-card Number and Badge fields**, for an index like `01` and a pill label like `NEW`.
+- **CTA Bento Grid: hover on every card.** Previously only an image cell that was *also a link* responded, so solid cards had no hover at all. A module-level **Card Hover** control offers *Lift + shadow (image cards also zoom)*, *Image zoom only*, or *None*, and every card reacts to hovering anywhere on itself. Skipped under `prefers-reduced-motion`.
+
+### Notes
+- Column Span and Row Span already existed per card and were verified working (a 2x2 and a 1x1 in the same grid). They live under the **Bento (Style 3)** tab inside each card, which is easy to miss, and every card is forced to 1x1 below the tablet breakpoint so a phone never overflows — which can read as "spans do nothing" when judged on a narrow window. Their help text now says both things.
+
+## [1.9.84] - 2026-08-10
+### Added
+- **Post Loop: Athletes "Compact Strip" layout.** A fifth Athlete card layout — a short, dense row (college logo left, athlete name and college centre, club mark right) instead of a tall photo card, for pages listing many commitments. The club mark falls back to the site's ACF `partner_logo` option, so the layout is correct on any fleet site with no configuration; the module's own Club Logo field overrides it per instance. (Released as a build-only cut: the layout merged just after v1.9.83 was tagged and so shipped in no zip.)
+
 ## [1.9.83] - 2026-08-08
 ### Added
 - **Images/Videos Carousel: the caption pill accepts an image as well as text (GH #109).** Each slide on the Stacked Deck layout gains a **Caption Image** field, so a pill can carry a sponsor logo or club crest beside its label, in place of it, or with no label at all. Set the image and leave the caption blank for an image-only pill; the pill now renders whenever *either* is filled. Size and arrangement are set once on the module rather than per slide, so pills line up however different the source logos are: **Caption Image Height** (default 22px, responsive), **Caption Image Max Width** (default 90px, responsive) and **Caption Image Placement** (left of, right of, or above the text — it only applies to slides that have both). Alt text comes from the attachment's own alt, falling back to the caption text only when the image has none, so a pill with both parts does not announce the same words twice. Text-only pills are byte-identical to before, and a layout saved before this release is unaffected.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.84
+ * Version:           1.9.85
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.84' );
+define( 'DS_TOOLKIT_VERSION', '1.9.85' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-cta/css/frontend.css
+++ b/modules/ds-cta/css/frontend.css
@@ -65,7 +65,7 @@
 .ds-cta--style3 .ds-cta-bento-cell{position:relative;overflow:hidden;border-radius:var(--ds-radius);text-decoration:none;display:flex;}
 .ds-cta--style3 .ds-cta-bento-img{background:var(--fl-global-dark-background);}
 .ds-cta--style3 .ds-cta-bento-bg{position:absolute;inset:0;background-position:center;background-size:cover;background-repeat:no-repeat;transition:transform .6s ease;}
-.ds-cta--style3 a.ds-cta-bento-img:hover .ds-cta-bento-bg{transform:scale(1.05);}
+
 .ds-cta--style3 .ds-cta-bento-text{flex-direction:column;justify-content:center;background:var(--fl-global-dark-background);color:var(--fl-global-white);padding:34px;}
 .ds-cta--style3 .ds-cta-bento-title{font-size:1.6rem;line-height:1;text-transform:uppercase;font-weight:800;margin:0 0 12px;color:var(--fl-global-white);}
 .ds-cta--style3 .ds-cta-bento-celldesc{color:#c7ccd2;font-size:.95rem;line-height:1.5;margin-bottom:18px;}
@@ -75,6 +75,51 @@
 .ds-cta--style3 .ds-cta-bento-btn:hover{filter:brightness(1.08);transform:translateY(-1px);}
 /* Cell eyebrow: small accent label in text cells; overlay pill on image cells. */
 .ds-cta--style3 .ds-cta-bento-eyebrow{font-size:.75rem;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--fl-global-accent);margin:0 0 10px;}
+/* ---- Bento flexible cards (GH #123) ---------------------------------------
+   Treatments let ONE grid mix an image card, a light card and a brand-colour
+   feature card. Literal fallbacks throughout: --fl-global-* is absent on older
+   Launchpad builds, and CSS drops a declaration whose var() cannot resolve. */
+/* Doubled class on purpose (0,3,0): includes/frontend.css.php emits the module-wide
+   cell background as `.fl-node-<id> .ds-cta-bento-text` at (0,2,0), AFTER this file,
+   so a single-class treatment tied on specificity and lost on source order. */
+.ds-cta--style3 .ds-cta-bento-cell.ds-cta-bento-cell--dark{background:var(--fl-global-dark-background,#101631);color:var(--fl-global-white,#fff);}
+.ds-cta--style3 .ds-cta-bento-cell.ds-cta-bento-cell--light{background:var(--fl-global-white,#fff);color:var(--fl-global-heading-color,#101631);}
+.ds-cta--style3 .ds-cta-bento-cell.ds-cta-bento-cell--accent{background:var(--fl-global-accent,#0b782d);color:var(--fl-global-white,#fff);}
+/* Two classes deep so a per-card treatment beats the module-wide title/desc
+   colours emitted at (0,2,0) from includes/frontend.css.php. */
+.ds-cta--style3 .ds-cta-bento-cell--dark .ds-cta-bento-title,.ds-cta--style3 .ds-cta-bento-cell--dark .ds-cta-bento-celldesc,
+.ds-cta--style3 .ds-cta-bento-cell--light .ds-cta-bento-title,.ds-cta--style3 .ds-cta-bento-cell--light .ds-cta-bento-celldesc,
+.ds-cta--style3 .ds-cta-bento-cell--accent .ds-cta-bento-title,.ds-cta--style3 .ds-cta-bento-cell--accent .ds-cta-bento-celldesc{color:inherit;}
+
+/* Overlay behind the content of an image card, so a title stays readable. */
+.ds-cta--style3 .ds-cta-bento-ov{position:absolute;inset:0;z-index:0;pointer-events:none;background:var(--ds-bento-ovc,#101631);opacity:var(--ds-bento-ov,0);transition:opacity .3s ease;}
+/* Content block for image cards. Text cards keep their original direct-child
+   flex layout untouched. */
+.ds-cta--style3 .ds-cta-bento-img .ds-cta-bento-content{position:relative;z-index:1;display:flex;flex-direction:column;align-items:flex-start;justify-content:flex-end;gap:9px;width:100%;padding:28px;color:var(--fl-global-white,#fff);}
+.ds-cta--style3 .ds-cta-bento-img .ds-cta-bento-content .ds-cta-bento-eyebrow{position:static;padding:0;background:none;border-radius:0;}
+.ds-cta--style3 .ds-cta-bento-img .ds-cta-bento-content .ds-cta-bento-title{margin:0;}
+
+.ds-cta--style3 .ds-cta-bento-num{font-weight:800;font-size:.78rem;letter-spacing:.14em;opacity:.72;}
+.ds-cta--style3 .ds-cta-bento-badge{align-self:flex-start;display:inline-block;padding:5px 11px;border-radius:999px;background:var(--fl-global-accent,#0b782d);color:var(--fl-global-white,#fff);font-weight:700;font-size:.66rem;letter-spacing:.12em;text-transform:uppercase;}
+.ds-cta--style3 .ds-cta-bento-cell--accent .ds-cta-bento-badge{background:var(--fl-global-white,#fff);color:var(--fl-global-accent,#0b782d);}
+/* The button is accent-on-accent on an accent card, so it inverts. Two classes
+   to clear the (0,2,0) button rule this file already sets. */
+.ds-cta--style3 .ds-cta-bento-cell--accent .ds-cta-bento-btn{background:var(--fl-global-white,#fff);color:var(--fl-global-accent,#0b782d);}
+
+/* Hover: every card responds to its OWN hover, link or not (GH #123 item 5). */
+@media (hover:hover){
+	.ds-cta--style3 .ds-cta-bento--hover-lift .ds-cta-bento-cell{transition:transform .3s ease,box-shadow .3s ease;}
+	.ds-cta--style3 .ds-cta-bento--hover-lift .ds-cta-bento-cell:hover{transform:translateY(-4px);box-shadow:0 14px 34px rgba(15,18,24,.18);}
+	.ds-cta--style3 .ds-cta-bento--hover-lift .ds-cta-bento-img:hover .ds-cta-bento-bg,
+	.ds-cta--style3 .ds-cta-bento--hover-zoom .ds-cta-bento-img:hover .ds-cta-bento-bg{transform:scale(1.05);}
+	.ds-cta--style3 .ds-cta-bento--hover-lift .ds-cta-bento-img:hover .ds-cta-bento-ov,
+	.ds-cta--style3 .ds-cta-bento--hover-zoom .ds-cta-bento-img:hover .ds-cta-bento-ov{opacity:calc(var(--ds-bento-ov,0) + .12);}
+}
+@media (prefers-reduced-motion:reduce){
+	.ds-cta--style3 .ds-cta-bento-cell,.ds-cta--style3 .ds-cta-bento-bg,.ds-cta--style3 .ds-cta-bento-ov{transition:none;}
+	.ds-cta--style3 .ds-cta-bento--hover-lift .ds-cta-bento-cell:hover{transform:none;box-shadow:none;}
+	.ds-cta--style3 .ds-cta-bento-img:hover .ds-cta-bento-bg{transform:none;}
+}
 .ds-cta--style3 .ds-cta-bento-img .ds-cta-bento-eyebrow{position:absolute;left:14px;bottom:12px;z-index:1;margin:0;padding:7px 13px;border-radius:999px;background:color-mix(in srgb, var(--fl-global-dark-background) 78%, transparent);color:var(--fl-global-white);}
 
 /* ---- Style 4: Big Hero contact CTA (sub-heading, heading, partner contact + social, big button over a background image) ---- */

--- a/modules/ds-cta/ds-cta.php
+++ b/modules/ds-cta/ds-cta.php
@@ -284,22 +284,47 @@ class DS_CTA_Module extends FLBuilderModule {
 
 		$arrow = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>';
 
-		echo '<div class="ds-cta-bento">';
+		// Hover behaviour is module-wide; every cell responds to its own hover.
+		$hover = in_array( $s->bento_hover ?? 'lift', array( 'lift', 'zoom', 'none' ), true ) ? ( $s->bento_hover ?? 'lift' ) : 'lift';
+
+		echo '<div class="ds-cta-bento ds-cta-bento--hover-' . esc_attr( $hover ) . '">';
 		foreach ( $cards as $cell ) {
 			$cell = (object) $cell;
 			$cs   = max( 1, (int) ( $cell->col_span ?? 1 ) );
 			$rs   = max( 1, (int) ( $cell->row_span ?? 1 ) );
-			$span = ' style="grid-column:span ' . $cs . ';grid-row:span ' . $rs . ';"';
 			$type = ( ( $cell->type ?? 'image' ) === 'text' ) ? 'text' : 'image';
 			list( $url, $target ) = $this->link_parts( $cell->link ?? '' );
 			$rel = '_blank' === $target ? ' rel="noopener noreferrer"' : '';
 
+			$eyebrow = trim( (string) ( $cell->eyebrow ?? '' ) );
+			$title   = trim( (string) ( $cell->title ?? '' ) );
+			$desc    = trim( (string) ( $cell->desc ?? '' ) );
+			$num     = trim( (string) ( $cell->number ?? '' ) );
+			$badge   = trim( (string) ( $cell->badge ?? '' ) );
+			$lt      = trim( (string) ( $cell->link_text ?? '' ) );
+
+			// Colour scheme for this cell. 'auto' is the historical look, so a card
+			// saved before this release renders exactly as it did.
+			$tr  = in_array( $cell->treatment ?? 'auto', array( 'auto', 'dark', 'light', 'accent' ), true ) ? ( $cell->treatment ?? 'auto' ) : 'auto';
+			$cls = 'ds-cta-bento-cell ds-cta-bento-' . ( 'text' === $type ? 'text' : 'img' );
+			if ( 'auto' !== $tr ) { $cls .= ' ds-cta-bento-cell--' . $tr; }
+
+			$style = 'grid-column:span ' . $cs . ';grid-row:span ' . $rs . ';';
+			$cbg   = DS_Module_UI::color( $cell->cell_bg ?? '' );
+			if ( '' !== $cbg ) { $style .= 'background:' . $cbg . ';'; }
+			$ctx = DS_Module_UI::color( $cell->cell_text ?? '' );
+			if ( '' !== $ctx ) { $style .= 'color:' . $ctx . ';'; }
+
 			if ( 'text' === $type ) {
-				echo '<div class="ds-cta-bento-cell ds-cta-bento-text"' . $span . '>';
-				if ( ! empty( $cell->eyebrow ) ) { echo '<div class="ds-cta-bento-eyebrow">' . DS_Module_UI::inline( $cell->eyebrow ) . '</div>'; }
-				if ( ! empty( $cell->title ) ) { echo '<h3 class="ds-cta-bento-title">' . DS_Module_UI::inline( $cell->title ) . '</h3>'; }
-				if ( ! empty( $cell->desc ) ) { echo '<div class="ds-cta-bento-celldesc">' . wpautop( wp_kses_post( $cell->desc ) ) . '</div>'; }
-				$lt = trim( (string) ( $cell->link_text ?? '' ) );
+				// Markup order and nesting kept identical to before — the existing
+				// .ds-cta-bento-text flex rules lay out these DIRECT children, so a
+				// wrapper here would silently re-flow every Bento already in the fleet.
+				echo '<div class="' . esc_attr( $cls ) . '" style="' . esc_attr( $style ) . '">';
+				if ( '' !== $num )     { echo '<span class="ds-cta-bento-num">' . esc_html( $num ) . '</span>'; }
+				if ( '' !== $badge )   { echo '<span class="ds-cta-bento-badge">' . esc_html( $badge ) . '</span>'; }
+				if ( '' !== $eyebrow ) { echo '<div class="ds-cta-bento-eyebrow">' . DS_Module_UI::inline( $eyebrow ) . '</div>'; }
+				if ( '' !== $title )   { echo '<h3 class="ds-cta-bento-title">' . DS_Module_UI::inline( $title ) . '</h3>'; }
+				if ( '' !== $desc )    { echo '<div class="ds-cta-bento-celldesc">' . wpautop( wp_kses_post( $desc ) ) . '</div>'; }
 				if ( '' !== $lt ) {
 					echo '<a class="ds-cta-bento-btn" href="' . $url . '" target="' . esc_attr( $target ) . '"' . $rel . '>' . esc_html( $lt ) . '</a>';
 				}
@@ -309,9 +334,43 @@ class DS_CTA_Module extends FLBuilderModule {
 				$has  = ( $url && '#' !== $url );
 				$tag  = $has ? 'a' : 'div';
 				$attr = $has ? ' href="' . $url . '" target="' . esc_attr( $target ) . '"' . $rel : '';
-				echo '<' . $tag . ' class="ds-cta-bento-cell ds-cta-bento-img"' . $span . $attr . '>';
+
+				// GH #123: image cells used to render the eyebrow and nothing else, so a
+				// Title / Description / Link Text typed on one silently vanished. They
+				// render now, in a content block over the image.
+				$block = ( '' !== $title || '' !== $desc || '' !== $num || '' !== $badge || '' !== $lt );
+
+				// Blank overlay means "decide from the content": a bare eyebrow is a pill
+				// with its own backing, so it needs none and stays pixel-identical to
+				// before; a title over a photo is unreadable without one.
+				$ovr = $cell->cell_overlay ?? '';
+				$ov  = ( '' === $ovr || null === $ovr ) ? ( $block ? 45 : 0 ) : max( 0, min( 100, (int) $ovr ) );
+				if ( $ov > 0 ) { $style .= '--ds-bento-ov:' . round( $ov / 100, 2 ) . ';'; }
+
+				echo '<' . $tag . ' class="' . esc_attr( $cls ) . '" style="' . esc_attr( $style ) . '"' . $attr . '>';
 				echo '<div class="ds-cta-bento-bg"' . ( $img ? ' style="background-image:url(' . esc_url( $img ) . ')"' : '' ) . '></div>';
-				if ( ! empty( $cell->eyebrow ) ) { echo '<div class="ds-cta-bento-eyebrow">' . esc_html( $cell->eyebrow ) . '</div>'; }
+				if ( $ov > 0 ) { echo '<div class="ds-cta-bento-ov"></div>'; }
+
+				if ( $block ) {
+					echo '<div class="ds-cta-bento-content">';
+					if ( '' !== $num )     { echo '<span class="ds-cta-bento-num">' . esc_html( $num ) . '</span>'; }
+					if ( '' !== $badge )   { echo '<span class="ds-cta-bento-badge">' . esc_html( $badge ) . '</span>'; }
+					if ( '' !== $eyebrow ) { echo '<div class="ds-cta-bento-eyebrow">' . DS_Module_UI::inline( $eyebrow ) . '</div>'; }
+					if ( '' !== $title )   { echo '<h3 class="ds-cta-bento-title">' . DS_Module_UI::inline( $title ) . '</h3>'; }
+					if ( '' !== $desc )    { echo '<div class="ds-cta-bento-celldesc">' . wpautop( wp_kses_post( $desc ) ) . '</div>'; }
+					if ( '' !== $lt ) {
+						// The whole cell is already the anchor when it has a link, and an
+						// anchor inside an anchor is invalid HTML that browsers unnest.
+						echo 'a' === $tag
+							? '<span class="ds-cta-bento-btn">' . esc_html( $lt ) . '</span>'
+							: '<a class="ds-cta-bento-btn" href="' . $url . '" target="' . esc_attr( $target ) . '"' . $rel . '>' . esc_html( $lt ) . '</a>';
+					}
+					echo '</div>';
+				} elseif ( '' !== $eyebrow ) {
+					// Unchanged: the standalone corner pill, for image cells that carry
+					// nothing but an eyebrow.
+					echo '<div class="ds-cta-bento-eyebrow">' . esc_html( $eyebrow ) . '</div>';
+				}
 				echo '</' . $tag . '>';
 			}
 		}
@@ -479,17 +538,36 @@ FLBuilder::register_settings_form( 'ds_cta_card_form', array(
 				'bento' => array(
 					'title'  => __( 'Bento (Style 3)', 'ds-toolkit' ),
 					'fields' => array(
-						'type'     => array(
+						'type'      => array(
 							'type'    => 'select',
 							'label'   => __( 'Cell Type', 'ds-toolkit' ),
 							'default' => 'image',
 							'options' => array( 'image' => __( 'Image', 'ds-toolkit' ), 'text' => __( 'Text / CTA', 'ds-toolkit' ) ),
-							'toggle'  => array( 'text' => array( 'fields' => array( 'desc' ) ) ),
-							'help'    => __( 'Bento (Style 3) only. Image cells use the Background Image; Text cells use Title + Description + the Link Text button.', 'ds-toolkit' ),
+							// 'desc' is no longer toggled off for image cells: they render
+							// Title / Description / Link Text now too (GH #123).
+							'toggle'  => array( 'image' => array( 'fields' => array( 'cell_overlay' ) ) ),
+							'help'    => __( 'Bento (Style 3) only. Image cells sit on the Background Image with an overlay; Text cells sit on the Treatment background. Both render Eyebrow, Title, Description and the Link Text button.', 'ds-toolkit' ),
 						),
-						'desc'     => array( 'type' => 'editor', 'media_buttons' => false, 'rows' => 6, 'wpautop' => false, 'label' => __( 'Description', 'ds-toolkit' ) ),
-						'col_span' => array( 'type' => 'unit', 'label' => __( 'Column Span', 'ds-toolkit' ), 'default' => '1', 'slider' => array( 'min' => 1, 'max' => 4, 'step' => 1 ) ),
-						'row_span' => array( 'type' => 'unit', 'label' => __( 'Row Span', 'ds-toolkit' ), 'default' => '1', 'slider' => array( 'min' => 1, 'max' => 3, 'step' => 1 ) ),
+						'desc'      => array( 'type' => 'editor', 'media_buttons' => false, 'rows' => 6, 'wpautop' => false, 'label' => __( 'Description', 'ds-toolkit' ) ),
+						'number'    => array( 'type' => 'text', 'label' => __( 'Number', 'ds-toolkit' ), 'connections' => array( 'string' ), 'help' => __( 'Optional index shown above the eyebrow, e.g. 01. Free text, so 01 / A / 1 of 4 all work.', 'ds-toolkit' ) ),
+						'badge'     => array( 'type' => 'text', 'label' => __( 'Badge', 'ds-toolkit' ), 'connections' => array( 'string' ), 'help' => __( 'Optional pill label, e.g. NEW or SOLD OUT.', 'ds-toolkit' ) ),
+						'treatment' => array(
+							'type'    => 'select',
+							'label'   => __( 'Treatment', 'ds-toolkit' ),
+							'default' => 'auto',
+							'options' => array(
+								'auto'   => __( 'Automatic (module colours)', 'ds-toolkit' ),
+								'dark'   => __( 'Dark background, light text', 'ds-toolkit' ),
+								'light'  => __( 'Light background, dark text', 'ds-toolkit' ),
+								'accent' => __( 'Brand accent, light text', 'ds-toolkit' ),
+							),
+							'help'    => __( 'Lets one grid mix an image card, a light card and a brand-colour feature card without needing separate modules. Automatic keeps the module-wide colours, so existing layouts are unchanged.', 'ds-toolkit' ),
+						),
+						'cell_bg'   => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Background Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true, 'help' => __( 'Overrides the Treatment background for this card only. On an image card it shows wherever the image does not cover.', 'ds-toolkit' ) ),
+						'cell_text' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Text Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'help' => __( 'Overrides the Treatment text colour for this card only. Set this if you pick a Background Colour the Treatment was not designed for.', 'ds-toolkit' ) ),
+						'cell_overlay' => array( 'type' => 'unit', 'label' => __( 'Image Overlay', 'ds-toolkit' ), 'default' => '', 'description' => '%', 'slider' => array( 'min' => 0, 'max' => 100, 'step' => 5 ), 'help' => __( 'Darkens the image so text stays readable. Blank is automatic: none for a card with only an eyebrow pill, 45% once it carries a title or description.', 'ds-toolkit' ) ),
+						'col_span'  => array( 'type' => 'unit', 'label' => __( 'Column Span', 'ds-toolkit' ), 'default' => '1', 'slider' => array( 'min' => 1, 'max' => 4, 'step' => 1 ), 'help' => __( 'How many grid columns this card occupies. Combine with Row Span for a 2x2 feature card, a 2x1 wide card, or a 1x2 tall card. Every card drops to 1x1 below the tablet breakpoint so nothing overflows on a phone.', 'ds-toolkit' ) ),
+						'row_span'  => array( 'type' => 'unit', 'label' => __( 'Row Span', 'ds-toolkit' ), 'default' => '1', 'slider' => array( 'min' => 1, 'max' => 3, 'step' => 1 ) ),
 					),
 				),
 			),
@@ -733,6 +811,17 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 				'title'  => __( 'Bento', 'ds-toolkit' ),
 				'fields' => array(
 					'row_height' => array( 'type' => 'unit', 'label' => __( 'Row Height', 'ds-toolkit' ), 'default' => '220', 'description' => 'px', 'responsive' => true, 'slider' => array( 'min' => 120, 'max' => 400, 'step' => 10 ) ),
+					'bento_hover' => array(
+						'type'    => 'select',
+						'label'   => __( 'Card Hover', 'ds-toolkit' ),
+						'default' => 'lift',
+						'options' => array(
+							'lift' => __( 'Lift + shadow (image cards also zoom)', 'ds-toolkit' ),
+							'zoom' => __( 'Image zoom only', 'ds-toolkit' ),
+							'none' => __( 'None', 'ds-toolkit' ),
+						),
+						'help'    => __( 'Applies to every card, image or solid, and responds to hovering anywhere on the card rather than only on a link. Skipped for visitors who ask for reduced motion.', 'ds-toolkit' ),
+					),
 					'bento_radius' => array( 'type' => 'unit', 'label' => __( 'Cell Corner Radius', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 40, 'step' => 1 ), 'help' => __( 'Rounds every bento cell (image + text cells).', 'ds-toolkit' ) ),
 					'bento_border_width' => array( 'type' => 'unit', 'label' => __( 'Cell Border Width', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'slider' => array( 'min' => 0, 'max' => 10, 'step' => 1 ), 'help' => __( 'Border around every bento cell. Blank or 0 = no border.', 'ds-toolkit' ) ),
 					'bento_border_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Cell Border Colour', 'ds-toolkit' ), 'default' => 'var(--fl-global-line-color)', 'show_reset' => true, 'show_alpha' => true ),

--- a/modules/ds-cta/includes/frontend.css.php
+++ b/modules/ds-cta/includes/frontend.css.php
@@ -125,6 +125,11 @@ if ( 'style3' === $style ) {
 	} elseif ( $accent ) {
 		echo "$node .ds-cta-bento-btn { background: {$accent} !important; color: var(--fl-global-white) !important; }\n";
 	}
+	// An accent-treatment card paints the button colour as its own background, so the
+	// button would be accent-on-accent. Emitted here rather than in css/frontend.css
+	// because both branches above use !important to beat the theme's button rules —
+	// a static rule cannot outrank that, however specific. (0,3,0) so it beats them.
+	echo "$node .ds-cta-bento-cell--accent .ds-cta-bento-btn { background: var(--fl-global-white,#fff) !important; color: " . ( $accent ? $accent : 'var(--fl-global-accent,#0b782d)' ) . " !important; }\n";
 
 	$typo = array( 'heading_typography' => '.ds-cta-heading', 'title_typography' => '.ds-cta-bento-title', 'eyebrow_typography' => '.ds-cta-bento-desc' );
 } elseif ( 'style2' === $style ) {


### PR DESCRIPTION
Closes #123.

I checked each of the six requirements against the running code rather than reading it. **Two already shipped, one was a real bug, three were missing.**

| # | Requirement | Before | Now |
|---|---|---|---|
| 1 | Independent Column Span | **already existed** | help text explains where it lives |
| 2 | Independent Row Span | **already existed** | same |
| 3 | Per-card background | missing | Treatment + Background Colour + Image Overlay |
| 4 | Per-card content, "Title must render" | **BUG** | fixed, plus Number and Badge |
| 5 | Per-card hover on image *and* solid cards | partial | every card, module-level control |
| 6 | Mixed card styles in one grid | missing | four treatments |

## The bug

Image cells rendered the eyebrow and closed the tag. Title, Description and Link Text were never emitted, so anything typed on an image cell vanished silently. Same settings, both cell types:

| Field | Image cell (before) | Text cell |
|---|---|---|
| Eyebrow | RENDERED | RENDERED |
| Title | **MISSING** | RENDERED |
| Description | **MISSING** | RENDERED |
| Link text | **MISSING** | RENDERED |

**This is visible on existing sites.** Any Bento image cell that already has a Title stored starts showing it on update — that is the point of the fix, but it is a change people will see. The blueprint's own Home page is an example: its three image cells carried `Dolor Sit` / `Tempor` / `Ut Labore` and an `Express Interest` button that were never drawn. After the fix they render over a dimmed image and match the text cells beside them.

## Backward compatibility was the constraint

- An image cell carrying **only** an eyebrow keeps the standalone corner pill and gets **no overlay** — pixel-identical to before.
- **Text cells keep their original markup down to the DOM nesting.** The existing `.ds-cta-bento-text` flex rules lay out *direct children*, so wrapping them would have silently re-flowed every Bento in the fleet.
- `Treatment` defaults to `auto`, which is the historical look.
- The whole-cell anchor case is guarded: the button renders as a `span` inside a linked cell, because an anchor inside an anchor is invalid HTML that browsers unnest.

## What was added

**Per card:** Treatment (Automatic / Dark / Light / Brand accent), Background Colour, Text Colour, Image Overlay (blank = automatic: none for a bare pill, 45% once there is a title), Number, Badge.

**Module-wide:** Card Hover — *Lift + shadow (image cards also zoom)*, *Image zoom only*, or *None*. Previously only an image cell that was **also a link** responded, so solid cards had no hover at all. Skipped under `prefers-reduced-motion`.

On an accent card the button and badge invert to white, otherwise they disappear into the background.

## Two specificity fights, both won deliberately

1. **Treatments needed (0,3,0).** `includes/frontend.css.php` emits the module-wide cell background as `.fl-node-<id> .ds-cta-bento-text` at (0,2,0), *after* `css/frontend.css`, so a single-class treatment tied on specificity and lost on source order. The Light card rendered dark until this was fixed.
2. **The accent button is emitted from the dynamic pass**, because both button branches there use `!important` to beat the theme's button rules, which no static rule can outrank however specific.

## Verified on ds-launchpad-6

| Check | Result |
|---|---|
| Image cell: title / desc / link text | all RENDERED |
| Nested `<a>` inside `<a>` | none |
| Image cell with **only** an eyebrow | standalone pill kept, no overlay, no content block |
| Text cell markup | no wrapper, eyebrow still a direct child |
| Four treatments in one grid | `--dark` / `--light` / `--accent` each once, plus a custom `#ff8800` card |
| Spans | 2x2 and 1x1 in the same grid |
| Hover setting | `lift` / `zoom` / `none` all emit correctly |
| **Solid non-link card lifts on hover** | 4px |
| Light card computed background | `rgb(255,255,255)` with dark text |
| Accent button computed | white on green (was green on green) |
| Number + badge | render |
| Mobile | stacks to 1x1, all treatments intact |
| **Blueprint Home page** | 5 CTA blocks, 9 bento cells, 0 PHP diagnostics |
| PHP lint, all tracked files | clean |
| Console errors | none |

Also restores the missing **1.9.84** changelog entry — that release shipped with no entry.

Test page and orphaned builder history were removed from the Local blueprint afterwards.
