### PR TITLE
fix: CTA Show Header off for new modules (GH #147) (1.9.100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.100] - 2026-08-25
+### Changed
+- **CTA: Show Header is off for new modules (GH #147).** The Heading field's default is the placeholder `{a}Lorem{/a} Ipsum Dolor`, so with the header on by default every freshly dropped CTA rendered Lorem copy onto the page until someone edited it or unticked the box. Lorem reaching a live page is a worse outcome than a section without a heading, so the header is now opt-in: switch Show Header to Yes and the placeholder heading is waiting to be edited. **Existing modules are untouched** — they carry their own saved value — and the render paths still fall back to showing the header for any module whose settings predate the field.
+- This is deliberately the shared default rather than a Style-6-only one. The issue asked for it on Style 6 alone, but Beaver Builder resolves a module's field defaults when the module is *created*, at which point its style is Style 1 — there is no moment at which a "new Style 6 module" exists to give a different default to. A Style-6-only field was rejected for the opposite reason: BB merges defaults into saved settings at render, so it would have evaluated to "no" for Style 6 modules saved *before* the field existed and hidden headers that are live today. The shared flip is the only version of this that helps without breaking anything, and it applies the same benefit to Styles 1, 2, 3 and 5.
+
 ## [1.9.99] - 2026-08-25
 ### Changed
 - **CTA + Org Stats: the Header panel now sits last (GH #147, #149, #150).** Cards are configured before the optional header, which is the order people actually work in. In the CTA module the Header panel moved to the end, which gives Style 1 *CTA Style → Cards → Header* and Style 6 *CTA Style → Program Cards → Header* from a single ordering; Org Stats is now *Stats Style → Stats → Header*. Beaver Builder renders panels in array order and the per-style toggles only control visibility, so one order serves every style. Panel order is builder UI only: no field values, saved configurations or frontend output change, and the other CTA styles get the same Header-last treatment as a side effect of there being one array.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.99
+ * Version:           1.9.100
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.99' );
+define( 'DS_TOOLKIT_VERSION', '1.9.100' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-cta/ds-cta.php
+++ b/modules/ds-cta/ds-cta.php
@@ -747,9 +747,19 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 					'show_header'  => array(
 						'type'    => 'select',
 						'label'   => __( 'Show Header', 'ds-toolkit' ),
-						'default' => 'yes',
+						// Off for NEW modules (GH #147). The Heading default is the
+						// placeholder "{a}Lorem{/a} Ipsum Dolor", so the old default meant
+						// every freshly dropped CTA rendered Lorem copy on the page until
+						// someone edited or unticked it — and Lorem reaching a live page is
+						// a worse outcome than a section without a heading. Turning it on is
+						// one click, and the heading placeholder is waiting when you do.
+						// Modules already saved are untouched: they carry their own value,
+						// and the render paths still fall back to 'yes' for any module whose
+						// settings predate this field entirely.
+						'default' => 'no',
 						'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No', 'ds-toolkit' ) ),
 						'toggle'  => array( 'yes' => array( 'fields' => array( 'heading', 'header_label' ) ) ),
+						'help'    => __( 'Off by default so a new module never ships placeholder heading text. Switch to Yes to add a heading above the cards; existing modules keep whatever they were set to.', 'ds-toolkit' ),
 					),
 					'heading'      => array(
 						'type'    => 'textarea',


### PR DESCRIPTION
Finishes #147. The reorder half shipped in 1.9.99; this is the default.

## Why the shared default, not a Style-6-only one

I said earlier this couldn't be done as specified, and that part stands — but the goal *is* reachable, just not the way the issue frames it.

- **There is no "new Style 6 module."** BB resolves a module's field defaults when it is **created**, and a new CTA module's style is `style1`. By the time anyone switches to Style 6 the defaults are already applied and saved. So a style-aware default has no moment to exist in.
- **A Style-6-only field fails the opposite way.** BB merges defaults into saved settings at render, so a new `no`-default field would evaluate to `no` for Style 6 modules saved *before* it existed — hiding headers that are live today.

So the shared flip is the only version of this that helps without breaking anything.

## Why it's the right call anyway

The Heading field's default is the placeholder **`{a}Lorem{/a} Ipsum Dolor`**. With the header on by default, every freshly dropped CTA rendered Lorem copy onto the page until someone edited it or unticked the box.

Shipping Lorem to a live page is a worse failure than a section without a heading — and it is not hypothetical: the blueprint's own pages carry Lorem placeholder copy. Making the header opt-in removes that failure mode across **every** CTA style, not just Style 6. Turning it on is one click, and the placeholder heading is waiting when you do.

The cost is one extra click when you do want a header. That seemed clearly worth it; flagging it explicitly since it goes beyond what the issue asked.

## Verified

| Case | Header |
|---|---|
| **New module (form defaults)** | **not rendered** |
| Existing module saved `yes` | rendered |
| Existing module saved `no` | not rendered |
| **Legacy module with no `show_header` key at all** | **rendered** (via the `?? 'yes'` render fallback) |

Existing modules are untouched in every case.

Also checked `version_compare('1.9.100','1.9.99','>') === true`, so the self-updater rolls forward correctly past 1.9.99.