### PR TITLE
fix: Nested Pages Order is opt-in, not on by default (1.9.96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.96] - 2026-08-24
+### Changed
+- **Nested Pages Order is now OFF by default, not on.** 1.9.95 shipped it defaulting to `1`, and `maybe_set_defaults()` backfills any missing key on every load, so the first page view after updating would have switched it on for every existing partner site and changed the visible order of their live archives. Not every partner wants that, and it is their call to make. The default is now `0`, which also puts the feature back in line with the rule `get_defaults()` states for itself: on a fresh install only the core branding features are on and everything else is opt-in.
+- **New builds still get it on, by inheritance rather than by default.** A new site is cloned from the blueprint, the clone copies `wp_options`, and `maybe_set_defaults()` only fills keys that are MISSING. So the blueprint's stored `1` survives the clone while an existing site's absent key resolves to `0`. The blueprint installs need the toggle on once for this to hold.
+- **The Post Loop `menu_order` direction fix is gated on the same setting.** It was unconditional in 1.9.95, which meant a plugin update could reverse the visible order of any existing loop set to Menu Order. One switch now governs the whole "follow the Nested Pages order" behaviour: with it off a site renders exactly as it does today, with it on both the archive ordering and the Post Loop direction apply together.
+
 ## [1.9.95] - 2026-08-24
 ### Fixed
 - **Front-end listings now follow the WP Nested Pages drag order.** Nested Pages gives editors a drag-to-reorder tree and saves the result to each post's `menu_order`, but it registers no `pre_get_posts` and no `posts_orderby` hook, so it never touches a front-end query. Archives kept WordPress's default `date DESC` and ignored the order an editor had set. Where every entry shares a publish date (bulk-imported rosters, sample content) an archive could even look correct by accident and then reshuffle as soon as one post was edited.

--- a/admin/views/page-settings.php
+++ b/admin/views/page-settings.php
@@ -403,7 +403,7 @@ $dst_mod_all = count( DS_Toolkit::module_features() );
             <div class="dst-card-icon"><span class="dashicons dashicons-sort"></span></div>
             <div class="dst-card-info">
                 <strong>Nested Pages Order on the Front End</strong>
-                <span>Makes archives list entries in the order set by dragging them in <strong>Nested Pages</strong>. Nested Pages saves that order but never applies it to the public site, so archives otherwise fall back to newest-first and ignore it. Applies to the custom post types Nested Pages manages (Teams, Staff, Athletes, Events). Blog posts stay newest-first, and any layout or loop that sets its own order always wins.</span>
+                <span><strong>Off by default on existing sites</strong>, because switching it on changes the visible order of live archives. Makes the front end list entries in the order set by dragging them in <strong>Nested Pages</strong>: Nested Pages saves that order but never applies it to the public site, so archives otherwise fall back to newest-first and ignore it. Also makes a Post Loop set to &ldquo;Menu Order / Nested Pages position&rdquo; read top-to-bottom instead of reversed. Applies to the custom post types Nested Pages manages (Teams, Staff, Athletes, Events). Blog posts stay newest-first, and any layout or loop that sets its own order always wins.</span>
             </div>
             <div class="dst-toggle">
                 <input type="hidden" name="ds_toolkit_settings[nested_order_enabled]" value="0">

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.95
+ * Version:           1.9.96
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.95' );
+define( 'DS_TOOLKIT_VERSION', '1.9.96' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -58,6 +58,13 @@ class DS_Toolkit {
         // Front-end archives follow the WP Nested Pages drag order. Nested Pages
         // writes menu_order but hooks no front-end query, so archives keep
         // WordPress's default date DESC and ignore the order an editor set.
+        //
+        // OFF by default. Turning this on changes the visible order of live
+        // archives, which is a partner's call, not ours: an existing site keeps
+        // rendering exactly as it does today until someone opts in. New builds
+        // get it on by inheritance instead, because a clone of the blueprint
+        // copies wp_options and maybe_set_defaults() only fills keys that are
+        // MISSING, so the blueprint's 1 survives the clone.
         'nested_order_enabled' => array(
             'file'  => 'features/class-ds-nested-order.php',
             'class' => 'DS_Nested_Order',
@@ -302,7 +309,7 @@ class DS_Toolkit {
             'getsubmenu_enabled'                  => 0,
             'current_year_enabled'               => 0,
             'overlay_nav_enabled'                => 0,
-            'nested_order_enabled'               => 1,
+            'nested_order_enabled'               => 0,
             'forminator_email_partner_enabled'   => 0,
             'forminator_email_partner_fallback'  => 'designshop' . DS_TOOLKIT_ADMIN_DOMAIN,
             'global_css_enabled'                 => 0,

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -289,6 +289,20 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 	 * The ONE query: built entirely from the Query tab (Post Type + number + order +
 	 * offset + taxonomy filter). Single source of truth for WHAT the loop fetches.
 	 */
+	/**
+	 * Is "Nested Pages Order on the Front End" switched on for this site?
+	 *
+	 * Read straight from the option rather than through DS_Nested_Order, because
+	 * that class is only loaded when the feature is enabled, so referencing it
+	 * here would fatal on every site that has it off.
+	 *
+	 * @return bool
+	 */
+	private static function nested_order_enabled() {
+		$s = get_option( 'ds_toolkit_settings' );
+		return is_array( $s ) && ! empty( $s['nested_order_enabled'] );
+	}
+
 	private function run_query() {
 		$s     = $this->settings;
 
@@ -316,10 +330,13 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 		// Descending renders that order backwards, and the Order field's
 		// date-flavoured labels ("Descending (newest first)") give an editor no
 		// reason to expect it, so the module shipped DESC by default and quietly
-		// reversed every dragged order. Every other child-page renderer in this
-		// plugin (getsubmenu, child_pages, page cards) hardcodes ASC for menu_order;
-		// this makes the loop agree with them and with the option's own label.
-		if ( 'menu_order' === $ob ) { $order = 'ASC'; }
+		// reversed every dragged order.
+		//
+		// Gated on the same setting as the archive ordering so ONE switch governs
+		// "follow the Nested Pages order". With it off, a live site keeps rendering
+		// exactly as it does today rather than having its visible order changed by
+		// a plugin update.
+		if ( 'menu_order' === $ob && self::nested_order_enabled() ) { $order = 'ASC'; }
 
 		$args = array(
 			'post_type'           => $ptype,


### PR DESCRIPTION
## The problem with 1.9.95

`nested_order_enabled` shipped defaulting to `1`. `maybe_set_defaults()` runs on **every load** and backfills any missing key with its default, so the first page view after updating would have written `1` on every existing partner site and switched the feature on, changing the visible order of their live archives.

Not every partner wants that, and it is their call. It also broke the rule `get_defaults()` states for itself:

> On fresh install only the core LeagueApps-branding features are on. Everything else is opt-in so a new site doesn't get unexpected CSS/JS, shortcodes, or MCP tools the moment the plugin is activated.

## The fix

**Default is now `0`.** An existing site updating to 1.9.96 keeps rendering exactly as it does today.

**New builds still get it on, by inheritance rather than by default.** A new site is cloned from the blueprint, the clone copies `wp_options`, and `maybe_set_defaults()` only fills keys that are MISSING. So the blueprint's stored `1` survives the clone, while an existing site's absent key resolves to `0`. This is the same mechanism other fleet features rely on.

**The Post Loop `menu_order` direction fix is gated on the same setting.** It was unconditional in 1.9.95, which meant a plugin update could reverse the visible order of any existing loop set to Menu Order. One switch now governs the whole "follow the Nested Pages order" behaviour: off renders as today, on applies both the archive ordering and the Post Loop direction together.

The module reads the option directly rather than calling into `DS_Nested_Order`, because that class is only loaded when the feature is enabled and referencing it would fatal on every site that has it off.

## Verified on the blueprint

Reversed the Teams drag order so the two states are distinguishable, then flipped the toggle:

| | archive `/team-category/u16/` | Post Loop set to Menu Order + DESC |
|---|---|---|
| `nested_order_enabled = 0` | Team 2 > 3 > 4 (unchanged) | Team 1 > 2 > 3 > 4 (unchanged) |
| `nested_order_enabled = 1` | Team 4 > 3 > 2 (follows Nested Pages) | Team 4 > 3 > 2 > 1 (follows Nested Pages) |

Nested drag order for that state was Team 4 > 3 > 2 > 1. Test data restored afterwards and confirmed.

## Follow-up needed

The blueprint installs need the toggle switched on once for the inheritance to hold. Done on `ds-launchpad-6.local`; `dslaunchpad6` on WP Engine still needs it before the next clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)