### PR TITLE
fix: CTA Section Background reachable from every card style (GH #154) (1.9.101)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.101] - 2026-08-25
+### Fixed
+- **CTA: Section Background is reachable from every card style (GH #154).** The control was defined inside the **Grid** panel, which Styles 5 and 6 do not show — so switching to Program Cards made it vanish even though the setting still applied. It now lives in its own **Section** panel, shown for Styles 1, 2, 3, 5 and 6. Style 4 keeps its own Hero Background controls and is deliberately left out. Nothing about the value or its output changed: it is the same `section_bg` field with the same default, still emitted by both the CTA stylesheet and the shared Program Cards chrome, so **existing modules of every style render exactly as before** — the control simply became visible where it was already working. Section Background and Card Background remain separate settings.
+
 ## [1.9.100] - 2026-08-25
 ### Changed
 - **CTA: Show Header is off for new modules (GH #147).** The Heading field's default is the placeholder `{a}Lorem{/a} Ipsum Dolor`, so with the header on by default every freshly dropped CTA rendered Lorem copy onto the page until someone edited it or unticked the box. Lorem reaching a live page is a worse outcome than a section without a heading, so the header is now opt-in: switch Show Header to Yes and the placeholder heading is waiting to be edited. **Existing modules are untouched** — they carry their own saved value — and the render paths still fall back to showing the header for any module whose settings predate the field.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.100
+ * Version:           1.9.101
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.100' );
+define( 'DS_TOOLKIT_VERSION', '1.9.101' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-cta/ds-cta.php
+++ b/modules/ds-cta/ds-cta.php
@@ -590,22 +590,22 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 						'help'    => __( 'Choose a CTA layout. More styles will be added; the options below adapt to the selected style.', 'ds-toolkit' ),
 						'toggle'  => array(
 							'style1' => array(
-								'sections' => array( 'header', 'cards', 'grid', 'clip', 'overlay', 'colors', 'typography', 'spacing' ),
+								'sections' => array( 'section_style', 'header', 'cards', 'grid', 'clip', 'overlay', 'colors', 'typography', 'spacing' ),
 							),
 							'style2' => array(
-								'sections' => array( 'header', 'cards', 'grid', 'card2', 'overlay', 'colors', 'typography', 'spacing' ),
+								'sections' => array( 'section_style', 'header', 'cards', 'grid', 'card2', 'overlay', 'colors', 'typography', 'spacing' ),
 							),
 							'style3' => array(
-								'sections' => array( 'header', 'cards', 'grid', 'bento', 'colors', 'typography', 'spacing' ),
+								'sections' => array( 'section_style', 'header', 'cards', 'grid', 'bento', 'colors', 'typography', 'spacing' ),
 							),
 							'style4' => array(
 								'sections' => array( 'hero', 'hero_contact', 'hero_button', 'hero_social', 'hero_bg', 'hero_box', 'hero_colors', 'hero_social_style', 'hero_typography', 'spacing' ),
 							),
 							'style5' => array(
-								'sections' => array( 'header', 'cards', 'mcard', 'mcard_fx', 'mcard_logo', 'typography', 'spacing' ),
+								'sections' => array( 'section_style', 'header', 'cards', 'mcard', 'mcard_fx', 'mcard_logo', 'typography', 'spacing' ),
 							),
 							'style6' => array(
-								'sections' => array( 'header', 'programs_sec', 'program_opts', 'program_chrome', 'spacing' ),
+								'sections' => array( 'section_style', 'header', 'programs_sec', 'program_opts', 'program_chrome', 'spacing' ),
 							),
 						),
 					),
@@ -777,6 +777,12 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 	'style'   => array(
 		'title'    => __( 'Style', 'ds-toolkit' ),
 		'sections' => array(
+			'section_style' => array(
+				'title'  => __( 'Section', 'ds-toolkit' ),
+				'fields' => array(
+					'section_bg' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Section Background', 'ds-toolkit' ), 'default' => 'var(--fl-global-light-background)', 'show_reset' => true ),
+				),
+			),
 			'grid' => array(
 				'title'  => __( 'Grid', 'ds-toolkit' ),
 				'fields' => array(
@@ -795,7 +801,6 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 					'content_max_width' => array( 'type' => 'unit', 'label' => __( 'Max Width', 'ds-toolkit' ), 'default' => '1280', 'description' => 'px', 'slider' => array( 'min' => 480, 'max' => 1920, 'step' => 10 ) ),
 					'columns'    => array( 'type' => 'unit', 'label' => __( 'Columns', 'ds-toolkit' ), 'default' => '4', 'responsive' => true, 'slider' => array( 'min' => 1, 'max' => 6, 'step' => 1 ) ),
 					'gap'        => array( 'type' => 'unit', 'label' => __( 'Gap', 'ds-toolkit' ), 'default' => '20', 'description' => 'px', 'responsive' => true, 'slider' => array( 'min' => 0, 'max' => 60, 'step' => 1 ) ),
-					'section_bg' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Section Background', 'ds-toolkit' ), 'default' => 'var(--fl-global-light-background)', 'show_reset' => true ),
 				),
 			),
 			// --- Style 1 only: clip-card shape ---


### PR DESCRIPTION
Closes #154.

## What was wrong

`section_bg` was defined inside the **Grid** panel, which Styles 5 and 6 do not show. So switching to Program Cards made the control disappear — **even though the setting still applied**, because both the CTA stylesheet and `DS_Program_Cards::chrome_css()` read it regardless of style.

So this was a missing control, not a missing feature.

## The fix

Moved into its own **Section** panel, exposed to Styles 1, 2, 3, 5 and 6. Style 4 is deliberately excluded — it has its own Hero Background controls and a second background control there would be confusing.

Same field, same key, same default, same emission. **Existing modules of every style render exactly as before**; the control simply became visible where it was already working. Section Background and Card Background remain separate settings.

## Verified

| Check | Result |
|---|---|
| Section panel resolves for style1/2/3/5/6 | yes |
| style4 (hero) | excluded, as intended |
| `section_bg` field definitions | **exactly 1** (not duplicated) |
| Default | unchanged (`var(--fl-global-light-background)`) |
| Shared Program Cards chrome still reads it | yes |

Not a regression from the 1.9.99 panel reorder — Style 6 never had the `colors` or `grid` panels; I checked before assuming.