### PR TITLE
fix: Partner role can reach Ninja Tables again

### DIFF
--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.108
+ * Version:           1.9.109
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.108' );
+define( 'DS_TOOLKIT_VERSION', '1.9.109' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-user-roles.php
+++ b/features/class-ds-user-roles.php
@@ -57,6 +57,7 @@ class DS_User_Roles {
 		add_action( 'init', array( $this, 'sync_role' ), 5 );
 		// After Beaver Builder has registered its own settings.
 		add_action( 'init', array( $this, 'sync_builder_access' ), 20 );
+		add_filter( 'ninja_table_admin_role', array( $this, 'allow_ninja_tables' ) );
 		// Very late, after every plugin has registered its menus.
 		add_action( 'admin_menu', array( $this, 'hide_admin_menus' ), 999999 );
 	}
@@ -103,6 +104,36 @@ class DS_User_Roles {
 		if ( $changed ) {
 			update_option( '_fl_builder_user_access', $settings );
 		}
+	}
+
+	/**
+	 * Let the Partner role reach Ninja Tables.
+	 *
+	 * Same trap as Beaver Builder above: the plugin keeps its OWN role list rather
+	 * than checking a capability, and its default is `administrator` only. Worse,
+	 * ninja_table_admin_role() tests roles with current_user_can( 'administrator' ),
+	 * a role name used as a pseudo-capability — a Partner carries `partner` in its
+	 * capability array, never `administrator`, so the check fails however privileged
+	 * the role is. Verified on dslaunchpad6: a Partner has manage_options but
+	 * can( 'administrator' ) is false, so the helper returned false.
+	 *
+	 * That return value is not a soft "no" either. AdminMenuHandler::add() bails on
+	 * a falsey capability before calling add_menu_page(), so the whole Ninja Tables
+	 * menu was never registered, and UserPolicy gates the REST/AJAX endpoints on the
+	 * same helper. Partners maintain their own rosters and standings, which live in
+	 * Ninja Tables, so both halves need to work.
+	 *
+	 * Adding the slug is enough: the helper returns the first role the user matches
+	 * and hands that straight to add_menu_page() as the capability, and
+	 * current_user_can( 'partner' ) is true for a Partner. Administrators keep
+	 * matching first, and no other role gains anything.
+	 */
+	public function allow_ninja_tables( $roles ) {
+		$roles = is_array( $roles ) ? $roles : array( $roles );
+		if ( ! in_array( self::ROLE_SLUG, $roles, true ) ) {
+			$roles[] = self::ROLE_SLUG;
+		}
+		return $roles;
 	}
 
 	private function plugin_access_allowed() {


### PR DESCRIPTION
Partners maintain their own rosters and standings, and those live in Ninja Tables, but the menu was missing for every Partner-role account.

### Cause
The same trap as Beaver Builder, which `DS_User_Roles` already works around: the plugin keeps its **own role list** instead of checking a capability, and its default is `administrator` only.

```php
function ninja_table_admin_role() {
    if (current_user_can('administrator')) return 'administrator';
    $roles = apply_filters('ninja_table_admin_role', array('administrator'));
    foreach ($roles as $role) { if (current_user_can($role)) return $role; }
    return false;
}
```

It tests roles with `current_user_can('administrator')` — a **role name used as a pseudo-capability**. A Partner carries `partner` in its capability array and never `administrator`, so the check fails however privileged the role is.

And the `false` is not a soft no:

```php
$capability = ninja_table_admin_role();
if (!$capability) { return; }   // AdminMenuHandler::add()
```

It returns *before* `add_menu_page()`, so the menu was never **registered** rather than hidden — and `UserPolicy` gates the REST/AJAX endpoints on the same helper, so the screen and its data layer both failed.

### Verified
On dslaunchpad6, against the real function, with an existing user recast in memory as a Partner and nothing written to the database:

| Check | Result |
|---|---|
| current user roles | `partner` |
| `can(administrator)` | **no** ← what the plugin tests first |
| `can(partner)` | YES |
| `can(manage_options)` | YES ← the role is not short on privilege |
| `ninja_table_admin_role()` **before** | `false` |
| `ninja_table_admin_role()` **after** | `'partner'` |
| menu would register | **YES** |
| REST/AJAX allowed | **YES** |

### Fix
Adding the slug to the filter is enough: the helper returns the first role the user matches and passes it straight to `add_menu_page()` as the capability, and `current_user_can('partner')` is true for a Partner. Administrators still match first via the plugin's own early return, and no other role gains anything.

**No `ROLE_VERSION` bump** — the Partner capability set is unchanged, so no install needs to re-sync the role. This is a runtime filter only, and it is gated behind the User Roles feature like the rest of the class.