### PR TITLE
docs: explain "The plugin does not have a valid header" on a fresh install

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,28 @@ Alipio Gabriel
 - HTTPS (live sites) — or `define('WP_ENVIRONMENT_TYPE', 'local')` for LocalWP
 - Node.js / npx — required on developer machines for the Claude Desktop MCP connection
 
+## Installing on a new site
+
+Upload the release zip, then **load the Plugins page before clicking Activate.**
+
+Activating straight from the upload screen can fail with:
+
+> The plugin does not have a valid header.
+
+That is a WordPress race, not a broken package. WordPress calls `get_plugins()` early in
+the install request and caches the result for that request; if the snapshot was taken
+before the new folder landed, the activation later in the *same* request consults the
+stale list, does not find `ds-toolkit/ds-toolkit.php`, and reports a missing header. The
+files are complete and correct — the next request rescans and activation succeeds.
+
+Nothing in the plugin can prevent it: `validate_plugin()` runs before any plugin code
+loads, so there is no hook available at that point. Seen on Flywheel (bluespringsbaseball,
+2026-08-13), where the plugin folder, permissions, header and byte count were all verified
+correct while the error was showing.
+
+If it persists *after* a Plugins-page visit, then it is a real problem — check for a folder
+not named `ds-toolkit`, a truncated upload, or permissions stopping PHP reading the header.
+
 ---
 
 ## Plugin Structure


### PR DESCRIPTION
Documents the activation error seen installing on Flywheel (bluespringsbaseball, 2026-08-13).

## Why this is documentation and not a code fix

**The plugin cannot prevent this error.** `validate_plugin()` runs before any plugin code loads — no hook, filter or bootstrap of ours is executing at that point. A release claiming to fix it would change nothing.

## What I verified on the live install

Everything that would make it a real packaging bug was checked and was fine:

| Check | Result |
|---|---|
| Folder name | `wp-content/plugins/ds-toolkit`, single copy, no stale duplicate |
| Permissions | `755` dir, `644` main file, readable |
| Byte-order mark | none — file starts `<?p` |
| Header | parses: DS Toolkit, 1.9.92 |
| File size | **1796 bytes — byte-identical to the repo and the shipped zip** |
| Persistent object cache | **none** |
| Final state | active, `active_plugins` → `ds-toolkit/ds-toolkit.php`, `get_plugins()` sees it |

The file being byte-identical rules out a truncated or partial upload, which was my first theory.

## What actually happens

WordPress calls `get_plugins()` early in the install request and caches the result **for that request**. If the snapshot was taken before the new folder landed, `validate_plugin()` later in the same request consults the stale array, does not find `ds-toolkit/ds-toolkit.php`, and reports a missing header. The next request rescans and activation succeeds — which is exactly the reported sequence.

With no persistent object cache on the site, the stale list cannot survive beyond that one request, which is why loading the Plugins page reliably clears it.

## What the README now says

- Load the Plugins page before clicking Activate on a new install.
- The error is a WordPress race, not a broken package.
- What to check if it ever *persists* past a Plugins-page visit: a folder not named `ds-toolkit`, a truncated upload, or permissions stopping PHP reading the header.

No version bump — documentation only, no shipped code change.