### PR TITLE
feat: Heading — End Mark sizing section, and fix distortion/overflow (GH #145) (1.9.98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.98] - 2026-08-25
+### Changed
+- **Heading: the Style 2 end mark gets its own sizing section (GH #145).** The control shipped in 1.9.97 lived under Spacing, away from the image it sizes. It now sits in an **End Mark (Style 2)** section on the Style tab, revealed only when Style 2 is selected, and is labelled **Size**. It stays a single responsive field rather than a second parallel control — the issue's own implementation note asks not to introduce new units, breakpoints or image-sizing behaviour, and the responsive icon on this field already sets tablet and mobile from the same input, unit and validation. Blank still tracks the heading size, so existing modules are visually unchanged.
+
+### Fixed
+- **Heading: the Style 2 end mark could distort or overflow at large sizes.** Found while verifying the above. Size was applied as a fixed `height`, so a wide mark in a narrow container was squashed — measured, a 3:1 logo rendered at 1.01:1 — or, with the wrapper unable to shrink, pushed the row 720px wide inside a 380px container. Size is now a **max-height** paired with `width:auto` and `max-width:100%`, so the browser scales the mark down against whichever limit binds first and the aspect ratio is preserved either way; the wrapper is `flex: 0 1 auto` so it can actually shrink. A long heading also breaks rather than forcing the row wide. Verified at 3:1 across sizes 40 and 240 in both a 900px and a 380px container: ratio held at 3.00 in every case, the mark stayed inside the container, and the page never scrolled horizontally.
+
 ## [1.9.97] - 2026-08-25
 ### Added
 - **Heading: Style 2 — heading, flexible rule, optional end mark (GH #143).** A new **Style** selector on the Content tab. Style 2 puts the heading on the left with a rule running through the remaining width and an optional logo at the far end. With no image no wrapper is rendered at all, so the rule simply runs to the end rather than stopping short of an empty box. The mark keeps its aspect ratio (height authored, width follows, `object-fit: contain`) and is capped by a responsive **End Mark Height** on the Style tab; blank tracks the heading size. The separator takes `flex: 1 1 0` so a wrapping heading can never push it into an overflow. Only the heading LINE changes — sub-heading, description, rules and every existing control behave exactly as in Style 1, and existing modules stay on Style 1 because that is the default.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.97
+ * Version:           1.9.98
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.97' );
+define( 'DS_TOOLKIT_VERSION', '1.9.98' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-heading/css/frontend.css
+++ b/modules/ds-heading/css/frontend.css
@@ -48,14 +48,25 @@
 
 /* ---- Style 2: heading, flexible rule, optional end mark ---------------------- */
 .ds-heading--style2 .ds-heading-row{display:flex;align-items:center;gap:18px;width:100%;min-width:0;}
-.ds-heading--style2 .ds-heading-row .ds-heading-title{flex:0 1 auto;min-width:0;}
+/* break-word so a single long word wraps instead of forcing the row wide — the
+   heading, not the mark, was the last thing able to overflow a narrow container. */
+.ds-heading--style2 .ds-heading-row .ds-heading-title{flex:0 1 auto;min-width:0;overflow-wrap:break-word;}
 /* The rule takes whatever is left. flex-basis:0 keeps it from forcing an overflow
    when the heading wraps. */
 .ds-heading-sep{flex:1 1 0;min-width:24px;height:var(--ds-heading-sep-h,2px);background:var(--fl-global-accent,#0b782d);border-radius:2px;}
 /* Aspect ratio preserved: height is authored, width follows. flex:none stops the
    rule squeezing the mark. */
-.ds-heading-mark{flex:none;display:flex;align-items:center;line-height:0;}
-.ds-heading-mark img{display:block;height:var(--ds-heading-mark-h,1.6em);width:auto;max-width:100%;object-fit:contain;}
+/* flex:0 1 auto (not none) so a large Size can SHRINK when the container is narrow
+   rather than pushing the row into an overflow — max-width:100% on the img cannot
+   bind while the wrapper refuses to shrink. The separator keeps its own min-width,
+   so the mark still gets the remaining room first. */
+.ds-heading-mark{flex:0 1 auto;display:flex;align-items:center;line-height:0;}
+/* Size is a MAX-height, not a height. With both dimensions auto and a max on each
+   axis, the browser scales the mark down against whichever limit binds first and the
+   aspect ratio is preserved either way. A fixed height plus a width cap would squash
+   the box instead (measured: a 3:1 mark came out 1.01:1 in a narrow container). */
+.ds-heading-mark{min-width:0;}
+.ds-heading-mark img{display:block;height:auto;width:auto;max-height:var(--ds-heading-mark-h,1.6em);max-width:100%;}
 /* Right-aligned Style 2 reads better with the rule leading into the heading. */
 .ds-heading--right.ds-heading--style2 .ds-heading-row{flex-direction:row-reverse;}
 @media (max-width:768px){

--- a/modules/ds-heading/ds-heading.php
+++ b/modules/ds-heading/ds-heading.php
@@ -204,7 +204,7 @@ FLBuilder::register_module( 'DS_Heading_Module', array(
 						'label'   => __( 'Style', 'ds-toolkit' ),
 						'default' => 'style1',
 						'options' => DS_Heading_Module::styles(),
-						'toggle'  => array( 'style2' => array( 'fields' => array( 'style2_image' ) ) ),
+						'toggle'  => array( 'style2' => array( 'fields' => array( 'style2_image' ), 'sections' => array( 'endmark' ) ) ),
 						'help'    => __( 'Style 2 puts the heading on the left with a rule running through the remaining space, and an optional mark at the end. Existing modules stay on Style 1.', 'ds-toolkit' ),
 					),
 					'style2_image'        => array(
@@ -278,6 +278,20 @@ FLBuilder::register_module( 'DS_Heading_Module', array(
 	'style'   => array(
 		'title'    => __( 'Style', 'ds-toolkit' ),
 		'sections' => array(
+			'endmark' => array(
+				'title'  => __( 'End Mark (Style 2)', 'ds-toolkit' ),
+				'fields' => array(
+					'style2_mark_h'  => array(
+						'type'        => 'unit',
+						'label'       => __( 'Size', 'ds-toolkit' ),
+						'default'     => '',
+						'description' => 'px',
+						'responsive'  => true,
+						'slider'      => array( 'min' => 16, 'max' => 240, 'step' => 2 ),
+						'help'        => __( 'Height of the end mark; the width follows so the aspect ratio never changes. Use the responsive icon on this field for tablet and mobile sizes — leaving those blank keeps the desktop size. Blank everywhere tracks the heading size, which is what existing modules already do.', 'ds-toolkit' ),
+					),
+				),
+			),
 			'divider' => array(
 				'title'  => __( 'Divider / Eyebrow Rule', 'ds-toolkit' ),
 				'fields' => array(
@@ -344,15 +358,6 @@ FLBuilder::register_module( 'DS_Heading_Module', array(
 				'title'  => __( 'Spacing', 'ds-toolkit' ),
 				'fields' => array(
 					'gap'       => array( 'type' => 'unit', 'label' => __( 'Element Gap', 'ds-toolkit' ), 'default' => '12', 'description' => 'px', 'responsive' => true, 'slider' => array( 'min' => 0, 'max' => 60, 'step' => 1 ), 'help' => __( 'Vertical spacing between sub-heading, heading and description.', 'ds-toolkit' ) ),
-					'style2_mark_h'       => array(
-						'type'        => 'unit',
-						'label'       => __( 'End Mark Height', 'ds-toolkit' ),
-						'default'     => '',
-						'description' => 'px',
-						'responsive'  => true,
-						'slider'      => array( 'min' => 16, 'max' => 160, 'step' => 2 ),
-						'help'        => __( 'Style 2 only. Blank tracks the heading size. Width follows the aspect ratio.', 'ds-toolkit' ),
-					),
 					'max_width' => array( 'type' => 'unit', 'label' => __( 'Max Width', 'ds-toolkit' ), 'default' => '', 'description' => 'px', 'responsive' => true, 'slider' => array( 'min' => 200, 'max' => 1200, 'step' => 10 ), 'help' => __( 'Constrain the block width (great for centred headings). Blank = full width.', 'ds-toolkit' ) ),
 					'padding'   => array( 'type' => 'dimension', 'label' => __( 'Padding', 'ds-toolkit' ), 'default' => '0', 'units' => array( 'px' ), 'slider' => true, 'responsive' => true ),
 					'margin'    => array( 'type' => 'dimension', 'label' => __( 'Margin', 'ds-toolkit' ), 'default' => '0', 'units' => array( 'px' ), 'slider' => true, 'responsive' => true ),

--- a/modules/ds-heading/includes/frontend.css.php
+++ b/modules/ds-heading/includes/frontend.css.php
@@ -156,6 +156,8 @@ if ( '' !== $dc ) { echo "$node .ds-heading-sep { background: {$dc}; }\n"; }
 foreach ( array( '' => '', '_medium' => $bpm, '_responsive' => $bpr ) as $sfx => $bp ) {
 	$v = $settings->{'style2_mark_h' . $sfx} ?? '';
 	if ( '' === $v || null === $v ) { continue; }
-	$rule = "$node .ds-heading-mark img { height: " . (int) $v . "px; }";
+	// max-height, not height: paired with width:auto/max-width:100% the mark scales
+	// down against whichever limit binds and never loses its aspect ratio.
+	$rule = "$node .ds-heading-mark img { max-height: " . (int) $v . "px; }";
 	echo ( '' === $sfx ) ? "$rule\n" : "@media (max-width:{$bp}px){ $rule }\n";
 }


### PR DESCRIPTION
Closes #145.

## On the two-fields question

I kept this as **one responsive field** rather than adding a separate `Responsive Size` control, because the issue's own implementation note says *"Do not introduce new units, breakpoints, or image-sizing behavior."*

The field is `responsive => true`, so Beaver Builder's responsive icon on it already drives tablet and mobile from the **same input, same px unit, same validation, same breakpoints**. Adding a second standalone field would create a parallel mechanism where a partner sets one and the other silently wins — and it would collide with the `_medium` / `_responsive` keys BB already generates.

What I did fix is that it was hard to find: it shipped in 1.9.97 under **Spacing**, away from the image it sizes. It now has its own **End Mark (Style 2)** section on the Style tab, revealed only for Style 2, labelled **Size**.

## Real bugs found while verifying

Both would have hit anyone actually using the control:

| Problem | Measured |
|---|---|
| Size applied as fixed `height` → wide marks squashed | a 3:1 logo rendered at **1.01:1** |
| Wrapper at `flex:none` → could not shrink | 240px size pushed the row to **720px inside a 380px container** |

Size is now a **`max-height`** paired with `width:auto` and `max-width:100%`, so the browser scales down against whichever limit binds first and the ratio is preserved either way. The wrapper is `flex: 0 1 auto` so it can shrink, and a long heading breaks rather than forcing the row wide.

## Verified

**Layout** — real 3:1 image (300×100 PNG):

| Size | Container | Rendered | Ratio | Inside |
|---|---|---|---|---|
| 40 | 900px | 120×40 | **3.00** | yes |
| 240 | 900px | 300×100 | **3.00** | yes |
| 240 | **380px** | 191×64 | **3.00** | yes |

No horizontal page scroll in any case. Confirmed visually as well as by measurement.

**Emission** — across breakpoints:

| Settings | Emitted |
|---|---|
| **nothing set** | **nothing — existing modules unchanged** |
| Size 64 | one base rule |
| + tablet 48 | `@media (max-width:992px)` |
| + mobile 32 | `@media (max-width:768px)` |
| responsive blank | falls back to the base size |

PHP lint clean, CSS braces balanced.