### PR TITLE
feat: Hero Banner centred eyebrow gets a rule on both sides (GH #170)

### DIFF
--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.109
+ * Version:           1.9.110
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.109' );
+define( 'DS_TOOLKIT_VERSION', '1.9.110' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-hero/css/frontend.css
+++ b/modules/ds-hero/css/frontend.css
@@ -28,7 +28,17 @@
 .ds-hero-inner{max-width:760px;}
 
 .ds-hero-eyebrow{display:inline-flex;align-items:center;gap:12px;font-weight:700;font-size:.74rem;letter-spacing:.28em;text-transform:uppercase;color:var(--fl-global-primary,#7ee29a);}
-.ds-hero-eyebrow::before{content:"";width:34px;height:2px;background:currentColor;display:inline-block;}
+/* ---- Eyebrow rules (GH #170) --------------------------------------------------
+   Both rules always exist; the trailing one only shows when the ACTIVE alignment is
+   centred. Same approach as the Heading module's centred eyebrow: expressing it in
+   CSS rather than PHP keeps it right per breakpoint, because Alignment is a
+   responsive field and the per-breakpoint override is emitted by the dynamic CSS
+   (which re-declares the ::after there). min-width:0 plus flex:0 1 auto lets the
+   rules shrink rather than push the text out of the hero. */
+.ds-hero-eyebrow{min-width:0;}
+.ds-hero-eyebrow::before,.ds-hero-eyebrow::after{content:"";width:34px;height:2px;background:currentColor;display:inline-block;flex:0 1 auto;min-width:0;}
+.ds-hero-eyebrow::after{display:none;}
+.ds-hero--center .ds-hero-eyebrow::after{display:inline-block;}
 
 .ds-hero-title{font-size:clamp(3.4rem,10vw,8rem);line-height:.92;text-transform:uppercase;letter-spacing:.01em;font-weight:700;color:var(--fl-global-white,#fff);margin:20px 0 0;overflow-wrap:normal;word-break:keep-all;hyphens:none;}
 .ds-hero-accent{color:var(--fl-global-primary,#7ee29a);}

--- a/modules/ds-hero/includes/frontend.css.php
+++ b/modules/ds-hero/includes/frontend.css.php
@@ -242,13 +242,19 @@ if ( $btn_global && $gs ) {
 
 // ---- Alignment (responsive overrides; base set by the modifier class) ----
 $align_rules = function( $align ) use ( $node ) {
+	// The eyebrow's trailing rule (GH #170) is re-declared per breakpoint alongside the
+	// alignment it follows. The static sheet keys it off .ds-hero--center, which only
+	// describes the BASE alignment — without this a hero centred on desktop and left on
+	// mobile would keep both rules on mobile.
 	if ( 'center' === $align ) {
 		return "$node .ds-hero .ds-hero-inner{margin-left:auto;margin-right:auto;text-align:center;}"
 			. "$node .ds-hero .ds-hero-eyebrow,$node .ds-hero .ds-hero-cta,$node .ds-hero .ds-hero-proof{justify-content:center;}"
+			. "$node .ds-hero .ds-hero-eyebrow::after{display:inline-block;}"
 			. "$node .ds-hero .ds-hero-sub{margin-left:auto;margin-right:auto;}";
 	}
 	return "$node .ds-hero .ds-hero-inner{margin-left:0;margin-right:0;text-align:left;}"
 		. "$node .ds-hero .ds-hero-eyebrow,$node .ds-hero .ds-hero-cta,$node .ds-hero .ds-hero-proof{justify-content:flex-start;}"
+		. "$node .ds-hero .ds-hero-eyebrow::after{display:none;}"
 		. "$node .ds-hero .ds-hero-sub{margin-left:0;margin-right:0;}";
 };
 if ( '' !== ( $settings->align_medium ?? '' ) ) { echo "@media (max-width:{$bpm}px){" . $align_rules( $settings->align_medium ) . "}\n"; }


### PR DESCRIPTION
Closes #170.

The hero draws its eyebrow rule with a `::before` pseudo-element rather than markup, so this needed **no markup change, no new control and no migration** — just a matching `::after` that shows only when the active alignment is centred.

### The one subtlety
**Alignment is a responsive field.** The static sheet can only key off `.ds-hero--center`, which describes the *base* alignment. So the per-breakpoint overrides in the dynamic CSS now re-declare the `::after` alongside the `justify-content` they already emit. Without that, a hero centred on desktop and left on mobile would have kept both rules on mobile.

This is the same reasoning the Heading module already records for its own centred eyebrow in #143: *"Doing it in CSS rather than PHP keeps it correct per breakpoint, since alignment is a responsive field."*

Both rules carry `flex:0 1 auto` and `min-width:0` so they shrink evenly rather than pushing the text out.

### Verified in a browser
| Case | Result |
|---|---|
| `align=center` at 1440 / 768 / 390 | both rules **34px**, gaps **L=46 R=46**, no overflow |
| `align=left` at 1440 | `::after` is `display:none` — unchanged single rule |
| centre desktop / left mobile | 1440 → both rules; 390 → single rule (responsive override works) |
| long eyebrow at 1440 / 768 / 390 / 320 | rules shrink **evenly** 34/34 → 20/20 → 16/16, stay equal, stay inside the container, no page overflow |

### Scope note
Only **Style 1** uses this eyebrow. Style 2's `.ds-banner-eyebrow` is a separate component that has **never had a divider**, so giving it one would change every existing banner — deliberately untouched. Style 3 has no eyebrow. That's my reading of "all styles that use the shared eyebrow component"; say the word if you want Style 2 banners to gain rules too.

### Acceptance criteria
- [x] Center-aligned hero eyebrows display lines on both sides
- [x] Both lines have matching width, colour, thickness and spacing (both `currentColor`, 34×2px, gap 12px each side)
- [x] Left alignment preserves existing behaviour
- [x] Balanced on desktop, tablet and mobile
- [x] Text does not wrap unnecessarily or leave its container
- [x] Builder preview matches the frontend (pure CSS, no render branch)
- [x] Existing content and saved configurations unchanged — rendered HTML and CSS for Styles 1, 2 and 3 at both base alignments are byte-for-byte identical to `main`