### PR TITLE
feat: Post Loop shows a real notice when the query is empty (1.9.93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.93] - 2026-08-13
+### Fixed
+- **Post Loop: an empty query rendered a heading over blank space.** Seen on `/programs/tournaments/` — the section heading and its rule drew, then nothing. Every layout in this module hid its empty message behind `is_builder_active()`, so an editor got an explanation and visitors got a void. All ten of those branches now render a real notice on the front end.
+
+### Added
+- **Post Loop: a "When There Are No Results" section on the Query tab.** Optional **Badge** (a pill such as COMING SOON), **Heading**, **Description** and **Alignment**, so partners word it themselves. **Existing builds need no configuration**: with nothing set the notice falls back to a "Coming Soon" heading, which is what a fresh install and every current site will show. Set **Show a Notice → No** where an empty loop should collapse silently, which is the pre-1.9.93 behaviour. The builder-only diagnostics are kept and are now shown *alongside* the notice, so an editor sees both what visitors see and why it is empty — those lines ("Publish events with a future Event Date") stay out of the public page, since they are instructions for whoever is building it.
+
 ## [1.9.92] - 2026-08-13
 ### Fixed
 - **Hero: per-module settings were being beaten by the module's own stylesheet on Themer pages (GH #136).** Content Width 1600 with Alignment Center rendered at 760px on the published page while looking correct in the builder. The per-node rules were written `.fl-node-<id> .ds-hero-inner` — two classes, the same specificity as the stylesheet's own `.ds-hero--center .ds-hero-inner{max-width:760px}`. A page that renders a Themer layout **plus** page content loads two Beaver Builder layout stylesheets, and each carries its own copy of the module's static CSS; the second copy lands after the per-node rules, so the tie was decided by source order and the module setting lost. Every node-scoped rule targeting a hero child is now three classes (`.fl-node-<id> .ds-hero .ds-hero-inner`), which settles it whatever the load order. Root-level rules are deliberately left as they were, since nothing static competes with them at that specificity. Reproduced against the real stylesheet under the duplicate-stylesheet condition: 760px before, 1600px after, both collapsing cleanly to the viewport at 700px.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.92
+ * Version:           1.9.93
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.92' );
+define( 'DS_TOOLKIT_VERSION', '1.9.93' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-post-loop/css/frontend.css
+++ b/modules/ds-post-loop/css/frontend.css
@@ -301,3 +301,17 @@
 .ds-teamcard:hover .ds-teamcard-ico{transform:translateX(3px);}
 @media(max-width:1024px){.ds-teamcard-grid{grid-template-columns:repeat(2,1fr);}}
 @media(max-width:600px){.ds-teamcard-grid{grid-template-columns:1fr;}}
+
+/* ---- Empty state (GH: /programs/tournaments/ rendered a heading over blank space) --
+   Shown on the FRONT END when a loop returns nothing, not just in the builder.
+   Literal fallbacks throughout: --fl-global-* is absent on older Launchpad builds and
+   CSS drops a declaration whose var() cannot resolve. */
+.ds-loop-empty{padding:34px 18px;}
+.ds-loop-empty--center{text-align:center;}
+.ds-loop-empty--left{text-align:left;}
+.ds-loop-empty-badge{display:inline-block;margin:0 0 10px;padding:6px 14px;border-radius:999px;background:var(--fl-global-accent,#0b782d);color:var(--fl-global-white,#fff);font-weight:800;font-size:.66rem;letter-spacing:.14em;text-transform:uppercase;line-height:1;}
+.ds-loop-empty-title{margin:0;font-size:1.35rem;line-height:1.25;color:var(--fl-global-headings,#101631);}
+.ds-loop-empty-desc{margin:10px auto 0;max-width:56ch;color:var(--fl-global-body,#4a5568);}
+.ds-loop-empty--left .ds-loop-empty-desc{margin-left:0;}
+.ds-loop-empty-desc p{margin:0 0 .7em;}
+.ds-loop-empty-desc p:last-child{margin-bottom:0;}

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -167,6 +167,47 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		return array( $get( 'inc_' . $key ), $get( 'exc_' . $key ) );
 	}
 
+	/**
+	 * What a visitor sees when the query returns nothing.
+	 *
+	 * Every layout used to hide its empty message behind is_builder_active(), so an
+	 * editor saw an explanation and the public saw a bare heading over blank space
+	 * (reported on /programs/tournaments/). The notice now renders on the front end
+	 * too, worded by the partner rather than by us.
+	 *
+	 * $hint stays builder-only on purpose: "Publish events with a future Event Date"
+	 * is a diagnostic for whoever is building the page, not copy for a visitor. In the
+	 * builder both appear, so an editor sees what the public sees AND why it is empty.
+	 *
+	 * @param string $hint Builder-only diagnostic for this layout.
+	 */
+	private function empty_state( $hint = '' ) {
+		$s    = $this->settings;
+		$show = ( $s->empty_show ?? 'yes' ) === 'yes';
+
+		if ( $show ) {
+			$badge   = trim( (string) ( $s->empty_text ?? '' ) );
+			$heading = trim( (string) ( $s->empty_heading ?? '' ) );
+			$desc    = trim( (string) ( $s->empty_desc ?? '' ) );
+			// Defaults so the notice is never blank on a site that has not touched
+			// these fields — which is every existing build.
+			if ( '' === $badge && '' === $heading && '' === $desc ) {
+				$heading = __( 'Coming Soon', 'ds-toolkit' );
+			}
+			$align = ( ( $s->empty_align ?? 'center' ) === 'left' ) ? 'left' : 'center';
+
+			echo '<div class="ds-loop-empty ds-loop-empty--' . esc_attr( $align ) . '">';
+			if ( '' !== $badge )   { echo '<span class="ds-loop-empty-badge">' . esc_html( $badge ) . '</span>'; }
+			if ( '' !== $heading ) { echo '<h3 class="ds-loop-empty-title">' . DS_Module_UI::inline( $heading ) . '</h3>'; }
+			if ( '' !== $desc )    { echo '<div class="ds-loop-empty-desc">' . wpautop( wp_kses_post( $desc ) ) . '</div>'; }
+			echo '</div>';
+		}
+
+		if ( '' !== $hint && class_exists( 'FLBuilderModel' ) && FLBuilderModel::is_builder_active() ) {
+			echo '<p class="ds-loop-empty-hint" style="padding:14px;opacity:.7">' . esc_html( $hint ) . '</p>';
+		}
+	}
+
 	public static function post_type_options() {
 		$out = array();
 		foreach ( get_post_types( array( 'public' => true ), 'objects' ) as $pt ) {
@@ -426,7 +467,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		$this->render_head();
 
 		if ( ! $q->have_posts() ) {
-			if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No Staff entries published yet.', 'ds-toolkit' ) . '</p>'; }
+			$this->empty_state( __( 'No Staff entries published yet.', 'ds-toolkit' ) );
 			echo '</div></section>';
 			return;
 		}
@@ -571,7 +612,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		echo '<section class="' . esc_attr( $root ) . '"><div class="ds-news-wrap">';
 		$this->render_head();
 		if ( ! $q->have_posts() ) {
-			if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No Commitments published yet.', 'ds-toolkit' ) . '</p>'; }
+			$this->empty_state( __( 'No Commitments published yet.', 'ds-toolkit' ) );
 			echo '</div></section>';
 			return false;
 		}
@@ -714,7 +755,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		$q = $this->run_query();
 		echo '<section class="ds-news ds-teams"><div class="ds-news-wrap">';
 		$this->render_head();
-		if ( ! $q->have_posts() ) { if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No Teams published yet.', 'ds-toolkit' ) . '</p>'; } echo '</div></section>'; return; }
+		if ( ! $q->have_posts() ) { $this->empty_state( __( 'No Teams published yet.', 'ds-toolkit' ) ); echo '</div></section>'; return; }
 		$arrow = DS_Card::icon( 'arrow' );
 		$ext   = DS_Card::icon( 'external' );
 		echo '<div class="ds-teams-list">';
@@ -742,7 +783,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		echo '<section class="ds-news ds-teamcards"><div class="ds-news-wrap">';
 		$this->render_head();
 		if ( ! $q->have_posts() ) {
-			if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No Teams published yet.', 'ds-toolkit' ) . '</p>'; }
+			$this->empty_state( __( 'No Teams published yet.', 'ds-toolkit' ) );
 			echo '</div></section>';
 			return;
 		}
@@ -924,9 +965,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 
 		$items = $this->collect_items();
 		if ( empty( $items ) ) {
-			if ( FLBuilderModel::is_builder_active() ) {
-				echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No posts found for this query. Publish posts of the selected type, or adjust the Query tab.', 'ds-toolkit' ) . '</p>';
-			}
+			$this->empty_state( __( 'No posts found for this query. Publish posts of the selected type, or adjust the Query tab.', 'ds-toolkit' ) );
 			echo '</div></section>';
 			return;
 		}
@@ -976,9 +1015,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 
 		$items = $this->collect_items();
 		if ( empty( $items ) ) {
-			if ( FLBuilderModel::is_builder_active() ) {
-				echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No posts found for this query. Publish posts of the selected type, or adjust the Query tab.', 'ds-toolkit' ) . '</p>';
-			}
+			$this->empty_state( __( 'No posts found for this query. Publish posts of the selected type, or adjust the Query tab.', 'ds-toolkit' ) );
 			echo '</div></section>';
 			return;
 		}
@@ -1003,7 +1040,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		echo '<section class="ds-news ds-people ds-sponsors"><div class="ds-news-wrap">';
 		$this->render_head();
 		if ( empty( $items ) ) {
-			if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No sponsors yet. Add them in the Query tab (Sponsors list).', 'ds-toolkit' ) . '</p>'; }
+			$this->empty_state( __( 'No sponsors yet. Add them in the Query tab (Sponsors list).', 'ds-toolkit' ) );
 			echo '</div></section>'; return;
 		}
 		$this->loop_open( 'ds-sponsor-grid' );
@@ -1172,7 +1209,7 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		echo '<section class="' . esc_attr( $root ) . '"><div class="ds-news-wrap">';
 		$this->render_head();
 		if ( empty( $items ) ) {
-			if ( FLBuilderModel::is_builder_active() ) { echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No upcoming events. Publish events with a future Event Date.', 'ds-toolkit' ) . '</p>'; }
+			$this->empty_state( __( 'No upcoming events. Publish events with a future Event Date.', 'ds-toolkit' ) );
 			echo '</div></section>'; return;
 		}
 
@@ -1297,17 +1334,13 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 
 		$items = $this->collect_items();
 		if ( empty( $items ) ) {
-			if ( FLBuilderModel::is_builder_active() ) {
-				echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'No posts found for this query. Publish posts of the selected type, or adjust the Query tab.', 'ds-toolkit' ) . '</p>';
-			}
+			$this->empty_state( __( 'No posts found for this query. Publish posts of the selected type, or adjust the Query tab.', 'ds-toolkit' ) );
 			echo '</div></section>';
 			return;
 		}
 
 		if ( '' === trim( $tpl ) ) {
-			if ( FLBuilderModel::is_builder_active() ) {
-				echo '<p style="padding:14px;opacity:.7">' . esc_html__( 'Add your HTML / shortcode in the "Custom Item Markup" field — it is rendered once per post.', 'ds-toolkit' ) . '</p>';
-			}
+			$this->empty_state( __( 'Add your HTML / shortcode in the "Custom Item Markup" field — it is rendered once per post.', 'ds-toolkit' ) );
 			echo '</div></section>';
 			return;
 		}
@@ -1563,6 +1596,47 @@ $ds_pl_form = array(
 					'keyword'        => array( 'type' => 'text', 'label' => __( 'Keyword Search', 'ds-toolkit' ), 'default' => '', 'help' => __( 'Only posts matching this keyword (searches title and content).', 'ds-toolkit' ) ),
 					'exclude_current' => array( 'type' => 'select', 'label' => __( 'Exclude Current Post', 'ds-toolkit' ), 'default' => 'no', 'options' => array( 'no' => __( 'No', 'ds-toolkit' ), 'yes' => __( 'Yes', 'ds-toolkit' ) ), 'help' => __( 'On a single post / CPT view, leave out the post being viewed — ideal for a “More News / Related” strip.', 'ds-toolkit' ) ),
 					'date_format'    => array( 'type' => 'text', 'label' => __( 'Date Format', 'ds-toolkit' ), 'default' => 'M Y', 'help' => __( 'PHP date format for the card date (e.g. M Y → Jun 2026).', 'ds-toolkit' ) ),
+				),
+			),
+			'empty_cfg' => array(
+				'title'  => __( 'When There Are No Results', 'ds-toolkit' ),
+				'fields' => array(
+					'empty_show' => array(
+						'type'    => 'select',
+						'label'   => __( 'Show a Notice', 'ds-toolkit' ),
+						'default' => 'yes',
+						'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No (render nothing)', 'ds-toolkit' ) ),
+						'toggle'  => array( 'yes' => array( 'fields' => array( 'empty_text', 'empty_heading', 'empty_desc', 'empty_align' ) ) ),
+						'help'    => __( 'What visitors see when the query returns nothing. Without it the section renders as a heading over blank space. Choose No only where an empty loop should collapse silently.', 'ds-toolkit' ),
+					),
+					'empty_text' => array(
+						'type'        => 'text',
+						'label'       => __( 'Badge', 'ds-toolkit' ),
+						'default'     => '',
+						'connections' => array( 'string' ),
+						'help'        => __( 'Optional small pill above the heading, e.g. COMING SOON.', 'ds-toolkit' ),
+					),
+					'empty_heading' => array(
+						'type'        => 'text',
+						'label'       => __( 'Heading', 'ds-toolkit' ),
+						'default'     => '',
+						'connections' => array( 'string' ),
+						'help'        => __( 'Blank shows "Coming Soon", unless a Badge or Description is set.', 'ds-toolkit' ),
+					),
+					'empty_desc' => array(
+						'type'          => 'editor',
+						'media_buttons' => false,
+						'rows'          => 3,
+						'wpautop'       => false,
+						'label'         => __( 'Description', 'ds-toolkit' ),
+						'help'          => __( 'Optional line under the heading, e.g. "Our next tournament dates are being finalised."', 'ds-toolkit' ),
+					),
+					'empty_align' => array(
+						'type'    => 'select',
+						'label'   => __( 'Alignment', 'ds-toolkit' ),
+						'default' => 'center',
+						'options' => array( 'center' => __( 'Center', 'ds-toolkit' ), 'left' => __( 'Left', 'ds-toolkit' ) ),
+					),
 				),
 			),
 			'query_filter' => array(


### PR DESCRIPTION
Reported on https://dslaunchpad6.wpenginepowered.com/programs/tournaments/ — the "UPCOMING EVENTS" heading and its rule render, then blank space.

## The cause

Every layout in this module hid its empty message behind `is_builder_active()`:

```php
if ( FLBuilderModel::is_builder_active() ) {
    echo '<p …>No upcoming events. Publish events with a future Event Date.</p>';
}
```

So an editor got an explanation and **visitors got a void**. Ten branches across the module did this — Staff, Commitments, Teams (x2), News (x3), Sponsors, Tournaments and Custom markup. All now go through one `empty_state()` helper that renders on the front end.

## New: "When There Are No Results" (Query tab)

Optional **Badge** (a pill such as COMING SOON), **Heading**, **Description** and **Alignment**, so partners word it themselves rather than inheriting our copy.

**Existing builds need no configuration.** With nothing set the notice falls back to a "Coming Soon" heading, which is what every current site shows on update. **Show a Notice → No** restores the pre-1.9.93 render-nothing behaviour for loops that should collapse silently.

## The builder diagnostics are kept

They now render *alongside* the notice rather than instead of it, so an editor sees both what visitors see and why it is empty. They stay off the public page — "Publish events with a future Event Date" is an instruction for whoever is building the page, not copy for a visitor.

## Verified

Six configurations against the real render path with the query forced empty:

| Case | Notice | Badge | Heading | Desc | Builder hint |
|---|---|---|---|---|---|
| **Default (existing build, nothing set)** | yes | – | **Coming Soon** | – | – |
| Custom copy | yes | COMING SOON | No events yet | yes | – |
| Badge only | yes | COMING SOON | – (no fallback) | – | – |
| Switched off | **no** | – | – | – | – |
| Switched off, in builder | no | – | – | – | **yes** |
| Default, in builder | yes | – | Coming Soon | – | **yes** |

Rendered visually against the real stylesheet in both the configured and default states. CSS braces balanced; literal fallbacks on every `--fl-global-*` so it survives older Launchpad builds. PHP lint clean.