### PR TITLE
fix: stacked-deck carousel no longer scrolls the page sideways on mobile (GH #166)

### DIFF
--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.107
+ * Version:           1.9.108
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.107' );
+define( 'DS_TOOLKIT_VERSION', '1.9.108' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-carousel/js/frontend.js
+++ b/modules/ds-carousel/js/frontend.js
@@ -30,15 +30,36 @@
 		var active = 0, timer = null;
 		var sign = dir === 'left' ? -1 : 1;
 
+		// The deck fans the cards behind the front one sideways with transforms, but the
+		// slides are already the full width of the deck, so the fan always lands OUTSIDE
+		// the stage. A wide column absorbs it; on a phone the stage nearly fills the
+		// screen and the overhang drags the whole page sideways (GH #166). Clamp the step
+		// to the room that actually exists on the side we fan towards, so desktop keeps
+		// the designed offset and narrow screens tighten the fan instead of overflowing.
+		function stepX() {
+			if (dir === 'center' || visible < 1) return 0;
+			var r    = deck.getBoundingClientRect();
+			var vw   = document.documentElement.clientWidth || window.innerWidth;
+			var room = (dir === 'left' ? r.left : vw - r.right) - 4;  // 4px breathing gap
+			if (room >= offx * visible) return offx;
+			return Math.max(0, room / visible);
+		}
+
 		function layout() {
+			var stepx = stepX();
+			// How much of the designed offset survived the clamp. When space is tight the
+			// shrink and tilt have to come down with it: at a 8px step an 8% scale step
+			// pulls each card's edge further in than the offset pushes it out, so the deck
+			// would read as one flat card instead of a stack.
+			var k = (dir === 'center' || offx <= 0) ? 1 : Math.min(1, stepx / offx);
 			for (var i = 0; i < n; i++) {
 				var s   = slides[i];
 				var rel = (i - active + n) % n;       // 0 = front, 1.. = behind
 				var shown = rel <= visible;
-				var tx = (dir === 'center' ? 0 : sign * rel * offx);
-				var ty = rel * offy;
-				var sc = Math.max(0.4, 1 - rel * scale);
-				var rt = (dir === 'center' ? 0 : sign * rel * rot);
+				var tx = (dir === 'center' ? 0 : sign * rel * stepx);
+				var ty = rel * offy * k;
+				var sc = Math.max(0.4, 1 - rel * scale * k);
+				var rt = (dir === 'center' ? 0 : sign * rel * rot * k);
 				s.style.transform    = 'translateX(calc(-50% + ' + tx + 'px)) translateY(' + ty + 'px) scale(' + sc + ') rotate(' + rt + 'deg)';
 				s.style.opacity      = shown ? String(1 - rel * 0.18) : '0';
 				s.style.zIndex       = String(100 - rel);
@@ -89,6 +110,12 @@
 				start();
 			});
 		}
+
+		var rt = null;
+		window.addEventListener('resize', function () {
+			if (rt) clearTimeout(rt);
+			rt = setTimeout(layout, 150);
+		});
 
 		layout();
 		start();


### PR DESCRIPTION
Closes #166.

### Cause
Style 1 fans the cards behind the front one sideways with transforms, but the slides are `position:absolute; left:50%; width:100%` of the deck, so the fan always lands **outside** the stage. A wide column absorbs it; on a phone the stage nearly fills the screen and nothing does, so the page gained 32px of horizontal scroll.

Deck right edge 370 in a 390 viewport, with the two cards behind reaching **396** and **422** at the default `visible:2` / `offx:40`.

### Fix
The per-card step is clamped to the room that actually exists on the side the deck fans towards, recomputed on a debounced resize. **Where there is space, nothing changes.**

Clamping the offset alone was not enough, and the intermediate result is worth recording: the cards behind also shrink 8% per level, so at an 8px step the shrink pulls each card's edge *further in* than the offset pushes it out. The deck rendered as one flat card with the stack invisible (right edges went 370 / 364 / 358 — behind the front card). The shrink, vertical offset and tilt now scale by the same factor the offset was clamped by, so a tight deck still reads as a stack.

### Measured
Local reproduction of the live geometry — 350px stage, 390px viewport, `visible:2`, `offx:40` — which reproduced the live numbers exactly before the fix.

| Viewport | overflow before | after | slide right edges | visible peek |
|---|---|---|---|---|
| 1440 desktop | 0 | 0 | 895 / 921 / 947 **unchanged** | 26 / 52 unchanged |
| 900 tablet | 0 | 0 | 625 / 651 / 677 **unchanged** | 26 / 52 unchanged |
| 390 mobile | **32** | **0** | 370 / 396 / 422 → 370 / 375 / 380 | 5 / 10 |
| 320 small | **40** | **0** | contained | 6 / 12 |

No console errors through a next-slide click and two viewport changes that exercise the new resize path.

Scoped to Style 1 (`initCarousel`); Styles 2, 3 and 4 are untouched.