### PR TITLE
feat: Hero Banner Style 3 "Slider" — centred peek carousel (GH #160)

### DIFF
--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.103
+ * Version:           1.9.104
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.103' );
+define( 'DS_TOOLKIT_VERSION', '1.9.104' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-hero/css/frontend.css
+++ b/modules/ds-hero/css/frontend.css
@@ -129,3 +129,87 @@
 /* WYSIWYG subtext/subtitle paragraphs (rendered in a div wrapper). */
 .ds-hero-sub p{margin:0 0 .6em;}
 .ds-hero-sub p:last-child{margin-bottom:0;}
+
+/* ---------------- Style 3: peek slider ----------------
+   The viewport spans the module; slides are narrower and centred, so the previous
+   and next slide peek in at the edges. Every tunable is a custom property so the
+   dynamic CSS can re-declare it per breakpoint without repeating these rules. */
+.ds-hero--style3{position:relative;width:100%;}
+.ds-hero--style3{display:block;}
+/* .ds-hero is display:flex, which would size .ds-peek to the track's max-content width
+   (three slides wide) and leave the "centred" slide clipped with no peek showing. The
+   slider owns the full row, so pin it to the container and let it shrink below content. */
+.ds-hero--style3 .ds-peek{position:relative;width:100%;flex:1 1 100%;min-width:0;--ds-peek-h:640px;--ds-peek-w:93%;--ds-peek-gap:30px;--ds-peek-r:16px;--ds-peek-pad:48px;--ds-peek-cmw:640px;}
+.ds-hero--style3 .ds-peek-viewport{overflow:hidden;width:100%;}
+.ds-hero--style3 .ds-peek-track{display:flex;align-items:stretch;gap:var(--ds-peek-gap);will-change:transform;}
+/* pan-y lets the browser keep vertical scrolling while we take the horizontal drag. */
+.ds-hero--style3 .ds-peek--drag .ds-peek-viewport{touch-action:pan-y;cursor:grab;}
+.ds-hero--style3 .ds-peek--drag .ds-peek-track.is-dragging{cursor:grabbing;}
+.ds-hero--style3 .ds-peek-slide{position:relative;flex:0 0 var(--ds-peek-w);height:var(--ds-peek-h);border-radius:var(--ds-peek-r);overflow:hidden;isolation:isolate;}
+
+/* Background layer stack: base colour, image, pattern, overlay — all behind the content
+   and all clipped by the slide radius. None of them may swallow a drag or a click. */
+.ds-hero--style3 .ds-peek-bg{position:absolute;inset:0;z-index:0;pointer-events:none;background:var(--ds-peek-base,transparent);}
+.ds-hero--style3 .ds-peek-pic{position:absolute;inset:0;display:block;}
+.ds-hero--style3 .ds-peek-img{width:100%;height:100%;max-width:none;display:block;object-fit:cover;}
+.ds-hero--style3 .ds-peek-pattern,.ds-hero--style3 .ds-peek-overlay{position:absolute;inset:0;display:block;}
+.ds-hero--style3 .ds-peek-overlay{background:linear-gradient(to bottom,rgba(17,17,17,.2) 50%,rgba(17,17,17,.8));}
+
+/* Content. Default desktop layout: heading bottom-left, CTA bottom-right. */
+.ds-hero--style3 .ds-peek-content{position:relative;z-index:2;box-sizing:border-box;display:flex;gap:24px;height:100%;padding:var(--ds-peek-pad);}
+.ds-hero--style3 .ds-peek-title{margin:0;max-width:var(--ds-peek-cmw);color:var(--fl-global-white,#fff);}
+.ds-hero--style3 .ds-peek-cta{flex:0 0 auto;display:inline-flex;align-items:center;gap:.5em;text-decoration:none;}
+.ds-hero--style3 .ds-peek-cta svg{width:1em;height:1em;display:block;}
+
+.ds-hero--style3.ds-peek--v-top .ds-peek-content{align-items:flex-start;}
+.ds-hero--style3.ds-peek--v-center .ds-peek-content{align-items:center;}
+.ds-hero--style3.ds-peek--v-bottom .ds-peek-content{align-items:flex-end;}
+.ds-hero--style3.ds-peek--a-split .ds-peek-content{flex-direction:row;justify-content:space-between;}
+.ds-hero--style3.ds-peek--a-split .ds-peek-title{flex:1 1 auto;min-width:0;}
+.ds-hero--style3.ds-peek--a-left .ds-peek-content{flex-direction:column;align-items:flex-start;text-align:left;}
+.ds-hero--style3.ds-peek--a-center .ds-peek-content{flex-direction:column;align-items:center;text-align:center;}
+.ds-hero--style3.ds-peek--a-right .ds-peek-content{flex-direction:column;align-items:flex-end;text-align:right;}
+/* The vertical modifier sets cross-axis alignment; in a column layout that is the
+   horizontal edge, so the stack needs justify-content to honour top/centre/bottom. */
+.ds-hero--style3.ds-peek--v-top .ds-peek-content{justify-content:flex-start;}
+.ds-hero--style3.ds-peek--v-center.ds-peek--a-left .ds-peek-content,
+.ds-hero--style3.ds-peek--v-center.ds-peek--a-center .ds-peek-content,
+.ds-hero--style3.ds-peek--v-center.ds-peek--a-right .ds-peek-content{justify-content:center;}
+.ds-hero--style3.ds-peek--v-bottom.ds-peek--a-left .ds-peek-content,
+.ds-hero--style3.ds-peek--v-bottom.ds-peek--a-center .ds-peek-content,
+.ds-hero--style3.ds-peek--v-bottom.ds-peek--a-right .ds-peek-content{justify-content:flex-end;}
+
+/* Controls. Arrows sit inside the centred slide, not the full-bleed viewport. */
+.ds-hero--style3 .ds-peek-nav{position:absolute;top:50%;transform:translateY(-50%);z-index:200;display:inline-flex;align-items:center;justify-content:center;width:44px;height:44px;padding:0;border:0;border-radius:50%;background:rgba(15,18,24,.5);color:var(--fl-global-white,#fff);cursor:pointer;transition:background .2s ease;}
+.ds-hero--style3 .ds-peek-nav:hover{background:rgba(15,18,24,.78);}
+.ds-hero--style3 .ds-peek-nav svg{width:20px;height:20px;display:block;}
+.ds-hero--style3 .ds-peek-nav--prev{left:calc((100% - var(--ds-peek-w)) / 2 + 14px);}
+.ds-hero--style3 .ds-peek-nav--next{right:calc((100% - var(--ds-peek-w)) / 2 + 14px);}
+.ds-hero--style3 .ds-peek-dots{display:flex;justify-content:center;align-items:center;gap:9px;margin-top:22px;}
+.ds-hero--style3 .ds-peek-dot{width:9px;height:9px;padding:0;border:0;border-radius:50%;cursor:pointer;background:rgba(20,20,20,.25);transition:background .2s ease,transform .2s ease;}
+.ds-hero--style3 .ds-peek-dot:hover{background:rgba(20,20,20,.5);}
+.ds-hero--style3 .ds-peek-dot.is-active{background:var(--fl-global-accent);transform:scale(1.3);}
+.ds-hero--style3 .ds-peek-play{display:inline-flex;align-items:center;justify-content:center;width:26px;height:26px;margin-left:6px;padding:0;border:0;border-radius:50%;background:rgba(20,20,20,.25);color:var(--fl-global-white,#fff);cursor:pointer;}
+.ds-hero--style3 .ds-peek-play:hover{background:rgba(20,20,20,.5);}
+.ds-hero--style3 .ds-peek-play svg{width:12px;height:12px;display:block;}
+.ds-hero--style3 .ds-peek-play .ds-peek-ico-play{display:none;}
+.ds-hero--style3 .ds-peek-play.is-paused .ds-peek-ico-play{display:block;}
+.ds-hero--style3 .ds-peek-play.is-paused .ds-peek-ico-pause{display:none;}
+/* Visible focus for every control (spec: keyboard reachable with a visible state). */
+.ds-hero--style3 .ds-peek-nav:focus-visible,.ds-hero--style3 .ds-peek-dot:focus-visible,
+.ds-hero--style3 .ds-peek-play:focus-visible,.ds-hero--style3 .ds-peek-cta:focus-visible{outline:3px solid var(--fl-global-accent);outline-offset:3px;}
+.ds-hero--style3 .ds-peek-live{position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0;}
+.ds-hero--style3 .ds-peek-empty{padding:40px;text-align:center;border:1px dashed rgba(20,20,20,.3);}
+
+@media (max-width:768px){
+  /* Arrows eat usable width on a phone; swipe and dots carry navigation there. */
+  .ds-hero--style3 .ds-peek-nav{display:none;}
+  .ds-hero--style3.ds-peek--a-split .ds-peek-content{flex-direction:column;align-items:flex-start;justify-content:flex-end;gap:14px;}
+  /* flex:1 1 auto lets the heading take the leftover space in the desktop ROW. Left in
+     place once the container becomes a column it grows vertically instead, pinning the
+     heading to the top and the CTA to the bottom rather than stacking them together. */
+  .ds-hero--style3.ds-peek--a-split .ds-peek-title{max-width:100%;flex:0 0 auto;}
+}
+@media (prefers-reduced-motion:reduce){
+  .ds-hero--style3 .ds-peek-track{transition:none !important;}
+}

--- a/modules/ds-hero/ds-hero.php
+++ b/modules/ds-hero/ds-hero.php
@@ -242,10 +242,24 @@ class DS_Hero_Module extends FLBuilderModule {
 	 *   4. Scope any style-specific CSS under `.ds-hero--<key>` (the modifier class
 	 *      is printed on the section automatically).
 	 */
+	/** Blend modes offered on the Style 3 background layers. */
+	public static function blend_modes() {
+		return array(
+			'normal'     => __( 'Normal', 'ds-toolkit' ),
+			'multiply'   => __( 'Multiply', 'ds-toolkit' ),
+			'overlay'    => __( 'Overlay', 'ds-toolkit' ),
+			'screen'     => __( 'Screen', 'ds-toolkit' ),
+			'darken'     => __( 'Darken', 'ds-toolkit' ),
+			'lighten'    => __( 'Lighten', 'ds-toolkit' ),
+			'soft-light' => __( 'Soft Light', 'ds-toolkit' ),
+		);
+	}
+
 	public static function styles() {
 		return array(
 			'style1' => __( 'Style 1 — Classic', 'ds-toolkit' ),
 			'style2' => __( 'Style 2 — Page Banner (auto)', 'ds-toolkit' ),
+			'style3' => __( 'Style 3 — Slider', 'ds-toolkit' ),
 		);
 	}
 
@@ -400,6 +414,194 @@ class DS_Hero_Module extends FLBuilderModule {
 		if ( '' !== $crumbs && 'below' === $crumb_pos ) { echo $crumbs; }
 		echo '</div></div></section>';
 	}
+	/* ------------------------------------------- Style 3 — Peek Slider (GH #160) */
+
+	/** The nine focal-point choices, as an object-position value. */
+	private static function focal_pos( $key ) {
+		$ok = array(
+			'left top', 'center top', 'right top',
+			'left center', 'center center', 'right center',
+			'left bottom', 'center bottom', 'right bottom',
+		);
+		$key = trim( (string) $key );
+		return in_array( $key, $ok, true ) ? $key : 'center center';
+	}
+
+	/**
+	 * Normalised Style 3 slides: [{image, mobile, alt, focal, head, tag, cta, link, target}].
+	 * A slide with no image and no heading is dropped, so the track, the dots and the
+	 * "n of N" labels always agree on how many slides there are.
+	 */
+	private function peek_slides() {
+		$out = array();
+		$raw = $this->settings->peek_slides ?? array();
+		if ( ! is_array( $raw ) ) { return $out; }
+
+		foreach ( $raw as $slide ) {
+			$slide = (object) $slide;
+			$img   = ! empty( $slide->image ) ? $this->photo_url( $slide->image, 'full' ) : '';
+			$mob   = ! empty( $slide->image_mobile ) ? $this->photo_url( $slide->image_mobile, 'full' ) : '';
+			$head  = trim( (string) ( $slide->heading ?? '' ) );
+			if ( '' === $img && '' === $mob && '' === $head ) { continue; }
+
+			$tag = preg_replace( '/[^a-z0-9]/', '', strtolower( (string) ( $slide->heading_tag ?? 'h2' ) ) );
+			if ( ! in_array( $tag, array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div', 'span' ), true ) ) { $tag = 'h2'; }
+
+			$out[] = array(
+				'image'  => '' !== $img ? $img : $mob,
+				'mobile' => '' !== $mob ? $mob : $img,
+				'alt'    => trim( (string) ( $slide->img_alt ?? '' ) ),
+				'focal'  => self::focal_pos( $slide->focal ?? 'center center' ),
+				'head'   => $head,
+				'tag'    => $tag,
+				'cta'    => trim( (string) ( $slide->cta_text ?? '' ) ),
+				'link'   => trim( (string) ( $slide->cta_link ?? '' ) ),
+				'target' => ( ( $slide->cta_target ?? '_self' ) === '_blank' ) ? '_blank' : '_self',
+			);
+		}
+		return $out;
+	}
+
+	/** One Style 3 slide. */
+	private function peek_slide( $sl, $i, $total, $sm ) {
+		printf(
+			'<div class="ds-peek-slide%s" role="group" aria-roledescription="%s" aria-label="%s">',
+			0 === $i ? ' is-active' : '',
+			esc_attr__( 'slide', 'ds-toolkit' ),
+			esc_attr( sprintf( __( '%1$d of %2$d', 'ds-toolkit' ), $i + 1, $total ) )
+		);
+
+		echo '<div class="ds-peek-bg">';
+		if ( '' !== $sl['image'] ) {
+			echo '<picture class="ds-peek-pic">';
+			if ( $sl['mobile'] !== $sl['image'] ) {
+				printf( '<source media="(max-width:%dpx)" srcset="%s">', (int) $sm, esc_url( $sl['mobile'] ) );
+			}
+			printf(
+				'<img class="ds-peek-img" src="%s" alt="%s" style="object-position:%s" loading="%s" decoding="async" draggable="false">',
+				esc_url( $sl['image'] ),
+				esc_attr( $sl['alt'] ),
+				esc_attr( $sl['focal'] ),
+				0 === $i ? 'eager' : 'lazy'
+			);
+			echo '</picture>';
+		}
+		echo '<span class="ds-peek-pattern" aria-hidden="true"></span><span class="ds-peek-overlay" aria-hidden="true"></span></div>';
+
+		if ( '' !== $sl['head'] || '' !== $sl['cta'] ) {
+			echo '<div class="ds-peek-content">';
+			if ( '' !== $sl['head'] ) {
+				printf( '<%1$s class="ds-peek-title">%2$s</%1$s>', $sl['tag'], DS_Module_UI::inline( $sl['head'] ) );
+			}
+			if ( '' !== $sl['cta'] ) {
+				printf(
+					'<a class="ds-peek-cta" href="%s"%s>%s<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg></a>',
+					esc_url( '' !== $sl['link'] ? $sl['link'] : '#' ),
+					'_blank' === $sl['target'] ? ' target="_blank" rel="noopener noreferrer"' : '',
+					esc_html( $sl['cta'] )
+				);
+			}
+			echo '</div>';
+		}
+		echo '</div>';
+	}
+
+	/**
+	 * Style 3 — Peek Slider. A horizontal track whose active slide is centred and
+	 * narrower than the viewport, so the neighbouring slides peek in at the edges.
+	 * Behaviour lives in js/frontend.js; every dimension is a custom property the
+	 * dynamic CSS re-declares per breakpoint.
+	 */
+	public function render_style3() {
+		$s      = $this->settings;
+		$slides = $this->peek_slides();
+
+		if ( empty( $slides ) ) {
+			if ( class_exists( 'FLBuilderModel' ) && FLBuilderModel::is_builder_active() ) {
+				echo '<section class="ds-hero ds-hero--style3"><div class="ds-peek-empty">'
+					. esc_html__( 'Peek Slider — add your slides under Content → Slides.', 'ds-toolkit' )
+					. '</div></section>';
+			}
+			return;
+		}
+
+		$total    = count( $slides );
+		$multi    = $total > 1;
+		$loop     = $multi && ( $s->peek_loop ?? 'yes' ) === 'yes';
+		$autoplay = $multi && ( $s->peek_autoplay ?? 'yes' ) === 'yes';
+		$drag     = $multi && ( $s->peek_drag ?? 'yes' ) === 'yes';
+		$arrows   = $multi && ( $s->peek_arrows ?? 'yes' ) === 'yes';
+		$dots     = $multi && ( $s->peek_dots ?? 'yes' ) === 'yes';
+		$playbtn  = $autoplay && ( $s->peek_playpause ?? 'yes' ) === 'yes';
+
+		$vpos  = (string) ( $s->peek_content_v ?? 'bottom' );
+		if ( ! in_array( $vpos, array( 'top', 'center', 'bottom' ), true ) ) { $vpos = 'bottom'; }
+		$align = (string) ( $s->peek_content_align ?? 'split' );
+		if ( ! in_array( $align, array( 'split', 'left', 'center', 'right' ), true ) ) { $align = 'split'; }
+
+		$label = trim( (string) ( $s->peek_label ?? '' ) );
+		if ( '' === $label ) { $label = __( 'Featured highlights', 'ds-toolkit' ); }
+
+		list( , $sm ) = DS_Module_UI::breakpoints();
+
+		printf(
+			'<section class="ds-hero ds-hero--style3 ds-peek--v-%s ds-peek--a-%s">',
+			esc_attr( $vpos ),
+			esc_attr( $align )
+		);
+		printf(
+			'<div class="ds-peek%s" role="region" aria-roledescription="%s" aria-label="%s">',
+			$drag ? ' ds-peek--drag' : '',
+			esc_attr__( 'carousel', 'ds-toolkit' ),
+			esc_attr( $label )
+		);
+
+		printf(
+			'<div class="ds-peek-viewport"><div class="ds-peek-track" data-loop="%s" data-autoplay="%s" data-interval="%s" data-pause="%s" data-resume="%s" data-drag="%s" data-speed="%d">',
+			$loop ? 'yes' : 'no',
+			$autoplay ? 'yes' : 'no',
+			esc_attr( (string) max( 2, (int) DS_Module_UI::u( $s->peek_interval ?? '', 7 ) ) ),
+			( $s->peek_pause_hover ?? 'yes' ) === 'yes' ? 'yes' : 'no',
+			( $s->peek_resume ?? 'yes' ) === 'yes' ? 'yes' : 'no',
+			$drag ? 'yes' : 'no',
+			max( 100, (int) DS_Module_UI::u( $s->peek_speed ?? '', 600 ) )
+		);
+		foreach ( $slides as $i => $sl ) { $this->peek_slide( $sl, $i, $total, $sm ); }
+		echo '</div></div>';
+
+		if ( $arrows ) {
+			echo '<button type="button" class="ds-peek-nav ds-peek-nav--prev" aria-label="' . esc_attr__( 'Previous slide', 'ds-toolkit' ) . '"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M15 6l-6 6 6 6"/></svg></button>';
+			echo '<button type="button" class="ds-peek-nav ds-peek-nav--next" aria-label="' . esc_attr__( 'Next slide', 'ds-toolkit' ) . '"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M9 6l6 6-6 6"/></svg></button>';
+		}
+
+		if ( $dots || $playbtn ) {
+			echo '<div class="ds-peek-dots">';
+			if ( $dots ) {
+				for ( $d = 0; $d < $total; $d++ ) {
+					printf(
+						'<button type="button" class="ds-peek-dot%s" aria-current="%s" aria-label="%s"></button>',
+						0 === $d ? ' is-active' : '',
+						0 === $d ? 'true' : 'false',
+						esc_attr( sprintf( __( 'Go to slide %d', 'ds-toolkit' ), $d + 1 ) )
+					);
+				}
+			}
+			if ( $playbtn ) {
+				printf(
+					'<button type="button" class="ds-peek-play" data-play="%s" data-pause="%s" aria-label="%s"><svg class="ds-peek-ico-pause" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><rect x="6" y="5" width="4" height="14"/><rect x="14" y="5" width="4" height="14"/></svg><svg class="ds-peek-ico-play" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M7 4l13 8-13 8z"/></svg></button>',
+					esc_attr__( 'Play slideshow', 'ds-toolkit' ),
+					esc_attr__( 'Pause slideshow', 'ds-toolkit' ),
+					esc_attr__( 'Pause slideshow', 'ds-toolkit' )
+				);
+			}
+			echo '</div>';
+		}
+
+		// Announces the slide number on a manual move only — autoplay stays silent.
+		echo '<span class="ds-peek-live" aria-live="polite" aria-atomic="true"></span>';
+		echo '</div></section>';
+	}
+
 }
 
 /* ---------------------------------------------------- Mixed Media slide sub-form */
@@ -467,6 +669,106 @@ FLBuilder::register_settings_form( 'ds_hero_slide_form', array(
 	),
 ) );
 
+/* -------------------------------------------- Style 3 Peek Slider slide sub-form */
+
+FLBuilder::register_settings_form( 'ds_hero_peek_slide_form', array(
+	'title' => __( 'Slide', 'ds-toolkit' ),
+	'tabs'  => array(
+		'general' => array(
+			'title'    => __( 'Slide', 'ds-toolkit' ),
+			'sections' => array(
+				'image' => array(
+					'title'  => __( 'Image', 'ds-toolkit' ),
+					'fields' => array(
+						'image' => array(
+							'type'        => 'photo',
+							'label'       => __( 'Desktop Image', 'ds-toolkit' ),
+							'show_remove' => true,
+							'connections' => array( 'photo' ),
+						),
+						'image_mobile' => array(
+							'type'        => 'photo',
+							'label'       => __( 'Mobile Image', 'ds-toolkit' ),
+							'show_remove' => true,
+							'connections' => array( 'photo' ),
+							'help'        => __( 'Optional. Used below the small breakpoint — handy when the desktop crop loses its subject on a phone.', 'ds-toolkit' ),
+						),
+						'img_alt' => array(
+							'type'        => 'text',
+							'label'       => __( 'Image Alt Text', 'ds-toolkit' ),
+							'default'     => '',
+							'connections' => array( 'string' ),
+							'help'        => __( 'Describe the photo for screen readers. Leave blank if the image is purely decorative.', 'ds-toolkit' ),
+						),
+						'focal' => array(
+							'type'    => 'select',
+							'label'   => __( 'Image Focal Point', 'ds-toolkit' ),
+							'default' => 'center center',
+							'options' => array(
+								'left top'      => __( 'Top Left', 'ds-toolkit' ),
+								'center top'    => __( 'Top Centre', 'ds-toolkit' ),
+								'right top'     => __( 'Top Right', 'ds-toolkit' ),
+								'left center'   => __( 'Middle Left', 'ds-toolkit' ),
+								'center center' => __( 'Centre', 'ds-toolkit' ),
+								'right center'  => __( 'Middle Right', 'ds-toolkit' ),
+								'left bottom'   => __( 'Bottom Left', 'ds-toolkit' ),
+								'center bottom' => __( 'Bottom Centre', 'ds-toolkit' ),
+								'right bottom'  => __( 'Bottom Right', 'ds-toolkit' ),
+							),
+							'help'    => __( 'The part of the photo to keep in frame when it is cropped to the slide.', 'ds-toolkit' ),
+						),
+					),
+				),
+				'content' => array(
+					'title'  => __( 'Content', 'ds-toolkit' ),
+					'fields' => array(
+						'heading' => array(
+							'type'        => 'text',
+							'label'       => __( 'Heading', 'ds-toolkit' ),
+							'default'     => '',
+							'connections' => array( 'string' ),
+						),
+						'heading_tag' => array(
+							'type'    => 'select',
+							'label'   => __( 'Heading Tag', 'ds-toolkit' ),
+							'default' => 'h2',
+							'options' => array(
+								'h1' => 'H1', 'h2' => 'H2', 'h3' => 'H3',
+								'h4' => 'H4', 'h5' => 'H5', 'h6' => 'H6',
+								'p'  => __( 'Paragraph', 'ds-toolkit' ),
+								'div' => 'DIV',
+							),
+							'help'    => __( 'Use one H1 per page. On a page that already has an H1, H2 is the right choice here.', 'ds-toolkit' ),
+						),
+						'cta_text' => array(
+							'type'        => 'text',
+							'label'       => __( 'CTA Label', 'ds-toolkit' ),
+							'default'     => '',
+							'connections' => array( 'string' ),
+							'help'        => __( 'Leave blank for a slide with no button.', 'ds-toolkit' ),
+						),
+						'cta_link' => array(
+							'type'        => 'link',
+							'label'       => __( 'CTA Link', 'ds-toolkit' ),
+							'default'     => '',
+							'connections' => array( 'url' ),
+						),
+						'cta_target' => array(
+							'type'    => 'select',
+							'label'   => __( 'CTA Link Target', 'ds-toolkit' ),
+							'default' => '_self',
+							'options' => array(
+								'_self'  => __( 'Same Window', 'ds-toolkit' ),
+								'_blank' => __( 'New Window', 'ds-toolkit' ),
+							),
+						),
+					),
+				),
+			),
+		),
+	),
+) );
+
 FLBuilder::register_module( 'DS_Hero_Module', array(
 	'content' => array(
 		'title'    => __( 'Content', 'ds-toolkit' ),
@@ -487,6 +789,9 @@ FLBuilder::register_module( 'DS_Hero_Module', array(
 							),
 							'style2' => array(
 								'sections' => array( 'banner', 'banner_design', 'banner_height', 'banner_nobg', 'overlay', 'banner_scrim', 'typography', 'spacing' ),
+							),
+							'style3' => array(
+								'sections' => array( 'peek_slides_sec', 'peek_behavior', 'peek_layout', 'peek_bg', 'peek_text', 'peek_cta', 'spacing' ),
 							),
 						),
 					),
@@ -521,6 +826,101 @@ FLBuilder::register_module( 'DS_Hero_Module', array(
 						'toggle'  => array( 'yes' => array( 'fields' => array( 'breadcrumbs_position' ) ) ),
 					),
 					'breadcrumbs_position' => array( 'type' => 'select', 'label' => __( 'Breadcrumbs Position', 'ds-toolkit' ), 'default' => 'top', 'options' => array( 'top' => __( 'Top (above heading)', 'ds-toolkit' ), 'below' => __( 'Below (under description)', 'ds-toolkit' ) ) ),
+				),
+			),
+			'peek_slides_sec' => array(
+				'title'       => __( 'Slides', 'ds-toolkit' ),
+				'description' => __( 'Add, duplicate, remove and drag to reorder. The order here is the order on the page.', 'ds-toolkit' ),
+				'fields'      => array(
+					'peek_slides' => array(
+						'type'         => 'form',
+						'label'        => __( 'Slide', 'ds-toolkit' ),
+						'form'         => 'ds_hero_peek_slide_form',
+						'preview_text' => 'heading',
+						'multiple'     => true,
+					),
+					'peek_label' => array(
+						'type'    => 'text',
+						'label'   => __( 'Carousel Label', 'ds-toolkit' ),
+						'default' => '',
+						'help'    => __( 'Names the carousel for screen readers, e.g. "Featured programs". Blank uses a generic label.', 'ds-toolkit' ),
+					),
+				),
+			),
+			'peek_behavior' => array(
+				'title'  => __( 'Slider Behaviour', 'ds-toolkit' ),
+				'fields' => array(
+					'peek_autoplay' => array(
+						'type'    => 'select',
+						'label'   => __( 'Autoplay', 'ds-toolkit' ),
+						'default' => 'yes',
+						'options' => array( 'yes' => __( 'Enabled', 'ds-toolkit' ), 'no' => __( 'Disabled', 'ds-toolkit' ) ),
+						'help'    => __( 'Always off for visitors who ask for reduced motion.', 'ds-toolkit' ),
+						'toggle'  => array( 'yes' => array( 'fields' => array( 'peek_interval', 'peek_pause_hover', 'peek_resume', 'peek_playpause' ) ) ),
+					),
+					'peek_interval' => array(
+						'type'        => 'unit',
+						'label'       => __( 'Autoplay Speed', 'ds-toolkit' ),
+						'default'     => '7',
+						'description' => 's',
+						'slider'      => array( 'min' => 2, 'max' => 20, 'step' => 1 ),
+					),
+					'peek_pause_hover' => array(
+						'type'    => 'select',
+						'label'   => __( 'Pause on Hover', 'ds-toolkit' ),
+						'default' => 'yes',
+						'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No', 'ds-toolkit' ) ),
+						'help'    => __( 'Keyboard focus inside the slider always pauses it, so a tabbing visitor is never moved mid-read.', 'ds-toolkit' ),
+					),
+					'peek_resume' => array(
+						'type'    => 'select',
+						'label'   => __( 'After a Manual Move', 'ds-toolkit' ),
+						'default' => 'yes',
+						'options' => array(
+							'yes' => __( 'Resume autoplay', 'ds-toolkit' ),
+							'no'  => __( 'Stop autoplay', 'ds-toolkit' ),
+						),
+					),
+					'peek_playpause' => array(
+						'type'    => 'select',
+						'label'   => __( 'Pause / Play Button', 'ds-toolkit' ),
+						'default' => 'yes',
+						'options' => array( 'yes' => __( 'Show', 'ds-toolkit' ), 'no' => __( 'Hide', 'ds-toolkit' ) ),
+						'help'    => __( 'Recommended: an autoplaying carousel should give visitors a way to stop it.', 'ds-toolkit' ),
+					),
+					'peek_speed' => array(
+						'type'        => 'unit',
+						'label'       => __( 'Transition Speed', 'ds-toolkit' ),
+						'default'     => '600',
+						'description' => 'ms',
+						'slider'      => array( 'min' => 150, 'max' => 1500, 'step' => 50 ),
+					),
+					'peek_loop' => array(
+						'type'    => 'select',
+						'label'   => __( 'Infinite Loop', 'ds-toolkit' ),
+						'default' => 'yes',
+						'options' => array( 'yes' => __( 'Enabled', 'ds-toolkit' ), 'no' => __( 'Disabled', 'ds-toolkit' ) ),
+					),
+					'peek_drag' => array(
+						'type'    => 'select',
+						'label'   => __( 'Drag / Swipe', 'ds-toolkit' ),
+						'default' => 'yes',
+						'options' => array( 'yes' => __( 'Enabled', 'ds-toolkit' ), 'no' => __( 'Disabled', 'ds-toolkit' ) ),
+						'help'    => __( 'Mouse dragging and touch swiping. Vertical swipes still scroll the page.', 'ds-toolkit' ),
+					),
+					'peek_arrows' => array(
+						'type'    => 'select',
+						'label'   => __( 'Navigation Arrows', 'ds-toolkit' ),
+						'default' => 'yes',
+						'options' => array( 'yes' => __( 'Show', 'ds-toolkit' ), 'no' => __( 'Hide', 'ds-toolkit' ) ),
+						'help'    => __( 'Hidden on phones either way — they cost more width than they earn.', 'ds-toolkit' ),
+					),
+					'peek_dots' => array(
+						'type'    => 'select',
+						'label'   => __( 'Pagination Dots', 'ds-toolkit' ),
+						'default' => 'yes',
+						'options' => array( 'yes' => __( 'Show', 'ds-toolkit' ), 'no' => __( 'Hide', 'ds-toolkit' ) ),
+					),
 				),
 			),
 			'text' => array(
@@ -817,6 +1217,298 @@ FLBuilder::register_module( 'DS_Hero_Module', array(
 					'sub_color'     => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Subtext', 'ds-toolkit' ), 'default' => 'var(--fl-global-white)', 'show_reset' => true ),
 					'stat_num_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Stat Number', 'ds-toolkit' ), 'default' => 'var(--fl-global-white)', 'show_reset' => true ),
 					'stat_label_color' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Stat Label', 'ds-toolkit' ), 'default' => 'var(--fl-global-accent)', 'show_reset' => true ),
+				),
+			),
+			'peek_layout' => array(
+				'title'  => __( 'Slide Layout', 'ds-toolkit' ),
+				'fields' => array(
+					'peek_height' => array(
+						'type'        => 'unit',
+						'label'       => __( 'Slide Height', 'ds-toolkit' ),
+						'default'     => '640',
+						'description' => 'px',
+						'responsive'  => true,
+						'slider'      => array( 'min' => 240, 'max' => 900, 'step' => 10 ),
+					),
+					'peek_width' => array(
+						'type'        => 'unit',
+						'label'       => __( 'Slide Width', 'ds-toolkit' ),
+						'default'     => '93',
+						'description' => '%',
+						'responsive'  => true,
+						'slider'      => array( 'min' => 50, 'max' => 100, 'step' => 1 ),
+						'help'        => __( 'Under 100% is what makes the neighbouring slides peek in at the edges.', 'ds-toolkit' ),
+					),
+					'peek_gap' => array(
+						'type'        => 'unit',
+						'label'       => __( 'Gap Between Slides', 'ds-toolkit' ),
+						'default'     => '30',
+						'description' => 'px',
+						'responsive'  => true,
+						'slider'      => array( 'min' => 0, 'max' => 80, 'step' => 2 ),
+					),
+					'peek_radius' => array(
+						'type'        => 'unit',
+						'label'       => __( 'Border Radius', 'ds-toolkit' ),
+						'default'     => '16',
+						'description' => 'px',
+						'responsive'  => true,
+						'slider'      => array( 'min' => 0, 'max' => 60, 'step' => 1 ),
+					),
+					'peek_pad' => array(
+						'type'        => 'unit',
+						'label'       => __( 'Content Padding', 'ds-toolkit' ),
+						'default'     => '48',
+						'description' => 'px',
+						'responsive'  => true,
+						'slider'      => array( 'min' => 8, 'max' => 120, 'step' => 2 ),
+					),
+					'peek_content_width' => array(
+						'type'        => 'unit',
+						'label'       => __( 'Heading Maximum Width', 'ds-toolkit' ),
+						'default'     => '640',
+						'description' => 'px',
+						'responsive'  => true,
+						'slider'      => array( 'min' => 200, 'max' => 1200, 'step' => 10 ),
+					),
+					'peek_content_v' => array(
+						'type'    => 'select',
+						'label'   => __( 'Vertical Content Position', 'ds-toolkit' ),
+						'default' => 'bottom',
+						'options' => array(
+							'top'    => __( 'Top', 'ds-toolkit' ),
+							'center' => __( 'Middle', 'ds-toolkit' ),
+							'bottom' => __( 'Bottom', 'ds-toolkit' ),
+						),
+					),
+					'peek_content_align' => array(
+						'type'    => 'select',
+						'label'   => __( 'Heading & CTA Alignment', 'ds-toolkit' ),
+						'default' => 'split',
+						'options' => array(
+							'split'  => __( 'Split — heading left, CTA right', 'ds-toolkit' ),
+							'left'   => __( 'Stacked left', 'ds-toolkit' ),
+							'center' => __( 'Stacked centre', 'ds-toolkit' ),
+							'right'  => __( 'Stacked right', 'ds-toolkit' ),
+						),
+						'help'    => __( 'Split stacks automatically on phones so nothing is squeezed.', 'ds-toolkit' ),
+					),
+				),
+			),
+			'peek_bg' => array(
+				'title'       => __( 'Slide Background Layers', 'ds-toolkit' ),
+				'description' => __( 'Stacked bottom to top: base colour, slide image, pattern, overlay, then the heading and CTA. Each slide sets its own image and focal point; these settings style every slide the same way.', 'ds-toolkit' ),
+				'fields'      => array(
+					'peek_base_color' => array(
+						'type'        => 'color',
+						'label'       => __( 'Base Background Colour', 'ds-toolkit' ),
+						'default'     => '',
+						'show_reset'  => true,
+						'show_alpha'  => true,
+						'connections' => array( 'color' ),
+						'help'        => __( 'Sits under the image — shows through a transparent PNG or a reduced image opacity.', 'ds-toolkit' ),
+					),
+					'peek_img_size' => array(
+						'type'    => 'select',
+						'label'   => __( 'Image Size', 'ds-toolkit' ),
+						'default' => 'cover',
+						'options' => array(
+							'cover'   => __( 'Cover (fill the slide)', 'ds-toolkit' ),
+							'contain' => __( 'Contain (fit inside)', 'ds-toolkit' ),
+						),
+					),
+					'peek_img_opacity' => array(
+						'type'        => 'unit',
+						'label'       => __( 'Image Opacity', 'ds-toolkit' ),
+						'default'     => '100',
+						'description' => '%',
+						'slider'      => array( 'min' => 0, 'max' => 100, 'step' => 1 ),
+					),
+					'peek_img_blend' => array(
+						'type'    => 'select',
+						'label'   => __( 'Image Blend Mode', 'ds-toolkit' ),
+						'default' => 'normal',
+						'options' => DS_Hero_Module::blend_modes(),
+					),
+					'peek_pattern' => array(
+						'type'        => 'photo',
+						'label'       => __( 'Pattern / Texture', 'ds-toolkit' ),
+						'show_remove' => true,
+						'connections' => array( 'photo' ),
+						'help'        => __( 'Optional tileable image laid over the photo.', 'ds-toolkit' ),
+					),
+					'peek_pattern_size' => array(
+						'type'    => 'select',
+						'label'   => __( 'Pattern Size', 'ds-toolkit' ),
+						'default' => 'auto',
+						'options' => array(
+							'auto'    => __( 'Original', 'ds-toolkit' ),
+							'cover'   => __( 'Cover', 'ds-toolkit' ),
+							'contain' => __( 'Contain', 'ds-toolkit' ),
+						),
+					),
+					'peek_pattern_repeat' => array(
+						'type'    => 'select',
+						'label'   => __( 'Pattern Repeat', 'ds-toolkit' ),
+						'default' => 'repeat',
+						'options' => array(
+							'repeat'    => __( 'Tile', 'ds-toolkit' ),
+							'repeat-x'  => __( 'Tile horizontally', 'ds-toolkit' ),
+							'repeat-y'  => __( 'Tile vertically', 'ds-toolkit' ),
+							'no-repeat' => __( 'No repeat', 'ds-toolkit' ),
+						),
+					),
+					'peek_pattern_pos' => array(
+						'type'    => 'select',
+						'label'   => __( 'Pattern Position', 'ds-toolkit' ),
+						'default' => 'center center',
+						'options' => array(
+							'left top'      => __( 'Top Left', 'ds-toolkit' ),
+							'center top'    => __( 'Top Centre', 'ds-toolkit' ),
+							'right top'     => __( 'Top Right', 'ds-toolkit' ),
+							'left center'   => __( 'Middle Left', 'ds-toolkit' ),
+							'center center' => __( 'Centre', 'ds-toolkit' ),
+							'right center'  => __( 'Middle Right', 'ds-toolkit' ),
+							'left bottom'   => __( 'Bottom Left', 'ds-toolkit' ),
+							'center bottom' => __( 'Bottom Centre', 'ds-toolkit' ),
+							'right bottom'  => __( 'Bottom Right', 'ds-toolkit' ),
+						),
+					),
+					'peek_pattern_opacity' => array(
+						'type'        => 'unit',
+						'label'       => __( 'Pattern Opacity', 'ds-toolkit' ),
+						'default'     => '100',
+						'description' => '%',
+						'slider'      => array( 'min' => 0, 'max' => 100, 'step' => 1 ),
+					),
+					'peek_pattern_blend' => array(
+						'type'    => 'select',
+						'label'   => __( 'Pattern Blend Mode', 'ds-toolkit' ),
+						'default' => 'normal',
+						'options' => DS_Hero_Module::blend_modes(),
+					),
+					'peek_ov_type' => array(
+						'type'    => 'select',
+						'label'   => __( 'Overlay Type', 'ds-toolkit' ),
+						'default' => 'gradient',
+						'options' => array(
+							'none'     => __( 'None', 'ds-toolkit' ),
+							'solid'    => __( 'Solid Colour', 'ds-toolkit' ),
+							'gradient' => __( 'Gradient', 'ds-toolkit' ),
+						),
+						'help'    => __( 'The default gradient is light at the top and dark near the bottom, so a heading placed low stays readable.', 'ds-toolkit' ),
+						'toggle'  => array(
+							'solid'    => array( 'fields' => array( 'peek_ov_color', 'peek_ov_opacity', 'peek_ov_blend' ) ),
+							'gradient' => array( 'fields' => array( 'peek_ov_color', 'peek_ov_color2', 'peek_ov_dir', 'peek_ov_opacity', 'peek_ov_blend' ) ),
+						),
+					),
+					'peek_ov_color' => array(
+						'type'        => 'color',
+						'label'       => __( 'Overlay Colour', 'ds-toolkit' ),
+						'default'     => '',
+						'show_reset'  => true,
+						'show_alpha'  => true,
+						'connections' => array( 'color' ),
+						'help'        => __( 'Gradient start. Blank keeps the designed default.', 'ds-toolkit' ),
+					),
+					'peek_ov_color2' => array(
+						'type'        => 'color',
+						'label'       => __( 'Overlay Colour 2', 'ds-toolkit' ),
+						'default'     => '',
+						'show_reset'  => true,
+						'show_alpha'  => true,
+						'connections' => array( 'color' ),
+						'help'        => __( 'Gradient end.', 'ds-toolkit' ),
+					),
+					'peek_ov_dir' => array(
+						'type'    => 'select',
+						'label'   => __( 'Gradient Direction', 'ds-toolkit' ),
+						'default' => 'to bottom',
+						'options' => array(
+							'to bottom'       => __( 'Top to bottom', 'ds-toolkit' ),
+							'to top'          => __( 'Bottom to top', 'ds-toolkit' ),
+							'to right'        => __( 'Left to right', 'ds-toolkit' ),
+							'to left'         => __( 'Right to left', 'ds-toolkit' ),
+							'to bottom right' => __( 'Diagonal ↘', 'ds-toolkit' ),
+							'to bottom left'  => __( 'Diagonal ↙', 'ds-toolkit' ),
+						),
+					),
+					'peek_ov_opacity' => array(
+						'type'        => 'unit',
+						'label'       => __( 'Overlay Opacity', 'ds-toolkit' ),
+						'default'     => '100',
+						'description' => '%',
+						'slider'      => array( 'min' => 0, 'max' => 100, 'step' => 1 ),
+					),
+					'peek_ov_blend' => array(
+						'type'    => 'select',
+						'label'   => __( 'Overlay Blend Mode', 'ds-toolkit' ),
+						'default' => 'normal',
+						'options' => DS_Hero_Module::blend_modes(),
+					),
+				),
+			),
+			'peek_text' => array(
+				'title'  => __( 'Slide Heading', 'ds-toolkit' ),
+				'fields' => array(
+					'peek_title_color' => array(
+						'type'        => 'color',
+						'label'       => __( 'Heading Colour', 'ds-toolkit' ),
+						'default'     => '',
+						'show_reset'  => true,
+						'show_alpha'  => true,
+						'connections' => array( 'color' ),
+						'help'        => __( 'Blank = white, which is what reads on a photo under the default overlay.', 'ds-toolkit' ),
+						'preview'     => array( 'type' => 'css', 'selector' => '.ds-peek-title', 'property' => 'color' ),
+					),
+					'peek_title_typography' => array(
+						'type'       => 'typography',
+						'label'      => __( 'Heading Typography', 'ds-toolkit' ),
+						'responsive' => true,
+						'preview'    => array( 'type' => 'css', 'selector' => '.ds-peek-title' ),
+						'help'       => __( 'Font, size, line height, letter spacing and text transform, per breakpoint.', 'ds-toolkit' ),
+					),
+				),
+			),
+			'peek_cta' => array(
+				'title'  => __( 'Slide CTA Button', 'ds-toolkit' ),
+				'fields' => array(
+					'peek_btn_global' => array(
+						'type'    => 'select',
+						'label'   => __( 'Button Style', 'ds-toolkit' ),
+						'default' => 'yes',
+						'options' => array(
+							'yes' => __( 'Match site Button (Theme Setting)', 'ds-toolkit' ),
+							'no'  => __( 'Custom (below)', 'ds-toolkit' ),
+						),
+						'toggle'  => array(
+							'no' => array( 'fields' => array( 'peek_btn_bg', 'peek_btn_color', 'peek_btn_border', 'peek_btn_hover_bg', 'peek_btn_hover_color' ) ),
+						),
+					),
+					'peek_btn_size' => array(
+						'type'    => 'select',
+						'label'   => __( 'Button Size', 'ds-toolkit' ),
+						'default' => 'medium',
+						'options' => array(
+							'small'  => __( 'Small', 'ds-toolkit' ),
+							'medium' => __( 'Medium', 'ds-toolkit' ),
+							'large'  => __( 'Large', 'ds-toolkit' ),
+						),
+					),
+					'peek_btn_radius' => array(
+						'type'        => 'unit',
+						'label'       => __( 'Button Border Radius', 'ds-toolkit' ),
+						'default'     => '',
+						'description' => 'px',
+						'slider'      => array( 'min' => 0, 'max' => 60, 'step' => 1 ),
+						'help'        => __( 'Blank follows the site button.', 'ds-toolkit' ),
+					),
+					'peek_btn_bg'          => array( 'type' => 'color', 'label' => __( 'Background Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true, 'connections' => array( 'color' ) ),
+					'peek_btn_color'       => array( 'type' => 'color', 'label' => __( 'Text Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'connections' => array( 'color' ) ),
+					'peek_btn_border'      => array( 'type' => 'color', 'label' => __( 'Border Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'connections' => array( 'color' ) ),
+					'peek_btn_hover_bg'    => array( 'type' => 'color', 'label' => __( 'Hover Background', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'show_alpha' => true, 'connections' => array( 'color' ) ),
+					'peek_btn_hover_color' => array( 'type' => 'color', 'label' => __( 'Hover Text Colour', 'ds-toolkit' ), 'default' => '', 'show_reset' => true, 'connections' => array( 'color' ) ),
+					'peek_btn_typography'  => array( 'type' => 'typography', 'label' => __( 'Button Typography', 'ds-toolkit' ), 'responsive' => true, 'preview' => array( 'type' => 'css', 'selector' => '.ds-peek-cta' ) ),
 				),
 			),
 			'typography' => array(

--- a/modules/ds-hero/includes/frontend.css.php
+++ b/modules/ds-hero/includes/frontend.css.php
@@ -45,8 +45,9 @@ $mix = function( $color, $op ) use ( $col ) {
 $g   = FLBuilderModel::get_global_settings();
 list( $bpm, $bpr ) = DS_Module_UI::breakpoints();
 
-// ---- Min height (responsive) — Style 1 only; Style 2 banner uses adaptive heights ----
-if ( 'style2' !== $style ) {
+// ---- Min height (responsive) — Style 1 only; Style 2 banner uses adaptive heights and
+// Style 3 takes its height from the slide, so neither may inherit this. ----
+if ( 'style1' === $style ) {
 	$mh = $u( $settings->min_height ?? '', 92 );
 	echo "$node .ds-hero { min-height: {$mh}vh; }\n";
 	if ( '' !== ( $settings->min_height_medium ?? '' ) ) { echo "@media (max-width:{$bpm}px){ $node .ds-hero { min-height: " . (int) $settings->min_height_medium . "vh; } }\n"; }
@@ -304,3 +305,194 @@ if ( class_exists( 'FLBuilderCSS' ) ) {
 $oc_ov = DS_Module_UI::color( $settings->outline_color ?? '' );
 if ( '' !== $oc_ov ) { echo "$node { --ds-outline-c: {$oc_ov}; }\n"; }
 if ( isset( $settings->outline_width ) && '' !== $settings->outline_width ) { echo "$node { --ds-outline-w: " . max( 1, (int) $settings->outline_width ) . "px; }\n"; }
+
+/* ---------------- Style 3 — Peek Slider (GH #160) ----------------
+   Every dimension is written as a custom property on the .ds-peek root, so a
+   breakpoint override is one re-declaration instead of a second copy of the
+   layout rules. Child selectors keep the three-class form documented at the top. */
+if ( 'style3' === $style ) {
+	list( $md, $sm ) = DS_Module_UI::breakpoints();
+	$peek = "$node .ds-hero--style3 .ds-peek";
+
+	// Responsive custom properties: desktop, then medium, then small.
+	//
+	// Each breakpoint carries its OWN fallback rather than inheriting the desktop value.
+	// A fixed 30px gap eats the free space at narrow widths — at 900px a 93% slide leaves
+	// only 1.5px of neighbour showing and at 390px none at all, which loses the one thing
+	// this style exists for. Narrower slides plus a tighter gap keep the peek visible all
+	// the way down. These fallbacks must be emitted here, not as static media queries:
+	// the dynamic rule is (0,3,0) and would outrank a (0,2,0) static @media whatever the
+	// load order.
+	$fallbacks = array(
+		//                        desktop, medium, small
+		'peek_height'        => array( 640, 520, 440 ),
+		'peek_width'         => array( 93, 92, 88 ),
+		'peek_gap'           => array( 30, 20, 12 ),
+		'peek_radius'        => array( 16, 14, 12 ),
+		'peek_pad'           => array( 48, 32, 22 ),
+		'peek_content_width' => array( 640, 520, 400 ),
+	);
+	$units = array(
+		'peek_height'        => array( '--ds-peek-h', 'px' ),
+		'peek_width'         => array( '--ds-peek-w', '%' ),
+		'peek_gap'           => array( '--ds-peek-gap', 'px' ),
+		'peek_radius'        => array( '--ds-peek-r', 'px' ),
+		'peek_pad'           => array( '--ds-peek-pad', 'px' ),
+		'peek_content_width' => array( '--ds-peek-cmw', 'px' ),
+	);
+	$vars = function( $suffix, $tier ) use ( $settings, $fallbacks, $units ) {
+		$out = '';
+		foreach ( $units as $key => $pair ) {
+			$v = $settings->{ $key . $suffix } ?? '';
+			if ( '' === $v || null === $v ) {
+				if ( 0 === $tier ) { continue; }
+				$base = (string) ( $settings->{$key} ?? '' );
+				// A desktop value the editor actually changed carries down, the way Beaver
+				// Builder responsive fields inherit. An untouched desktop value means they
+				// never had an opinion, so use the tier default and keep the peek visible.
+				$touched = ( '' !== $base && (float) $base !== (float) $fallbacks[ $key ][0] );
+				$v = $touched ? $base : $fallbacks[ $key ][ $tier ];
+			}
+			$out .= $pair[0] . ':' . ( (float) $v ) . $pair[1] . ';';
+		}
+		return $out;
+	};
+
+	$base = $vars( '', 0 );
+	if ( '' !== $base ) { echo "$peek { $base }\n"; }
+	$mid = $vars( '_medium', 1 );
+	if ( '' !== $mid ) { echo "@media (max-width:{$md}px){ $peek { $mid } }\n"; }
+	$small = $vars( '_responsive', 2 );
+	if ( '' !== $small ) { echo "@media (max-width:{$sm}px){ $peek { $small } }\n"; }
+
+	$pct = function( $v, $d ) {
+		$n = ( isset( $v ) && '' !== $v ) ? (float) $v : $d;
+		return max( 0, min( 100, $n ) ) / 100;
+	};
+	$blend = function( $v ) {
+		$v = preg_replace( '/[^a-z-]/', '', strtolower( (string) $v ) );
+		return in_array( $v, array( 'normal', 'multiply', 'overlay', 'screen', 'darken', 'lighten', 'soft-light' ), true ) ? $v : 'normal';
+	};
+
+	// ---- Base colour (behind the image) ----
+	$basec = DS_Module_UI::color( $settings->peek_base_color ?? '' );
+	if ( '' !== $basec ) { echo "$peek .ds-peek-bg { background: {$basec}; }\n"; }
+
+	// ---- Main image ----
+	$img_decl = '';
+	$isize = ( ( $settings->peek_img_size ?? 'cover' ) === 'contain' ) ? 'contain' : 'cover';
+	$img_decl .= "object-fit:{$isize};";
+	$iop = $pct( $settings->peek_img_opacity ?? '', 100 );
+	if ( $iop < 1 ) { $img_decl .= 'opacity:' . rtrim( rtrim( number_format( $iop, 3, '.', '' ), '0' ), '.' ) . ';'; }
+	$ibl = $blend( $settings->peek_img_blend ?? 'normal' );
+	if ( 'normal' !== $ibl ) { $img_decl .= "mix-blend-mode:{$ibl};"; }
+	if ( '' !== $img_decl ) { echo "$peek .ds-peek-img { $img_decl }\n"; }
+
+	// ---- Pattern / texture ----
+	$pat = '';
+	$praw = $settings->peek_pattern ?? '';
+	if ( is_array( $praw ) )      { $praw = $praw['id'] ?? ( $praw['url'] ?? '' ); }
+	elseif ( is_object( $praw ) ) { $praw = $praw->id ?? ( $praw->url ?? '' ); }
+	if ( ! empty( $praw ) ) {
+		$purl = is_numeric( $praw ) ? (string) wp_get_attachment_image_url( (int) $praw, 'full' ) : esc_url( (string) $praw );
+		if ( '' !== $purl ) {
+			$positions = array(
+				'left top', 'center top', 'right top',
+				'left center', 'center center', 'right center',
+				'left bottom', 'center bottom', 'right bottom',
+			);
+			$psize   = (string) ( $settings->peek_pattern_size ?? 'auto' );
+			if ( ! in_array( $psize, array( 'auto', 'cover', 'contain' ), true ) ) { $psize = 'auto'; }
+			$prepeat = (string) ( $settings->peek_pattern_repeat ?? 'repeat' );
+			if ( ! in_array( $prepeat, array( 'repeat', 'repeat-x', 'repeat-y', 'no-repeat' ), true ) ) { $prepeat = 'repeat'; }
+			$ppos    = (string) ( $settings->peek_pattern_pos ?? 'center center' );
+			if ( ! in_array( $ppos, $positions, true ) ) { $ppos = 'center center'; }
+			$pat    .= 'background-image:url(' . $purl . ');';
+			$pat    .= "background-size:{$psize};background-repeat:{$prepeat};background-position:{$ppos};";
+			$pop     = $pct( $settings->peek_pattern_opacity ?? '', 100 );
+			if ( $pop < 1 ) { $pat .= 'opacity:' . rtrim( rtrim( number_format( $pop, 3, '.', '' ), '0' ), '.' ) . ';'; }
+			$pbl = $blend( $settings->peek_pattern_blend ?? 'normal' );
+			if ( 'normal' !== $pbl ) { $pat .= "mix-blend-mode:{$pbl};"; }
+		}
+	}
+	if ( '' !== $pat ) { echo "$peek .ds-peek-pattern { $pat }\n"; }
+
+	// ---- Overlay ----
+	$otype = (string) ( $settings->peek_ov_type ?? 'gradient' );
+	if ( ! in_array( $otype, array( 'none', 'solid', 'gradient' ), true ) ) { $otype = 'gradient'; }
+	if ( 'none' === $otype ) {
+		echo "$peek .ds-peek-overlay { display:none; }\n";
+	} else {
+		$ov = '';
+		$c1 = DS_Module_UI::color( $settings->peek_ov_color ?? '' );
+		$c2 = DS_Module_UI::color( $settings->peek_ov_color2 ?? '' );
+		if ( 'solid' === $otype ) {
+			if ( '' !== $c1 ) { $ov .= "background:{$c1};"; }
+		} elseif ( '' !== $c1 || '' !== $c2 ) {
+			// One colour set = fade that colour to transparent, so a single pick still reads.
+			$g1  = '' !== $c1 ? $c1 : 'transparent';
+			$g2  = '' !== $c2 ? $c2 : 'transparent';
+			$dir = (string) ( $settings->peek_ov_dir ?? 'to bottom' );
+			$dir = in_array( $dir, array( 'to bottom', 'to top', 'to right', 'to left', 'to bottom right', 'to bottom left' ), true ) ? $dir : 'to bottom';
+			$ov .= "background:linear-gradient({$dir},{$g1},{$g2});";
+		}
+		$oop = $pct( $settings->peek_ov_opacity ?? '', 100 );
+		if ( $oop < 1 ) { $ov .= 'opacity:' . rtrim( rtrim( number_format( $oop, 3, '.', '' ), '0' ), '.' ) . ';'; }
+		$obl = $blend( $settings->peek_ov_blend ?? 'normal' );
+		if ( 'normal' !== $obl ) { $ov .= "mix-blend-mode:{$obl};"; }
+		if ( '' !== $ov ) { echo "$peek .ds-peek-overlay { $ov }\n"; }
+	}
+
+	// ---- Heading ----
+	$tc = DS_Module_UI::color( $settings->peek_title_color ?? '' );
+	if ( '' !== $tc ) { echo "$peek .ds-peek-title { color:{$tc}; }\n"; }
+
+	// ---- CTA button ----
+	$sizes = array(
+		'small'  => 'padding:9px 16px;font-size:14px;',
+		'medium' => 'padding:12px 22px;font-size:16px;',
+		'large'  => 'padding:16px 30px;font-size:18px;',
+	);
+	$bsize = $settings->peek_btn_size ?? 'medium';
+	echo "$peek .ds-peek-cta { " . ( $sizes[ $bsize ] ?? $sizes['medium'] ) . " }\n";
+
+	if ( ( $settings->peek_btn_global ?? 'yes' ) === 'yes' ) {
+		DS_Module_UI::global_button_css( "$peek .ds-peek-cta" );
+	} else {
+		$b = '';
+		$bbg = DS_Module_UI::color( $settings->peek_btn_bg ?? '' );
+		$bfg = DS_Module_UI::color( $settings->peek_btn_color ?? '' );
+		$bbd = DS_Module_UI::color( $settings->peek_btn_border ?? '' );
+		if ( '' !== $bbg ) { $b .= "background:{$bbg};"; }
+		if ( '' !== $bfg ) { $b .= "color:{$bfg};"; }
+		if ( '' !== $bbd ) { $b .= "border:2px solid {$bbd};"; }
+		if ( '' !== $b ) { echo "$peek .ds-peek-cta { $b }\n"; }
+
+		$h   = '';
+		$hbg = DS_Module_UI::color( $settings->peek_btn_hover_bg ?? '' );
+		$hfg = DS_Module_UI::color( $settings->peek_btn_hover_color ?? '' );
+		if ( '' !== $hbg ) { $h .= "background:{$hbg};"; }
+		if ( '' !== $hfg ) { $h .= "color:{$hfg};"; }
+		if ( '' !== $h ) { echo "$peek .ds-peek-cta:hover, $peek .ds-peek-cta:focus { $h }\n"; }
+	}
+	if ( isset( $settings->peek_btn_radius ) && '' !== $settings->peek_btn_radius ) {
+		echo "$peek .ds-peek-cta { border-radius:" . max( 0, (int) $settings->peek_btn_radius ) . "px; }\n";
+	}
+
+	// ---- Typography (deferred; flushed by FLBuilderCSS::render() after this file) ----
+	if ( class_exists( 'FLBuilderCSS' ) ) {
+		$ptypo = array(
+			'peek_title_typography' => '.ds-peek-title',
+			'peek_btn_typography'   => '.ds-peek-cta',
+		);
+		foreach ( $ptypo as $key => $sel ) {
+			if ( ! empty( $settings->{$key} ) ) {
+				FLBuilderCSS::typography_field_rule( array(
+					'settings'     => $settings,
+					'setting_name' => $key,
+					'selector'     => "$peek $sel",
+				) );
+			}
+		}
+	}
+}

--- a/modules/ds-hero/js/frontend.js
+++ b/modules/ds-hero/js/frontend.js
@@ -148,3 +148,220 @@
 		jQuery(document).on('fl-builder.layout-rendered', function () { boot(); });
 	}
 })();
+
+/* ---- Style 3: peek slider — centred active slide, neighbours peeking at the edges.
+   Horizontal track (never a fade). Infinite looping clones the head and tail slide and
+   snaps silently on transitionend, so the wrap never shows a jump. Vanilla, idempotent. ---- */
+(function () {
+	function num(v, d) { v = parseFloat(v); return isNaN(v) ? d : v; }
+
+	function initPeek(root) {
+		if (root.dsPeekInit) return;
+		var vp    = root.querySelector('.ds-peek-viewport');
+		var track = root.querySelector('.ds-peek-track');
+		if (!vp || !track) { return; }        // not a style-3 hero
+		var n = track.children.length;
+		if (!n) { return; }
+		root.dsPeekInit = true;
+
+		var dots   = [].slice.call(root.querySelectorAll('.ds-peek-dot'));
+		var play   = root.querySelector('.ds-peek-play');
+		var live   = root.querySelector('.ds-peek-live');
+		var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+		var ds     = track.dataset;
+
+		var loop     = ds.loop === 'yes' && n > 1;
+		var autoplay = ds.autoplay === 'yes' && !reduce && n > 1;
+		var interval = Math.max(1500, num(ds.interval, 7) * 1000);
+		var pause    = ds.pause === 'yes';
+		var resume   = ds.resume !== 'no';
+		var drag     = ds.drag !== 'no' && n > 1;
+		var speed    = Math.max(100, num(ds.speed, 600));
+		var ease     = 'cubic-bezier(.22,.61,.36,1)';
+
+		// Loop clones: the last slide before the first, the first after the last. They are
+		// decorative duplicates, so they leave the a11y tree and the tab order.
+		var offset = 0;
+		if (loop) {
+			var head = track.children[0].cloneNode(true);
+			var tail = track.children[n - 1].cloneNode(true);
+			[ head, tail ].forEach(function (c) {
+				c.classList.add('ds-peek-clone');
+				c.setAttribute('aria-hidden', 'true');
+				c.removeAttribute('role');
+				c.querySelectorAll('a,button,input,select,textarea,[tabindex]').forEach(function (f) {
+					f.setAttribute('tabindex', '-1');
+				});
+			});
+			track.insertBefore(tail, track.children[0]);
+			track.appendChild(head);
+			offset = 1;
+		}
+
+		// `active` is the logical slide index; while looping it sits transiently at
+		// -1 or n (a clone) until transitionend snaps it back.
+		var active = 0, timer = null, hovered = false, stopped = false;
+
+		function cell() { return track.children[offset]; }
+		function step() {
+			var c   = cell();
+			var gap = parseFloat(getComputedStyle(track).columnGap || getComputedStyle(track).gap || '0') || 0;
+			return c ? c.getBoundingClientRect().width + gap : 0;
+		}
+		function centreOffset() {
+			var c = cell();
+			return (vp.getBoundingClientRect().width - (c ? c.getBoundingClientRect().width : 0)) / 2;
+		}
+		function current() { return ((active % n) + n) % n; }
+
+		function setX(animate) {
+			var x = centreOffset() - (active + offset) * step();
+			track.style.transition = (animate && !reduce) ? ('transform ' + speed + 'ms ' + ease) : 'none';
+			track.style.transform  = 'translate3d(' + x + 'px,0,0)';
+		}
+		function syncDots() {
+			var cur = current();
+			for (var i = 0; i < dots.length; i++) {
+				dots[i].classList.toggle('is-active', i === cur);
+				dots[i].setAttribute('aria-current', i === cur ? 'true' : 'false');
+			}
+			for (var c = 0; c < track.children.length; c++) {
+				track.children[c].classList.toggle('is-active', c === cur + offset);
+			}
+		}
+
+		// Landed on a clone → re-seat on the matching real slide with no animation.
+		track.addEventListener('transitionend', function (e) {
+			if (e.target !== track || e.propertyName !== 'transform' || !loop) return;
+			if (active < 0)      { active = n - 1; setX(false); }
+			else if (active > n - 1) { active = 0; setX(false); }
+		});
+
+		function go(to)  { active = to; setX(true); syncDots(); }
+		function next()  { if (!loop && active >= n - 1) return; go(active + 1); }
+		function prev()  { if (!loop && active <= 0)     return; go(active - 1); }
+
+		function stop()  { if (timer) { clearInterval(timer); timer = null; } syncPlay(); }
+		function start() {
+			if (!autoplay || stopped || hovered || document.hidden) { syncPlay(); return; }
+			if (timer) clearInterval(timer);
+			timer = setInterval(next, interval);
+			syncPlay();
+		}
+		function syncPlay() {
+			if (!play) return;
+			play.classList.toggle('is-paused', !timer);
+			play.setAttribute('aria-label', timer ? (play.dataset.pause || 'Pause') : (play.dataset.play || 'Play'));
+		}
+		// A manual move either restarts the timer or retires autoplay, per the setting.
+		// It announces the new position; autoplay stays silent, so the
+		// slider never talks over a screen reader on its own.
+		function nudged() {
+			if (resume) { start(); } else { stopped = true; stop(); }
+			if (live) { live.textContent = (current() + 1) + ' / ' + n; }
+		}
+
+		root.querySelectorAll('.ds-peek-nav--next').forEach(function (b) { b.addEventListener('click', function (e) { e.preventDefault(); next(); nudged(); }); });
+		root.querySelectorAll('.ds-peek-nav--prev').forEach(function (b) { b.addEventListener('click', function (e) { e.preventDefault(); prev(); nudged(); }); });
+		dots.forEach(function (d, idx) { d.addEventListener('click', function (e) { e.preventDefault(); go(idx); nudged(); }); });
+
+		if (play) {
+			play.addEventListener('click', function (e) {
+				e.preventDefault();
+				if (timer) { stopped = true; stop(); }
+				else       { stopped = false; start(); }
+			});
+		}
+
+		root.addEventListener('keydown', function (e) {
+			if (e.key === 'ArrowRight')     { e.preventDefault(); next(); nudged(); }
+			else if (e.key === 'ArrowLeft') { e.preventDefault(); prev(); nudged(); }
+		});
+
+		if (pause) {
+			root.addEventListener('mouseenter', function () { hovered = true;  stop(); });
+			root.addEventListener('mouseleave', function () { hovered = false; start(); });
+		}
+		// Keyboard focus pauses too, so a tabbing visitor is never moved mid-read.
+		root.addEventListener('focusin',  function () { hovered = true; stop(); });
+		root.addEventListener('focusout', function () {
+			if (!root.contains(document.activeElement)) { hovered = false; start(); }
+		});
+		document.addEventListener('visibilitychange', function () { if (document.hidden) { stop(); } else { start(); } });
+
+		// Drag / swipe. Unlike the flick-detect on the other carousels the track follows
+		// the pointer, which is what a peek slider needs to read as direct manipulation.
+		// The axis lock hands a vertical gesture straight back to the page.
+		if (drag) {
+			var x0 = 0, y0 = 0, baseX = 0, dx = 0, dragging = false, axis = null, pid = null;
+
+			function release(delta) {
+				if (!dragging) return;
+				dragging = false; axis = null;
+				track.classList.remove('is-dragging');
+				if (pid !== null) { try { vp.releasePointerCapture(pid); } catch (err) {} pid = null; }
+				var threshold = Math.min(120, step() * 0.18);
+				if (delta <= -threshold)     { next(); }
+				else if (delta >= threshold) { prev(); }
+				else                         { setX(true); }
+				nudged();
+			}
+
+			vp.addEventListener('pointerdown', function (e) {
+				if (e.button) return;
+				dragging = true; axis = null; dx = 0; pid = e.pointerId;
+				x0 = e.clientX; y0 = e.clientY;
+				baseX = centreOffset() - (active + offset) * step();
+				stop();
+			});
+			vp.addEventListener('pointermove', function (e) {
+				if (!dragging) return;
+				var mx = e.clientX - x0, my = e.clientY - y0;
+				if (axis === null) {
+					if (Math.abs(mx) < 6 && Math.abs(my) < 6) return;
+					axis = Math.abs(mx) > Math.abs(my) ? 'x' : 'y';
+					if (axis === 'y') { release(0); return; }
+					track.classList.add('is-dragging');
+					try { vp.setPointerCapture(e.pointerId); } catch (err) {}
+				}
+				if (axis !== 'x') return;
+				dx = mx;
+				track.style.transition = 'none';
+				track.style.transform  = 'translate3d(' + (baseX + mx) + 'px,0,0)';
+			});
+			window.addEventListener('pointerup',     function () { release(dx); });
+			window.addEventListener('pointercancel', function () { release(0); });
+			// A drag that finishes on a link must not also follow it.
+			vp.addEventListener('click', function (e) {
+				if (Math.abs(dx) > 5) { e.preventDefault(); e.stopPropagation(); dx = 0; }
+			}, true);
+			vp.addEventListener('dragstart', function (e) { e.preventDefault(); });
+		}
+
+		function relayout() { setX(false); syncDots(); }
+
+		var rt = null;
+		window.addEventListener('resize', function () {
+			if (rt) clearTimeout(rt);
+			rt = setTimeout(relayout, 150);
+		});
+		// The builder preview resizes the container without a window resize event.
+		if (window.ResizeObserver) { new ResizeObserver(relayout).observe(vp); }
+		if (document.fonts && document.fonts.ready) { document.fonts.ready.then(relayout).catch(function () {}); }
+
+		setX(false);
+		syncDots();
+		start();
+	}
+
+	function boot(root) {
+		(root || document).querySelectorAll('.ds-peek').forEach(initPeek);
+	}
+
+	if (document.readyState !== 'loading') boot();
+	else document.addEventListener('DOMContentLoaded', function () { boot(); });
+
+	if (window.jQuery) {
+		jQuery(document).on('fl-builder.layout-rendered', function () { boot(); });
+	}
+})();


### PR DESCRIPTION
Adds `Style 3 - Slider` to the existing **Hero Banner** module (not a separate module, per the issue). Refs #160.

### Reference study
Inspected the live reference first, as the issue requires. It runs Flickity with a 1344px slide in a 1440px viewport (93%), a 30px gap, ~15px radius, `object-fit:cover`, and a `linear-gradient(rgba(23,23,23,.2) 50%, rgba(23,23,23,.8))` overlay. Those numbers are the defaults here. The engine is written in-house in the same shape as the existing `ds-carousel` styles rather than bundling Flickity, which keeps the plugin dependency-free and avoids its GPL-or-commercial licensing question. None of the reference's images, text or branding is used.

### Behaviour
Horizontal track, active slide centred and narrower than the viewport so neighbours peek in. Infinite loop clones the head and tail slide and re-seats silently on `transitionend`, so the wrap shows no jump. Drag and swipe follow the pointer, with an axis lock that hands vertical gestures back to the page. Autoplay 7s by default, pauses on hover and on keyboard focus, off entirely under `prefers-reduced-motion`. Arrows, dots, pause/play and arrow keys share one state. Multiple instances per page are independent.

### Controls
Content gets **Slides** (repeatable: desktop image, mobile image, alt, focal point, heading, heading tag, CTA label/link/target) and **Slider Behaviour**. Style gets **Slide Layout**, **Slide Background Layers**, **Slide Heading** and **Slide CTA Button**. All six sit behind the `hero_style` toggle, so the Style 1 and Style 2 forms are untouched.

Background layers render base colour, image, pattern, overlay, then content, clipped to the slide radius and isolated so blend modes stay inside the slide.

### Three fixes found while verifying
| Bug | Effect | Fix |
|---|---|---|
| `.ds-hero` is `display:flex`, so `.ds-peek` became a flex item at the track's max-content width (2116px in a 1440px page) | Only `overflow:hidden` hid it. The slide was wider than the visible area with **no peek at all** | `width:100%; flex:1 1 100%; min-width:0` |
| The min-height block is commented "Style 1 only" but guarded `'style2' !== $style` | Style 3 inherited a 92vh floor | Guard now matches the comment |
| Dimensions inherited the desktop 30px gap at every breakpoint | 1.5px of peek at 900px, none at 390px | Per-breakpoint fallbacks, emitted from the dynamic CSS because a static `@media` at (0,2,0) loses to the dynamic (0,3,0) rule |

### Verification
LocalWP is still down, so this ran against a two-instance page assembled from the real module output plus the real CSS and JS, including Beaver Builder's own `.fl-module img{max-width:100%}` so specificity was tested for real.

**56/56 Playwright checks pass:** peek geometry and centring at 1440/900/390 (20px / 16px / 11px of neighbour visible, 0px centring error), no horizontal page scroll and nothing wider than the page box at any width, 7s autoplay, seamless wrap forward and backward with the transform returning to the identical value, clone a11y (`aria-hidden`, no `role`, out of the tab order), drag left/right plus a 4px nudge that must not navigate, dot/slide/aria-current sync, live region silent on autoplay but announcing manual moves, hover pause, pause/play relabelling, arrow keys, visible focus ring, reduced motion, two independent instances, and the desktop split / mobile stacked layouts.

**Acceptance criteria — Style 1 and Style 2 unchanged:** their rendered HTML and CSS are byte-for-byte identical to `main`, confirmed by diffing both against a stashed tree.

Screenshots checked at all three widths.