### PR TITLE
fix: Hero Style 3 slide change now settles like the reference (GH #160)

### DIFF
--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.104
+ * Version:           1.9.105
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.104' );
+define( 'DS_TOOLKIT_VERSION', '1.9.105' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-hero/ds-hero.php
+++ b/modules/ds-hero/ds-hero.php
@@ -539,6 +539,9 @@ class DS_Hero_Module extends FLBuilderModule {
 		$align = (string) ( $s->peek_content_align ?? 'split' );
 		if ( ! in_array( $align, array( 'split', 'left', 'center', 'right' ), true ) ) { $align = 'split'; }
 
+		$ease = (string) ( $s->peek_ease ?? 'settle' );
+		if ( ! in_array( $ease, array( 'settle', 'snap', 'smooth' ), true ) ) { $ease = 'settle'; }
+
 		$label = trim( (string) ( $s->peek_label ?? '' ) );
 		if ( '' === $label ) { $label = __( 'Featured highlights', 'ds-toolkit' ); }
 
@@ -557,14 +560,15 @@ class DS_Hero_Module extends FLBuilderModule {
 		);
 
 		printf(
-			'<div class="ds-peek-viewport"><div class="ds-peek-track" data-loop="%s" data-autoplay="%s" data-interval="%s" data-pause="%s" data-resume="%s" data-drag="%s" data-speed="%d">',
+			'<div class="ds-peek-viewport"><div class="ds-peek-track" data-loop="%s" data-autoplay="%s" data-interval="%s" data-pause="%s" data-resume="%s" data-drag="%s" data-speed="%d" data-ease="%s">',
 			$loop ? 'yes' : 'no',
 			$autoplay ? 'yes' : 'no',
 			esc_attr( (string) max( 2, (int) DS_Module_UI::u( $s->peek_interval ?? '', 7 ) ) ),
 			( $s->peek_pause_hover ?? 'yes' ) === 'yes' ? 'yes' : 'no',
 			( $s->peek_resume ?? 'yes' ) === 'yes' ? 'yes' : 'no',
 			$drag ? 'yes' : 'no',
-			max( 100, (int) DS_Module_UI::u( $s->peek_speed ?? '', 600 ) )
+			max( 100, (int) DS_Module_UI::u( $s->peek_speed ?? '', 525 ) ),
+			esc_attr( $ease )
 		);
 		foreach ( $slides as $i => $sl ) { $this->peek_slide( $sl, $i, $total, $sm ); }
 		echo '</div></div>';
@@ -891,9 +895,20 @@ FLBuilder::register_module( 'DS_Hero_Module', array(
 					'peek_speed' => array(
 						'type'        => 'unit',
 						'label'       => __( 'Transition Speed', 'ds-toolkit' ),
-						'default'     => '600',
+						'default'     => '525',
 						'description' => 'ms',
-						'slider'      => array( 'min' => 150, 'max' => 1500, 'step' => 50 ),
+						'slider'      => array( 'min' => 150, 'max' => 1500, 'step' => 25 ),
+					),
+					'peek_ease' => array(
+						'type'    => 'select',
+						'label'   => __( 'Slide Motion', 'ds-toolkit' ),
+						'default' => 'settle',
+						'options' => array(
+							'settle' => __( 'Settle (recommended)', 'ds-toolkit' ),
+							'snap'   => __( 'Snap (faster, sharper)', 'ds-toolkit' ),
+							'smooth' => __( 'Smooth (even glide)', 'ds-toolkit' ),
+						),
+						'help'    => __( 'Settle moves most of the way quickly then eases the last stretch in, so the photo appears to settle into place. Smooth glides at an even rate.', 'ds-toolkit' ),
 					),
 					'peek_loop' => array(
 						'type'    => 'select',

--- a/modules/ds-hero/js/frontend.js
+++ b/modules/ds-hero/js/frontend.js
@@ -176,8 +176,17 @@
 		var pause    = ds.pause === 'yes';
 		var resume   = ds.resume !== 'no';
 		var drag     = ds.drag !== 'no' && n > 1;
-		var speed    = Math.max(100, num(ds.speed, 600));
-		var ease     = 'cubic-bezier(.22,.61,.36,1)';
+		var speed    = Math.max(100, num(ds.speed, 525));
+		// Slide-change easing. "settle" is measured off the reference carousel: roughly 90%
+		// of the travel lands in the first third, then the last few percent drift in. That
+		// asymptotic tail is what reads as the image settling into place — the reference
+		// never transforms the image itself, the whole effect is in how the track decelerates.
+		var EASES    = {
+			settle: 'cubic-bezier(.3,1,.3,1)',
+			snap:   'cubic-bezier(.16,1,.3,1)',
+			smooth: 'cubic-bezier(.22,.61,.36,1)'
+		};
+		var ease     = EASES[ds.ease] || EASES.settle;
 
 		// Loop clones: the last slide before the first, the first after the last. They are
 		// decorative duplicates, so they leave the a11y tree and the tab order.


### PR DESCRIPTION
Follow-up to #161. The peek slider shipped with a generic 600ms ease-out, which does not move like the reference. Refs #160.

### What the reference actually does
I sampled the reference carousel at frame rate through a slide change, on the cell, the image and every wrapper between them.

**The image never moves.** `transform: none`, `scale: none`, `opacity: 1` on the `<img>` for the whole transition, and the cell is identity too. There is no Ken Burns, no zoom-settle, no parallax. The entire effect is in how the **track** decelerates, so this is an easing fix rather than an image animation.

The measured curve puts ~90% of the travel in the first 180ms, then drifts the last few percent in over another 340ms. That long asymptotic tail is what reads as the photo settling into place. No overshoot, so it is not a spring.

### The fix
Best fit across the measured samples is `cubic-bezier(.3,1,.3,1)` — which turns out to be the reference theme's own declared easing constant.

| Curve | RMS vs measured reference |
|---|---|
| `cubic-bezier(.3,1,.3,1)` @525ms | **4.41%** |
| `cubic-bezier(.25,1,.5,1)` @525ms | 6.93% |
| `cubic-bezier(.22,1,.36,1)` @525ms | 7.54% |
| `cubic-bezier(.16,1,.3,1)` @525ms | 12.77% |
| shipped `cubic-bezier(.22,.61,.36,1)` @600ms | 16.08% |

Measured on the built module after the change: **4.44% RMS**, within 2.5 percentage points of the reference from 100ms onward.

| t | reference | before | after |
|---|---|---|---|
| 100ms | 60.1% | 43.1% | 59.7% |
| 150ms | 82.0% | 59.4% | 79.5% |
| 200ms | 92.7% | 71.8% | 90.4% |
| 300ms | 99.1% | 87.3% | 98.1% |

### Changes
- New **Slide Motion** control: Settle (default, matches the reference), Snap, Smooth (the previous curve, for anyone who prefers it).
- Transition Speed default 600ms to 525ms, step now 25ms.

### Why this reaches heroes that are already built
Beaver Builder bakes a field's value into the saved node, so retuning an existing default would never reach a module somebody has already built — `dslaunchpad6` has `speed: "600"` baked in already. A field that did not exist yet is *absent* from those saved settings, so its default does apply at render. Making the easing a new field means existing Style 3 heroes pick up the settle motion without being reopened. They keep their saved duration, which still lands at 6.5% RMS against the reference.

### Verification
56/56 browser checks still pass. Style 1 and Style 2 output stays byte-for-byte identical to `main`.