### PR TITLE
feat: CTA Style 4 centred sub-heading gets a rule on both sides (GH #158) (1.9.103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.103] - 2026-08-26
+### Added
+- **CTA Style 4: a centred sub-heading gets an eyebrow rule on both sides (GH #158).** Matching the Heading module, as asked. Both rules are always in the markup and the trailing one is revealed by CSS only when the active alignment is centred, so the behaviour stays tied to the alignment in force rather than to a decision made at render time. Left alignment keeps the single leading rule it has always had, and no new toggle is introduced. Both sides share one class, so colour, thickness and spacing stay identical without duplicating a setting. The rules are now `flex: 0 1 auto` with `min-width: 0` so they shrink evenly on a narrow screen instead of pushing the text out — measured at 300px with a long sub-heading, they came down to 23px each, still balanced, with no overflow.
+
 ## [1.9.102] - 2026-08-26
 ### Changed
 - **Heading: the Text panel is ordered content-first (GH #156).** Style, then the Sub-heading and Heading text, then the End Mark, with the structural controls (Show Sub-heading, Sub-heading Position, the two SEO tag pickers and Alignment) below them. Display order only — every field keeps its name, default, help text and conditional visibility, so saved values are untouched and nothing about the rendered output changes. Verified the form still carries the same 34 fields, that the End Mark still appears only on Style 2, that Show Sub-heading still reveals the sub-heading and its position, and that Alignment is still responsive.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.102
+ * Version:           1.9.103
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.102' );
+define( 'DS_TOOLKIT_VERSION', '1.9.103' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-cta/css/frontend.css
+++ b/modules/ds-cta/css/frontend.css
@@ -134,7 +134,15 @@
 /* Sub-heading */
 .ds-cta--style4 .ds-cta-hero-eyebrow{display:flex;align-items:center;justify-content:center;gap:14px;font-weight:700;font-size:.8rem;letter-spacing:.22em;text-transform:uppercase;color:var(--fl-global-accent);margin:0 0 18px;}
 .ds-cta--style4-left .ds-cta-hero-eyebrow{justify-content:flex-start;}
-.ds-cta--style4 .ds-cta-hero-eyebrow-line{display:inline-block;width:34px;height:2px;background:currentColor;flex:none;}
+/* flex:0 1 auto + min-width:0 so the rules shrink on a narrow screen instead of
+   pushing the text out; both sides share this class, so colour, thickness and
+   spacing stay identical without duplicating any setting. */
+.ds-cta--style4 .ds-cta-hero-eyebrow-line{display:inline-block;width:34px;height:2px;background:currentColor;flex:0 1 auto;min-width:0;}
+.ds-cta--style4 .ds-cta-hero-eyebrow{min-width:0;}
+/* Trailing rule only when the active alignment is centred (GH #158). Left keeps the
+   single leading rule it has always had. */
+.ds-cta--style4 .ds-cta-hero-eyebrow-line--after{display:none;}
+.ds-cta--style4-center .ds-cta-hero-eyebrow-line--after{display:inline-block;}
 /* Heading */
 .ds-cta--style4 .ds-cta-hero-heading{font-size:clamp(2.2rem,5vw,3.5rem);line-height:.95;letter-spacing:-.01em;text-transform:uppercase;font-weight:900;color:var(--fl-global-white);margin:0 0 22px;}
 .ds-cta--style4 .ds-cta-hero-heading .ds-cta-accent{color:var(--fl-global-accent);}

--- a/modules/ds-cta/ds-cta.php
+++ b/modules/ds-cta/ds-cta.php
@@ -457,8 +457,15 @@ class DS_CTA_Module extends FLBuilderModule {
 		// Eyebrow / sub-heading.
 		if ( ( $s->hero_show_eyebrow ?? 'yes' ) === 'yes' && ! empty( $s->hero_eyebrow ) ) {
 			echo '<div class="ds-cta-hero-eyebrow">';
-			if ( ( $s->hero_eyebrow_line ?? 'yes' ) === 'yes' ) { echo '<span class="ds-cta-hero-eyebrow-line" aria-hidden="true"></span>'; }
-			echo '<span>' . DS_Module_UI::inline( $s->hero_eyebrow ) . '</span></div>';
+			// A rule on BOTH sides when centred (GH #158), matching the Heading module.
+			// Both are always emitted and the trailing one is hidden by CSS unless the
+			// active alignment is centred — same reason as there: it keeps the rule tied
+			// to whatever alignment is in force rather than to a PHP-time decision.
+			$eyeline = ( $s->hero_eyebrow_line ?? 'yes' ) === 'yes';
+			if ( $eyeline ) { echo '<span class="ds-cta-hero-eyebrow-line ds-cta-hero-eyebrow-line--before" aria-hidden="true"></span>'; }
+			echo '<span class="ds-cta-hero-eyebrow-text">' . DS_Module_UI::inline( $s->hero_eyebrow ) . '</span>';
+			if ( $eyeline ) { echo '<span class="ds-cta-hero-eyebrow-line ds-cta-hero-eyebrow-line--after" aria-hidden="true"></span>'; }
+			echo '</div>';
 		}
 
 		// Heading.


### PR DESCRIPTION
Closes #158. Implemented the same way as the Heading module, as requested.

## How

Both rules are always in the markup; the trailing one is revealed by CSS only when the active alignment is centred. Doing it in CSS rather than PHP keeps the rule tied to whatever alignment is in force — `hero_align` is not responsive today, but this stays correct if it ever becomes so, which is the same reasoning used in the Heading module.

Left alignment keeps the single leading rule it has always had. **No new toggle**, per the issue.

Both sides share the `.ds-cta-hero-eyebrow-line` class, so colour, thickness and spacing are identical without duplicating a setting — that satisfies "existing line color, width, thickness, and spacing settings remain supported" for free.

The rules moved from `flex: none` to `flex: 0 1 auto` with `min-width: 0`, so they shrink evenly instead of pushing the text out of a narrow container.

## Verified

| Case | Leading rule | Trailing rule | Widths | Balanced | Overflow |
|---|---|---|---|---|---|
| **Centred, 760px** | shown | **shown** | 34 / 34 | yes | none |
| Left, 760px | shown | hidden | 34 / – | n/a | none |
| **Centred, 300px, long text** | shown | shown | **23 / 23** | yes | none |

No document horizontal scroll in any case. Also confirmed `justify-content` still computes to `center` / `flex-start`, so the existing centring behaviour is untouched — adding a third child to the flex row does not change it.