### PR TITLE
fix: Heading Text panel ordered content-first (GH #156) (1.9.102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.102] - 2026-08-26
+### Changed
+- **Heading: the Text panel is ordered content-first (GH #156).** Style, then the Sub-heading and Heading text, then the End Mark, with the structural controls (Show Sub-heading, Sub-heading Position, the two SEO tag pickers and Alignment) below them. Display order only — every field keeps its name, default, help text and conditional visibility, so saved values are untouched and nothing about the rendered output changes. Verified the form still carries the same 34 fields, that the End Mark still appears only on Style 2, that Show Sub-heading still reveals the sub-heading and its position, and that Alignment is still responsive.
+
 ## [1.9.101] - 2026-08-25
 ### Fixed
 - **CTA: Section Background is reachable from every card style (GH #154).** The control was defined inside the **Grid** panel, which Styles 5 and 6 do not show — so switching to Program Cards made it vanish even though the setting still applied. It now lives in its own **Section** panel, shown for Styles 1, 2, 3, 5 and 6. Style 4 keeps its own Hero Background controls and is deliberately left out. Nothing about the value or its output changed: it is the same `section_bg` field with the same default, still emitted by both the CTA stylesheet and the shared Program Cards chrome, so **existing modules of every style render exactly as before** — the control simply became visible where it was already working. Section Background and Card Background remain separate settings.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.101
+ * Version:           1.9.102
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.101' );
+define( 'DS_TOOLKIT_VERSION', '1.9.102' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-heading/ds-heading.php
+++ b/modules/ds-heading/ds-heading.php
@@ -207,6 +207,15 @@ FLBuilder::register_module( 'DS_Heading_Module', array(
 						'toggle'  => array( 'style2' => array( 'fields' => array( 'style2_image' ), 'sections' => array( 'endmark' ) ) ),
 						'help'    => __( 'Style 2 puts the heading on the left with a rule running through the remaining space, and an optional mark at the end. Existing modules stay on Style 1.', 'ds-toolkit' ),
 					),
+					'subheading'          => array( 'type' => 'text', 'label' => __( 'Sub-heading', 'ds-toolkit' ), 'default' => 'Sub Heading', 'connections' => array( 'string' ) ),
+					'heading'             => array(
+						'type'        => 'textarea',
+						'label'       => __( 'Heading', 'ds-toolkit' ),
+						'rows'        => 2,
+						'default'     => 'Section {a}Heading{/a}',
+						'connections' => array( 'string' ),
+						'help'        => __( 'Wrap a word in {a}…{/a} to colour it with the accent. Line breaks are kept. Use the connect (+) icon to pull a dynamic field (post title, ACF, etc.). {outline}…{/outline} renders outlined (transparent, stroked) text — default style in Theme Setting.', 'ds-toolkit' ),
+					),
 					'style2_image'        => array(
 						'type'        => 'photo',
 						'label'       => __( 'End Mark (optional)', 'ds-toolkit' ),
@@ -222,20 +231,11 @@ FLBuilder::register_module( 'DS_Heading_Module', array(
 						'toggle'  => array( 'yes' => array( 'fields' => array( 'subheading', 'subheading_position' ) ) ),
 						'help'    => __( 'The sub-heading is always output as a <span> (never a heading tag), so it stays SEO-clean.', 'ds-toolkit' ),
 					),
-					'subheading'          => array( 'type' => 'text', 'label' => __( 'Sub-heading', 'ds-toolkit' ), 'default' => 'Sub Heading', 'connections' => array( 'string' ) ),
 					'subheading_position' => array(
 						'type'    => 'select',
 						'label'   => __( 'Sub-heading Position', 'ds-toolkit' ),
 						'default' => 'above',
 						'options' => array( 'above' => __( 'Above heading', 'ds-toolkit' ), 'below' => __( 'Below heading', 'ds-toolkit' ) ),
-					),
-					'heading'             => array(
-						'type'        => 'textarea',
-						'label'       => __( 'Heading', 'ds-toolkit' ),
-						'rows'        => 2,
-						'default'     => 'Section {a}Heading{/a}',
-						'connections' => array( 'string' ),
-						'help'        => __( 'Wrap a word in {a}…{/a} to colour it with the accent. Line breaks are kept. Use the connect (+) icon to pull a dynamic field (post title, ACF, etc.). {outline}…{/outline} renders outlined (transparent, stroked) text — default style in Theme Setting.', 'ds-toolkit' ),
 					),
 					'heading_tag'         => array(
 						'type'    => 'select',


### PR DESCRIPTION
Closes #156.

Display order only — no field name, default, help text or conditional visibility changed, and no CSS or render code was touched.

| # | Field | Was |
|---|---|---|
| 1 | Style | 1 |
| 2 | Sub-heading | 4 |
| 3 | Heading | 6 |
| 4 | End Mark (optional) | 2 |
| 5 | Show Sub-heading | 3 |
| 6 | Sub-heading Position | 5 |
| 7 | Heading Tag (SEO) | 7 |
| 8 | Sub-heading Tag (SEO) | 8 |
| 9 | Alignment | 9 |

## Verified

| Check | Result |
|---|---|
| Order matches the request exactly | yes |
| **Form still carries 34 fields** (before and after) | yes — nothing dropped while re-slicing blocks |
| End Mark shows only on Style 2 | yes, and still pulls in its Style-tab section |
| Show Sub-heading reveals sub-heading + position | yes |
| Alignment still responsive | yes |
| PHP lint | clean |

Note on the toggles: BB resolves them by field name, not position, so `Show Sub-heading` still controls `Sub-heading` even though that field now appears above it.