### PR TITLE
fix: Style 3 slider controls survive Beaver Builder's global button CSS

### DIFF
--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.105
+ * Version:           1.9.106
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.105' );
+define( 'DS_TOOLKIT_VERSION', '1.9.106' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-hero/css/frontend.css
+++ b/modules/ds-hero/css/frontend.css
@@ -195,6 +195,30 @@
 .ds-hero--style3 .ds-peek-play .ds-peek-ico-play{display:none;}
 .ds-hero--style3 .ds-peek-play.is-paused .ds-peek-ico-play{display:block;}
 .ds-hero--style3 .ds-peek-play.is-paused .ds-peek-ico-pause{display:none;}
+/* Beaver Builder ships global button styling that outranks these controls: its
+   `.fl-builder-content .fl-module-content:not(:has(.fl-inline-editor)) button:not(.fl-content-ui-button)`
+   is (0,4,1) and paints background-color, and a second (0,2,1) rule forces a 5px radius,
+   uppercase and letter-spacing on every button inside a layout. That turned the dots,
+   arrows and pause button into brand-coloured rounded squares and, worse, painted the
+   active dot the same colour as the idle ones so the position indicator disappeared.
+   Those BB rules are not !important, so declaring these few properties !important is
+   enough to win without needing to out-specify them. Same approach DS_Module_UI's
+   global_button_css() already uses for the reverse case. */
+.ds-hero--style3 .ds-peek button.ds-peek-dot,
+.ds-hero--style3 .ds-peek button.ds-peek-nav,
+.ds-hero--style3 .ds-peek button.ds-peek-play{
+  border:0 !important;box-shadow:none !important;text-shadow:none !important;
+  padding:0 !important;letter-spacing:normal !important;text-transform:none !important;
+  background-clip:border-box !important;
+}
+.ds-hero--style3 .ds-peek button.ds-peek-dot{background:rgba(20,20,20,.25) !important;border-radius:50% !important;}
+.ds-hero--style3 .ds-peek button.ds-peek-dot:hover{background:rgba(20,20,20,.5) !important;}
+.ds-hero--style3 .ds-peek button.ds-peek-dot.is-active{background:var(--fl-global-accent) !important;}
+.ds-hero--style3 .ds-peek button.ds-peek-nav{background:rgba(15,18,24,.5) !important;border-radius:50% !important;}
+.ds-hero--style3 .ds-peek button.ds-peek-nav:hover{background:rgba(15,18,24,.78) !important;}
+.ds-hero--style3 .ds-peek button.ds-peek-play{background:rgba(20,20,20,.25) !important;border-radius:50% !important;}
+.ds-hero--style3 .ds-peek button.ds-peek-play:hover{background:rgba(20,20,20,.5) !important;}
+
 /* Visible focus for every control (spec: keyboard reachable with a visible state). */
 .ds-hero--style3 .ds-peek-nav:focus-visible,.ds-hero--style3 .ds-peek-dot:focus-visible,
 .ds-hero--style3 .ds-peek-play:focus-visible,.ds-hero--style3 .ds-peek-cta:focus-visible{outline:3px solid var(--fl-global-accent);outline-offset:3px;}


### PR DESCRIPTION
Found on the live blueprint build after shipping #162 — not caught by the original harness. Refs #160.

### Symptom
On a real site the dots, arrows and pause button rendered as **brand-green rounded squares**, and every dot got the same colour, so the active-slide indicator was effectively invisible (only the 1.3x scale still distinguished it).

### Cause
Beaver Builder ships two global button rules in the layout CSS:

| Selector | Specificity | Sets |
|---|---|---|
| `.fl-builder-content .fl-module-content:not(:has(.fl-inline-editor)) button:not(.fl-content-ui-button)` | **(0,4,1)** | `background-color` |
| `.fl-builder-content button:not(.fl-content-ui-button)` | **(0,2,1)** | `border-radius:5px`, uppercase, letter-spacing |

The module's control rules are `(0,2,0)`, so both outranked them. This also explains why `width:9px` survived while the fill did not — BB sets no width — and why a probe at `(0,3,1)` recovered the radius but not the background: it beats `(0,2,1)` but not `(0,4,1)`.

### Fix
The BB rules are **not** `!important`, so declaring the handful of clobbered properties `!important` wins without an escalating-specificity war. Same approach `DS_Module_UI::global_button_css()` already takes for the reverse case.

### Why the harness missed it
It carried Beaver Builder's `.fl-module img{max-width:100%}` but not the global button CSS. The harness now includes both rules **verbatim from the live layout CSS** and wraps the module in the real `.fl-builder-content > .fl-module-content` chain. It reproduces the bug exactly — same colours, same 5px radius, same 11.7 / 9 / 44 / 26 sizes as measured live — and six new assertions cover it.

**62/62 checks pass.** Style 1 and Style 2 output unchanged.