### PR TITLE
feat: Heading — Style 2, Sub-heading Tag (SEO), centred double eyebrow rule (GH #143) (1.9.97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.97] - 2026-08-25
+### Added
+- **Heading: Style 2 — heading, flexible rule, optional end mark (GH #143).** A new **Style** selector on the Content tab. Style 2 puts the heading on the left with a rule running through the remaining width and an optional logo at the far end. With no image no wrapper is rendered at all, so the rule simply runs to the end rather than stopping short of an empty box. The mark keeps its aspect ratio (height authored, width follows, `object-fit: contain`) and is capped by a responsive **End Mark Height** on the Style tab; blank tracks the heading size. The separator takes `flex: 1 1 0` so a wrapping heading can never push it into an overflow. Only the heading LINE changes — sub-heading, description, rules and every existing control behave exactly as in Style 1, and existing modules stay on Style 1 because that is the default.
+- **Heading: Sub-heading Tag (SEO).** Same options and allowlist as Heading Tag. It defaults to `span`, which is what the sub-heading has always rendered, so a module saved before the setting existed is untouched and no migration is needed. An unrecognised value falls back to `span`. Styling hangs off the `.ds-heading-sub` class rather than the element, and the static CSS zeroes the margin and pins the font-size a heading tag would otherwise bring, so switching to `h3` changes the markup and nothing visual.
+- **Heading: centred eyebrow gets a rule on BOTH sides.** Both rules are always in the markup and the trailing one is revealed by CSS only when the active alignment is centred — which keeps it correct per breakpoint, since Alignment is a responsive field and the dynamic CSS already emits per-breakpoint alignment. Left and right alignment keep the existing single rule. The rules use `flex: 0 1 auto` with `min-width: 0` so they shrink around the text instead of pushing it out of the container.
+
 ## [1.9.96] - 2026-08-24
 ### Changed
 - **Nested Pages Order is now OFF by default, not on.** 1.9.95 shipped it defaulting to `1`, and `maybe_set_defaults()` backfills any missing key on every load, so the first page view after updating would have switched it on for every existing partner site and changed the visible order of their live archives. Not every partner wants that, and it is their call to make. The default is now `0`, which also puts the feature back in line with the rule `get_defaults()` states for itself: on a fresh install only the core branding features are on and everything else is opt-in.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.96
+ * Version:           1.9.97
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.96' );
+define( 'DS_TOOLKIT_VERSION', '1.9.97' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-heading/css/frontend.css
+++ b/modules/ds-heading/css/frontend.css
@@ -29,3 +29,36 @@
 
 /* Inline (eyebrow) rule sits inside the sub-heading flex, so it shrinks to its line */
 .ds-heading-sub .ds-heading-rule{width:auto;}
+
+/* ---- Sub-heading tag (GH #143) ------------------------------------------------
+   The tag is selectable, so a heading element must not bring its own margin or
+   font-size with it. Everything visual stays on the class. */
+.ds-heading-sub{margin:0;font-size:.8rem;}
+
+/* ---- Centred eyebrow: a rule on BOTH sides (GH #143) --------------------------
+   Both rules are always in the markup; the trailing one only shows when the ACTIVE
+   alignment is centred. Doing it in CSS rather than PHP keeps it correct per
+   breakpoint, since alignment is a responsive field. min-width:0 lets the lines
+   shrink instead of pushing the text out of the container. */
+.ds-heading-sub--withrule{min-width:0;}
+.ds-heading-sub--withrule .ds-heading-rule{flex:0 1 auto;min-width:0;}
+.ds-heading-sub--withrule .ds-heading-rule--after{display:none;}
+.ds-heading--center .ds-heading-sub--withrule .ds-heading-rule--after{display:flex;}
+.ds-heading--center .ds-heading-sub--withrule{justify-content:center;}
+
+/* ---- Style 2: heading, flexible rule, optional end mark ---------------------- */
+.ds-heading--style2 .ds-heading-row{display:flex;align-items:center;gap:18px;width:100%;min-width:0;}
+.ds-heading--style2 .ds-heading-row .ds-heading-title{flex:0 1 auto;min-width:0;}
+/* The rule takes whatever is left. flex-basis:0 keeps it from forcing an overflow
+   when the heading wraps. */
+.ds-heading-sep{flex:1 1 0;min-width:24px;height:var(--ds-heading-sep-h,2px);background:var(--fl-global-accent,#0b782d);border-radius:2px;}
+/* Aspect ratio preserved: height is authored, width follows. flex:none stops the
+   rule squeezing the mark. */
+.ds-heading-mark{flex:none;display:flex;align-items:center;line-height:0;}
+.ds-heading-mark img{display:block;height:var(--ds-heading-mark-h,1.6em);width:auto;max-width:100%;object-fit:contain;}
+/* Right-aligned Style 2 reads better with the rule leading into the heading. */
+.ds-heading--right.ds-heading--style2 .ds-heading-row{flex-direction:row-reverse;}
+@media (max-width:768px){
+  .ds-heading--style2 .ds-heading-row{gap:12px;}
+  .ds-heading-sep{min-width:16px;}
+}

--- a/modules/ds-heading/ds-heading.php
+++ b/modules/ds-heading/ds-heading.php
@@ -42,6 +42,29 @@ class DS_Heading_Module extends FLBuilderModule {
 		);
 	}
 
+	/** Registered presentations. Style 1 is the original layout. */
+	public static function styles() {
+		return array(
+			'style1' => __( 'Style 1 — Stacked (default)', 'ds-toolkit' ),
+			'style2' => __( 'Style 2 — Heading + separator rule', 'ds-toolkit' ),
+		);
+	}
+
+	/** Resolve a BB photo field (id, url, or {id,url}) to a URL. */
+	private function photo_url( $val, $size = 'medium' ) {
+		if ( is_array( $val ) )      { $val = $val['id'] ?? ( $val['url'] ?? '' ); }
+		elseif ( is_object( $val ) ) { $val = $val->id ?? ( $val->url ?? '' ); }
+		if ( is_numeric( $val ) )    { $u = wp_get_attachment_image_url( (int) $val, $size ); return $u ? $u : ''; }
+		return $val ? esc_url( (string) $val ) : '';
+	}
+
+	/** Alt text for the Style 2 mark: the attachment's own alt, else decorative. */
+	private function photo_alt( $val ) {
+		if ( is_array( $val ) )      { $val = $val['id'] ?? ''; }
+		elseif ( is_object( $val ) ) { $val = $val->id ?? ''; }
+		return is_numeric( $val ) ? trim( (string) get_post_meta( (int) $val, '_wp_attachment_image_alt', true ) ) : '';
+	}
+
 	/** Heading markup: escape, {a}..{/a} -> accent span, newlines -> <br>. */
 	private function heading_html( $raw ) {
 		$h = DS_Module_UI::inline( (string) $raw ); // safe inline HTML (span/strong/em...) allowed
@@ -51,17 +74,36 @@ class DS_Heading_Module extends FLBuilderModule {
 	}
 
 	/** The eyebrow/divider rule element. */
-	private function rule_html() {
-		return '<span class="ds-heading-rule" aria-hidden="true"><span class="ds-heading-rule-line"></span></span>';
+	private function rule_html( $side = '' ) {
+		$mod = ( '' !== $side ) ? ' ds-heading-rule--' . $side : '';
+		return '<span class="ds-heading-rule' . $mod . '" aria-hidden="true"><span class="ds-heading-rule-line"></span></span>';
 	}
 
-	/** Sub-heading element (always a <span>, optionally carrying an inline rule). */
+	/**
+	 * Sub-heading element.
+	 *
+	 * The tag is selectable for SEO (GH #143). It defaults to `span`, which is what
+	 * this element has always rendered, so a module saved before the setting existed
+	 * is untouched. All styling hangs off the .ds-heading-sub CLASS rather than the
+	 * element, so switching to h3 changes the markup and nothing else — the static
+	 * CSS zeroes the margin a heading tag would otherwise bring with it.
+	 *
+	 * With an inline rule, a rule is emitted on BOTH sides. The trailing one is
+	 * hidden by CSS unless the active alignment is centred, which keeps the
+	 * behaviour correct per breakpoint without the PHP needing to know the
+	 * breakpoint — alignment is a responsive field.
+	 */
 	private function subheading_html( $inline_rule ) {
+		$tag = $this->settings->subheading_tag ?? 'span';
+		if ( ! array_key_exists( $tag, self::tags() ) ) { $tag = 'span'; }
+
 		$txt = '<span class="ds-heading-sub-text">' . DS_Module_UI::inline( $this->settings->subheading ) . '</span>';
 		if ( $inline_rule ) {
-			return '<span class="ds-heading-sub ds-heading-sub--withrule">' . $this->rule_html() . $txt . '</span>';
+			return '<' . $tag . ' class="ds-heading-sub ds-heading-sub--withrule">'
+				. $this->rule_html( 'before' ) . $txt . $this->rule_html( 'after' )
+				. '</' . $tag . '>';
 		}
-		return '<span class="ds-heading-sub">' . $txt . '</span>';
+		return '<' . $tag . ' class="ds-heading-sub">' . $txt . '</' . $tag . '>';
 	}
 
 	/** Entry point called by includes/frontend.php. */
@@ -85,7 +127,9 @@ class DS_Heading_Module extends FLBuilderModule {
 		$inline_rule = $div_show && 'sub' === $div_pos && $sub_show;
 		if ( $div_show && 'sub' === $div_pos && ! $sub_show ) { $div_pos = 'above'; }
 
-		$mods  = 'ds-heading ds-heading--' . $align;
+		$hstyle = array_key_exists( (string) ( $s->heading_style ?? 'style1' ), self::styles() ) ? (string) $s->heading_style : 'style1';
+
+		$mods  = 'ds-heading ds-heading--' . $align . ' ds-heading--' . $hstyle;
 		$mods .= ' ds-heading--rule-' . ( $div_style ?: 'solid' );
 		if ( '' !== trim( (string) ( $s->heading ?? '' ) ) || $sub_show || $desc_show ) {
 			// renderable
@@ -104,9 +148,27 @@ class DS_Heading_Module extends FLBuilderModule {
 		// Standalone rule above the heading.
 		if ( $div_show && 'above' === $div_pos ) { echo $this->rule_html(); }
 
-		// Heading.
+		// Heading. Style 2 puts it in a row with a separator that takes the remaining
+		// width and an optional mark at the far end (GH #143). Only the heading LINE
+		// changes — sub-heading, description, rules and every existing control behave
+		// exactly as they do in Style 1.
 		if ( '' !== trim( (string) ( $s->heading ?? '' ) ) ) {
-			echo '<' . $tag . ' class="ds-heading-title">' . $this->heading_html( $s->heading ) . '</' . $tag . '>';
+			$title = '<' . $tag . ' class="ds-heading-title">' . $this->heading_html( $s->heading ) . '</' . $tag . '>';
+			if ( 'style2' === $hstyle ) {
+				$img = $this->photo_url( $s->style2_image ?? '' );
+				echo '<div class="ds-heading-row">';
+				echo $title;
+				echo '<span class="ds-heading-sep" aria-hidden="true"></span>';
+				// No image means no wrapper at all, so the separator simply runs to the
+				// end rather than stopping short of an empty box.
+				if ( '' !== $img ) {
+					$alt = $this->photo_alt( $s->style2_image ?? '' );
+					echo '<span class="ds-heading-mark"><img src="' . esc_url( $img ) . '" alt="' . esc_attr( $alt ) . '" loading="lazy" /></span>';
+				}
+				echo '</div>';
+			} else {
+				echo $title;
+			}
 		}
 
 		// Standalone rule below the heading.
@@ -137,6 +199,21 @@ FLBuilder::register_module( 'DS_Heading_Module', array(
 			'text' => array(
 				'title'  => __( 'Text', 'ds-toolkit' ),
 				'fields' => array(
+					'heading_style'       => array(
+						'type'    => 'select',
+						'label'   => __( 'Style', 'ds-toolkit' ),
+						'default' => 'style1',
+						'options' => DS_Heading_Module::styles(),
+						'toggle'  => array( 'style2' => array( 'fields' => array( 'style2_image' ) ) ),
+						'help'    => __( 'Style 2 puts the heading on the left with a rule running through the remaining space, and an optional mark at the end. Existing modules stay on Style 1.', 'ds-toolkit' ),
+					),
+					'style2_image'        => array(
+						'type'        => 'photo',
+						'label'       => __( 'End Mark (optional)', 'ds-toolkit' ),
+						'show_remove' => true,
+						'connections' => array( 'photo' ),
+						'help'        => __( 'Logo or graphic at the far end of the rule. Keeps its aspect ratio and is capped by the End Mark Height on the Style tab. Leave empty and the rule simply runs to the end.', 'ds-toolkit' ),
+					),
 					'subheading_show'     => array(
 						'type'    => 'select',
 						'label'   => __( 'Show Sub-heading', 'ds-toolkit' ),
@@ -166,6 +243,13 @@ FLBuilder::register_module( 'DS_Heading_Module', array(
 						'default' => 'h2',
 						'options' => DS_Heading_Module::tags(),
 						'help'    => __( 'Pick the semantic tag. Use one H1 per page; H2 is the safe default for a section title.', 'ds-toolkit' ),
+					),
+					'subheading_tag'      => array(
+						'type'    => 'select',
+						'label'   => __( 'Sub-heading Tag (SEO)', 'ds-toolkit' ),
+						'default' => 'span',
+						'options' => DS_Heading_Module::tags(),
+						'help'    => __( 'The element the sub-heading renders as. Defaults to Span, which is what it has always been — changing it alters the markup only, never the look.', 'ds-toolkit' ),
 					),
 					'alignment'           => array(
 						'type'       => 'select',
@@ -260,6 +344,15 @@ FLBuilder::register_module( 'DS_Heading_Module', array(
 				'title'  => __( 'Spacing', 'ds-toolkit' ),
 				'fields' => array(
 					'gap'       => array( 'type' => 'unit', 'label' => __( 'Element Gap', 'ds-toolkit' ), 'default' => '12', 'description' => 'px', 'responsive' => true, 'slider' => array( 'min' => 0, 'max' => 60, 'step' => 1 ), 'help' => __( 'Vertical spacing between sub-heading, heading and description.', 'ds-toolkit' ) ),
+					'style2_mark_h'       => array(
+						'type'        => 'unit',
+						'label'       => __( 'End Mark Height', 'ds-toolkit' ),
+						'default'     => '',
+						'description' => 'px',
+						'responsive'  => true,
+						'slider'      => array( 'min' => 16, 'max' => 160, 'step' => 2 ),
+						'help'        => __( 'Style 2 only. Blank tracks the heading size. Width follows the aspect ratio.', 'ds-toolkit' ),
+					),
 					'max_width' => array( 'type' => 'unit', 'label' => __( 'Max Width', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'responsive' => true, 'slider' => array( 'min' => 200, 'max' => 1200, 'step' => 10 ), 'help' => __( 'Constrain the block width (great for centred headings). Blank = full width.', 'ds-toolkit' ) ),
 					'padding'   => array( 'type' => 'dimension', 'label' => __( 'Padding', 'ds-toolkit' ), 'default' => '0', 'units' => array( 'px' ), 'slider' => true, 'responsive' => true ),
 					'margin'    => array( 'type' => 'dimension', 'label' => __( 'Margin', 'ds-toolkit' ), 'default' => '0', 'units' => array( 'px' ), 'slider' => true, 'responsive' => true ),

--- a/modules/ds-heading/includes/frontend.css.php
+++ b/modules/ds-heading/includes/frontend.css.php
@@ -27,16 +27,20 @@ $align_css = static function ( $a ) {
 	$ml = ( 'center' === $a ) ? 'auto' : ( 'right' === $a ? 'auto' : '0' );
 	$mr = ( 'center' === $a ) ? 'auto' : ( 'right' === $a ? '0' : 'auto' );
 	$rule_justify = ( 'center' === $a ) ? 'center' : ( 'right' === $a ? 'flex-end' : 'flex-start' );
-	return "ALIGN_INNER{align-items:{$items};text-align:{$text};margin-left:{$ml};margin-right:{$mr};}ALIGN_RULE{justify-content:{$rule_justify};}";
+	// The centred eyebrow shows a rule on BOTH sides, so the trailing one has to
+	// follow the alignment that is active at THIS breakpoint (GH #143).
+	$after = ( 'center' === $a ) ? 'flex' : 'none';
+	return "ALIGN_INNER{align-items:{$items};text-align:{$text};margin-left:{$ml};margin-right:{$mr};}ALIGN_RULE{justify-content:{$rule_justify};}"
+		. "ALIGN_AFTER{display:{$after};}";
 };
 $am = in_array( $settings->alignment_medium ?? '', array( 'left', 'center', 'right' ), true ) ? $settings->alignment_medium : '';
 $ar = in_array( $settings->alignment_responsive ?? '', array( 'left', 'center', 'right' ), true ) ? $settings->alignment_responsive : '';
 if ( '' !== $am ) {
-	$css = str_replace( array( 'ALIGN_INNER', 'ALIGN_RULE' ), array( "$node .ds-heading-inner", "$node .ds-heading-rule" ), $align_css( $am ) );
+	$css = str_replace( array( 'ALIGN_INNER', 'ALIGN_RULE', 'ALIGN_AFTER' ), array( "$node .ds-heading-inner", "$node .ds-heading-rule", "$node .ds-heading-sub--withrule .ds-heading-rule--after" ), $align_css( $am ) );
 	echo "@media (max-width:{$bpm}px){ {$css} }\n";
 }
 if ( '' !== $ar ) {
-	$css = str_replace( array( 'ALIGN_INNER', 'ALIGN_RULE' ), array( "$node .ds-heading-inner", "$node .ds-heading-rule" ), $align_css( $ar ) );
+	$css = str_replace( array( 'ALIGN_INNER', 'ALIGN_RULE', 'ALIGN_AFTER' ), array( "$node .ds-heading-inner", "$node .ds-heading-rule", "$node .ds-heading-sub--withrule .ds-heading-rule--after" ), $align_css( $ar ) );
 	echo "@media (max-width:{$bpr}px){ {$css} }\n";
 }
 
@@ -143,3 +147,15 @@ if ( '' !== $sa ) { echo "@media (max-width:{$bpr}px){ $node .ds-heading-sub{ali
 $oc_ov = DS_Module_UI::color( $settings->outline_color ?? '' );
 if ( '' !== $oc_ov ) { echo "$node { --ds-outline-c: {$oc_ov}; }\n"; }
 if ( isset( $settings->outline_width ) && '' !== $settings->outline_width ) { echo "$node { --ds-outline-w: " . max( 1, (int) $settings->outline_width ) . "px; }\n"; }
+
+/* ---- Style 2 (GH #143) ---- */
+$sep_h = $u( $settings->divider_thickness ?? '', 2 );
+echo "$node .ds-heading-sep { --ds-heading-sep-h: {$sep_h}px; }\n";
+$dc = DS_Module_UI::color( $settings->divider_color ?? '' );
+if ( '' !== $dc ) { echo "$node .ds-heading-sep { background: {$dc}; }\n"; }
+foreach ( array( '' => '', '_medium' => $bpm, '_responsive' => $bpr ) as $sfx => $bp ) {
+	$v = $settings->{'style2_mark_h' . $sfx} ?? '';
+	if ( '' === $v || null === $v ) { continue; }
+	$rule = "$node .ds-heading-mark img { height: " . (int) $v . "px; }";
+	echo ( '' === $sfx ) ? "$rule\n" : "@media (max-width:{$bp}px){ $rule }\n";
+}


### PR DESCRIPTION
Closes #143. All three parts, extending the existing module rather than adding one.

## Style 2

New **Style** selector on the Content tab. Heading left, rule through the remaining width, optional mark at the end.

- **No image → no wrapper at all**, so the rule runs to the end instead of stopping short of an empty box.
- Mark keeps its aspect ratio: height authored, width auto, `object-fit: contain`, capped by a responsive **End Mark Height** (blank tracks the heading size).
- Separator is `flex: 1 1 0`, so a wrapping heading can never push it into an overflow.
- Only the heading **line** changes. Sub-heading, description, rules, typography, colour and spacing all behave as in Style 1, and existing modules stay on Style 1 because that is the default.

## Sub-heading Tag (SEO)

Same options and allowlist as Heading Tag, defaulting to `span` — what this element has always rendered — so saved modules are untouched and **no migration is needed**. An unrecognised value falls back to `span`.

Styling stays on the `.ds-heading-sub` class rather than the element, and the static CSS zeroes the margin and pins the font-size a heading tag would otherwise bring. Switching to `h3` changes the markup and nothing visual.

## Centred eyebrow: rule on both sides

Both rules are always in the markup; the trailing one is revealed by CSS **only when the active alignment is centred**. Doing it in CSS rather than PHP is what makes it correct per breakpoint — Alignment is a responsive field and the dynamic CSS already emits per-breakpoint alignment, so that same emitter now drives the trailing rule too. Left and right keep the existing single rule.

`flex: 0 1 auto` with `min-width: 0` lets the lines shrink around the text instead of pushing it out of the container.

## Verified

**Markup, against the real render path**

| Case | Row | Sep | Mark | Rules | Sub tag |
|---|---|---|---|---|---|
| style1 default *(regression)* | – | – | – | 0 | span |
| style1 + eyebrow *(regression)* | – | – | – | 2 | span |
| style1 centred + eyebrow *(regression)* | – | – | – | 2 | span |
| style2, no image | y | y | **–** | 0 | span |
| style2, with image | y | y | y | 0 | span |
| style2 + centred eyebrow | y | y | y | 2 | span |

Sub-heading tag: unset→`span`, `span`, `h3`, `h4`, `p` all render; `bogus`→`span`. Alt text taken from the attachment.

**Layout, measured at 1100px and 390px**

| | 1100px | 390px |
|---|---|---|
| Trailing rule, left align | hidden | hidden |
| Trailing rule, centred | shown | shown |
| Separator, no image | 749px | 45px |
| Separator, with mark | 547px | 16px |
| Mark width | 77px | 77px |
| **Horizontal scrolling** | **none** | **none** |

CSS braces balanced, PHP lint clean across all tracked files.