### PR TITLE
fix: zip-upload installs offered the Origin Guard installer as the plugin to activate (1.9.94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.94] - 2026-08-17
+### Fixed
+- **Zip-upload installs no longer offer the wrong file to activate.** Every upload install since Origin Guard shipped ended in "The plugin does not have a valid header": the installer class embedded its generated mu-plugin's header verbatim, putting the literal `Plugin Name: DS Origin Guard` inside the first 8KB of `includes/class-ds-origin-guard-installer.php`. WordPress's upload installer scans one subdirectory deep and sorts by plugin name, and "DS Origin Guard" outranks "DS Toolkit" alphabetically — so the success screen's Activate button targeted the class file, which `validate_plugin()` always rejects. The header key is now assembled at runtime (`'Plugin ' . 'Name:'`), so the literal never appears in the source file; the *generated* `ds-origin-guard.php` mu-plugin is byte-identical, so no payload refresh is triggered. This supersedes the 1.9.93 README explanation (#138), which blamed a `get_plugins()` caching race — the failure was deterministic, and activating later from the Plugins page only worked because that list never scans two levels deep.
+
 ## [1.9.93] - 2026-08-13
 ### Fixed
 - **Post Loop: an empty query rendered a heading over blank space.** Seen on `/programs/tournaments/` — the section heading and its rule drew, then nothing. Every layout in this module hid its empty message behind `is_builder_active()`, so an editor got an explanation and visitors got a void. All ten of those branches now render a real notice on the front end.

--- a/README.md
+++ b/README.md
@@ -17,25 +17,29 @@ Alipio Gabriel
 
 ## Installing on a new site
 
-Upload the release zip, then **load the Plugins page before clicking Activate.**
-
-Activating straight from the upload screen can fail with:
+Upload the release zip and activate normally. On releases **before 1.9.94**, the
+Activate button on the upload-success screen fails every time with:
 
 > The plugin does not have a valid header.
 
-That is a WordPress race, not a broken package. WordPress calls `get_plugins()` early in
-the install request and caches the result for that request; if the snapshot was taken
-before the new folder landed, the activation later in the *same* request consults the
-stale list, does not find `ds-toolkit/ds-toolkit.php`, and reports a missing header. The
-files are complete and correct — the next request rescans and activation succeeds.
+Root cause (found on goldenwolves, 2026-08-17; earlier diagnosed as a WordPress
+caching race on bluespringsbaseball, 2026-08-13 — that diagnosis was wrong): the
+Origin Guard installer class embedded its generated mu-plugin's header, so the
+literal `Plugin Name: DS Origin Guard` sat within the first 8KB of
+`includes/class-ds-origin-guard-installer.php`. WordPress's upload installer scans
+the package one subdirectory deep and sorts what it finds by plugin name, and
+"DS Origin Guard" sorts before "DS Toolkit" — so the success screen's Activate
+button pointed at the class file, which `validate_plugin()` then rejects with the
+error above. Deterministic, not a race.
 
-Nothing in the plugin can prevent it: `validate_plugin()` runs before any plugin code
-loads, so there is no hook available at that point. Seen on Flywheel (bluespringsbaseball,
-2026-08-13), where the plugin folder, permissions, header and byte count were all verified
-correct while the error was showing.
+Since 1.9.94 the header key is assembled at runtime, the literal never appears in
+the file, and activating from the upload screen works. On an older zip, the
+workaround is simply: go to the **Plugins page** and activate "DS Toolkit" from
+the list there (the list only scans one level, so it always offers the right file).
 
-If it persists *after* a Plugins-page visit, then it is a real problem — check for a folder
-not named `ds-toolkit`, a truncated upload, or permissions stopping PHP reading the header.
+If activation fails from the Plugins page itself, that IS a real problem — check
+for a folder not named `ds-toolkit`, a truncated upload, or permissions stopping
+PHP reading the header.
 
 ---
 

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.93
+ * Version:           1.9.94
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.93' );
+define( 'DS_TOOLKIT_VERSION', '1.9.94' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/class-ds-origin-guard-installer.php
+++ b/includes/class-ds-origin-guard-installer.php
@@ -150,6 +150,13 @@ class DS_Origin_Guard_Installer {
 	private function render( $block_login, $block_xmlrpc ) {
 		$v = self::PAYLOAD_VERSION;
 
+		// The literal plugin-header key must never appear in this file's first
+		// 8KB: WordPress's upload installer scans one subdirectory deep, and a
+		// header here outranks the real one alphabetically ("DS Origin Guard" <
+		// "DS Toolkit"), pointing the post-install Activate button at this
+		// class file — which then always fails validate_plugin() (GH #138).
+		$header = 'Plugin ' . 'Name:';
+
 		$login_rule = $block_login ? <<<'PHP'
 
 // 2) Cold login POSTs (no test cookie = the login form was never rendered).
@@ -171,7 +178,7 @@ PHP : '';
 		return <<<PHP
 <?php
 /**
- * Plugin Name: DS Origin Guard
+ * {$header} DS Origin Guard
  * Description: Refuses known bot-flood request patterns before WordPress loads plugins, so each attack request costs ~20ms instead of a full render. Managed by ds-toolkit — do not edit; changes are overwritten on update. Payload v{$v}.
  * Version: {$v}
  *


### PR DESCRIPTION
## The bug

Every zip-upload install since Origin Guard shipped ends with:

> The plugin does not have a valid header.

Reported again today on goldenwolves (WPE `pinesgoldenwlv`); the activate URL in the browser shows the real cause:

`plugins.php?action=activate&plugin=ds-toolkit%2Fincludes%2Fclass-ds-origin-guard-installer.php`

WordPress is trying to activate the **installer class file**, not `ds-toolkit/ds-toolkit.php`.

## Root cause (deterministic, not a race)

- `class-ds-origin-guard-installer.php` embeds the generated mu-plugin's header in its heredoc payload, so the literal `Plugin Name: DS Origin Guard` sits at **byte 5620** of the file — inside the 8KB window `get_plugin_data()` scans.
- The upload installer's `Plugin_Upgrader::plugin_info()` calls `get_plugins( '/ds-toolkit' )`, which scans the folder **plus one subdirectory level**, so it finds the class file, and sorts by plugin name: "DS Origin Guard" < "DS Toolkit".
- The success screen's Activate button uses entry zero → the class file → `validate_plugin()` checks the top-level plugin list (one level deep, file absent) → "does not have a valid header", every time.

This supersedes #138, which blamed a `get_plugins()` caching race. The Plugins-page workaround documented there only worked because that list never scans two levels deep, not because a cache had refreshed.

## The fix

Assemble the header key at runtime (`'Plugin ' . 'Name:'`) inside the interpolating heredoc, so the literal never appears in the source file. Verified:

- `grep -c 'Plugin Name' includes/class-ds-origin-guard-installer.php` → 0
- The interpolated line is byte-identical to the old literal, so the **generated** `ds-origin-guard.php` is unchanged — `PAYLOAD_VERSION` untouched, no fleet-wide mu-plugin rewrite fires
- `php -l` clean on both touched PHP files

README install section rewritten to the correct explanation; changelog entry under 1.9.94; version bumped in both places as the final commit.