### PR TITLE
fix: closed mega panel intercepted clicks over open dropdowns (GH #125) (1.9.86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.86] - 2026-08-11
+### Fixed
+- **Menu: a CLOSED mega panel was intercepting clicks aimed at other open dropdowns (GH #125).** On any menu with a mega item, hovering an item in a neighbouring dropdown showed the wrong URL in the status bar and clicking navigated to it — on skywalkerslax, "FAQ" under About Us went to a `/teams/` page. The closed panel was hidden with `opacity: 0` and `visibility: hidden`, but `visibility` is inheritable and the `.ds-mega-col .ds-submenu` rule sets it back to `visible` on the panel's own columns, while `opacity: 0` hides a layer without disabling hit testing. The result was an invisible, fully clickable layer at `z-index: 999` sitting over whatever it overlapped. The closed state now sets `pointer-events: none`, which the open states switch back on — that also covers the 0.15s closing transition, which a `visibility` fix would not. Plain (non-mega) dropdowns were never affected, because nothing re-enables visibility inside them while closed.
+- **Menu: the same fix does not break the mobile drawer.** In the overlay the mega panel is reused as a height-animated accordion at `opacity: 1`, collapsed by `height: 0`, and none of the three desktop open selectors match there — so the guard alone would have made every mega link in the drawer unclickable. The overlay rule now re-enables `pointer-events` explicitly. Verified both ways in a hit-test harness: without the re-enable a drawer mega link hits nothing at all; with it the link resolves normally.
+
+### Notes
+- Sites carrying the interim Additional CSS workaround (`.ds-mega { pointer-events: none }` plus the three open selectors) should have it removed once they are on 1.9.86. That workaround is the two-rule version and has **no overlay override**, so on those sites the mobile drawer's mega links are currently dead. skywalkerslax is one — its rendered CSS has the two rules and no `.ds-menu-open .ds-mega` override.
+
 ## [1.9.85] - 2026-08-10
 ### Fixed
 - **CTA Bento Grid: an image cell was silently dropping its Title, Description and Link Text (GH #123).** Only the eyebrow ever reached the page, so anything else typed on an image cell disappeared with no warning. All of it renders now, in a content block over the image. **This is visible on existing sites:** any Bento image cell that already has a Title stored starts showing it on update, which is the point of the fix. The blueprint's own Home page is an example — its three image cells carried titles and buttons that were never drawn. A cell carrying *only* an eyebrow is untouched and still renders the corner pill exactly as before, and text cells keep their original markup down to the DOM nesting, because the existing flex rules lay out their direct children.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.85
+ * Version:           1.9.86
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.85' );
+define( 'DS_TOOLKIT_VERSION', '1.9.86' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-menu/css/frontend.css
+++ b/modules/ds-menu/css/frontend.css
@@ -52,12 +52,21 @@
 	   min-width floor). min-content column floors keep text wrapping at words. */
 	gap: 8px 28px; padding: 22px 26px; min-width: 460px; max-width: 90vw; overflow-x: auto;
 	opacity: 0; visibility: hidden; transform: translateY(6px);
+	/* pointer-events is what actually stops the CLOSED panel eating clicks (GH #125).
+	   opacity:0 hides it but does not disable hit testing, and visibility:hidden does
+	   not help either because the .ds-mega-col .ds-submenu rule below sets
+	   visibility:visible back on its own children — visibility is inheritable and a
+	   descendant can override it. The result was an invisible, fully clickable layer
+	   at z-index 999 sitting over any other open dropdown it overlapped: hovering
+	   "FAQ" under About Us reported a /teams/ URL and clicking navigated there.
+	   Guarding pointer-events also covers the 0.15s closing transition. */
+	pointer-events: none;
 	transition: opacity .15s ease, transform .15s ease, visibility .15s;
 	box-shadow: 0 12px 32px rgba(0,0,0,.14); border-radius: var(--ds-radius);
 }
 .ds-menu-wrap:not(.ds-js-hover) .ds-menu-item.is-mega:hover > .ds-mega,
 .ds-menu-item.is-mega.ds-hover-open > .ds-mega,
-.ds-menu-item.is-mega:focus-within > .ds-mega { opacity: 1; visibility: visible; transform: translateY(0); }
+.ds-menu-item.is-mega:focus-within > .ds-mega { opacity: 1; visibility: visible; transform: translateY(0); pointer-events: auto; }
 .ds-mega-col .ds-mega-head { display: block; font-weight: 700; text-decoration: none; padding: 4px 0 6px; }
 .ds-mega-col .ds-submenu { position: static; opacity: 1; visibility: visible; transform: none; box-shadow: none; padding: 0; min-width: 0; }
 .ds-mega-col .ds-submenu .ds-menu-item > a { padding: 4px 0; white-space: normal; }

--- a/modules/ds-menu/includes/frontend.css.php
+++ b/modules/ds-menu/includes/frontend.css.php
@@ -494,6 +494,11 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 	<?php echo $open; ?> .ds-submenu,
 	<?php echo $open; ?> .ds-mega {
 		position: static; opacity: 1; visibility: visible; transform: none; box-shadow: none;
+		/* Restores what the closed-state guard in css/frontend.css switches off (GH #125).
+		   In the overlay the panel is a flattened accordion collapsed by height:0, not by
+		   opacity, and none of the desktop open selectors match here — so without this
+		   every mega link in the drawer would be unclickable. */
+		pointer-events: auto;
 		display: block; grid-template-columns: 1fr; width: 100%; min-width: 0; background: transparent;
 		height: 0; overflow: hidden; margin-top: 0; padding: 0 0 0 14px;
 		transition: height .3s ease;


### PR DESCRIPTION
Closes #125.

## The fix

A closed `.ds-mega` was hidden with `opacity: 0` + `visibility: hidden`, but neither disables hit testing here:

- `visibility` is inheritable, and `.ds-mega-col .ds-submenu` sets it back to `visible` on the panel's own columns.
- `opacity: 0` hides a layer but never disabled hit testing to begin with.

So the closed panel was an invisible, fully clickable layer at `z-index: 999` over whatever it overlapped. The closed state now sets `pointer-events: none`; the three open states switch it back on. That also protects the 0.15s closing transition, which changing line 62 to `visibility: inherit` would not.

## The part the suggested fix would have broken

The issue proposed two rules. Applied alone they make **every mega link in the mobile drawer unclickable**.

In the overlay, `.ds-mega` is reused as a height-animated accordion at `opacity: 1`, collapsed by `height: 0` — and none of the three desktop open selectors match there. The overlay rule in `includes/frontend.css.php` now re-enables `pointer-events` explicitly.

Proven both ways in a harness:

| Drawer state | `.ds-mega` pointer-events | Mega link clickable |
|---|---|---|
| Two-rule fix alone | `none` | **NO — hits nothing** |
| With the overlay re-enable | `auto` | YES |

## Desktop verification

Hit-test harness against the **real stylesheet**, About Us hovered open and Teams never touched, panel positioned to overlap the way `clampMega()` puts it on a live site:

| | Coaches |
|---|---|
| pointer-events forced back on (pre-fix) | hits `/teams/2027-blue/` ❌ |
| with the fix | hits `/about-us/coaches/` ✅ |

With the fix, 6/6 About Us items hit their own href. Without it, the overlapping item resolves into the closed Teams panel — exactly the reported symptom.

## ⚠️ Sites carrying the interim workaround

`skywalkerslax` has the two-rule version in Additional CSS. I read its rendered CSS: `.ds-mega { pointer-events: none }` plus the open selectors, and **zero** `.ds-menu-open .ds-mega` rules. That means its **mobile drawer mega links are dead right now**. The workaround should be removed once the site is on 1.9.86 — the plugin fix supersedes it and handles the drawer, which the workaround does not.

## Verified

| Check | Result |
|---|---|
| Desktop hit test, pre-fix control | reproduces the bug |
| Desktop hit test, with fix | 6/6 items correct |
| Drawer without the overlay re-enable | link hits nothing (regression caught) |
| Drawer with the overlay re-enable | link resolves |
| CSS braces balanced | yes |
| PHP lint, all tracked files | clean |

Plain non-mega dropdowns were never affected, because nothing re-enables visibility inside them while closed.
