### PR TITLE
feat: Heading eyebrow divider can be an image (GH #169)

### DIFF
--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.110
+ * Version:           1.9.111
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.110' );
+define( 'DS_TOOLKIT_VERSION', '1.9.111' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-heading/css/frontend.css
+++ b/modules/ds-heading/css/frontend.css
@@ -26,6 +26,15 @@
 .ds-heading--center .ds-heading-rule{justify-content:center;}
 .ds-heading--right .ds-heading-rule{justify-content:flex-end;}
 .ds-heading-rule-line{display:block;width:48px;height:3px;background:var(--fl-global-accent);border-radius:2px;}
+/* ---- Image divider (GH #169) ---------------------------------------------------
+   Same slot as the line. height:auto + width:auto + max-height/max-width is the
+   end-mark recipe: the image scales down against whichever limit binds first and
+   never loses its aspect ratio, so it cannot stretch or overflow its container.
+   The trailing copy on a centred sub-heading is mirrored, so an asymmetric ornament
+   reads as a matched pair pointing inwards rather than two arrows facing the same
+   way. A symmetric divider is unaffected by the flip. */
+.ds-heading-rule-img{display:block;height:auto;width:auto;max-height:var(--ds-heading-rule-h,1.6em);max-width:100%;}
+.ds-heading-rule--after .ds-heading-rule-img{transform:scaleX(-1);}
 
 /* Inline (eyebrow) rule sits inside the sub-heading flex, so it shrinks to its line */
 .ds-heading-sub .ds-heading-rule{width:auto;}

--- a/modules/ds-heading/ds-heading.php
+++ b/modules/ds-heading/ds-heading.php
@@ -73,10 +73,28 @@ class DS_Heading_Module extends FLBuilderModule {
 		return nl2br( $h );
 	}
 
-	/** The eyebrow/divider rule element. */
+	/**
+	 * The eyebrow/divider rule element.
+	 *
+	 * Normally a plain line. With Divider Type set to Image (GH #169) the line is
+	 * swapped for the chosen image, in the same slot and with the same spacing, so
+	 * alignment and the centred both-sides behaviour keep working untouched. The
+	 * wrapper already carries aria-hidden, and the img gets an empty alt on top of
+	 * it, because a divider is decoration either way. Falls back to the line if the
+	 * image is missing, so a half-configured module never renders an empty gap.
+	 */
 	private function rule_html( $side = '' ) {
-		$mod = ( '' !== $side ) ? ' ds-heading-rule--' . $side : '';
-		return '<span class="ds-heading-rule' . $mod . '" aria-hidden="true"><span class="ds-heading-rule-line"></span></span>';
+		$mod   = ( '' !== $side ) ? ' ds-heading-rule--' . $side : '';
+		$inner = '<span class="ds-heading-rule-line"></span>';
+
+		if ( 'image' === ( $this->settings->divider_type ?? 'line' ) ) {
+			$url = $this->photo_url( $this->settings->divider_image ?? '', 'medium' );
+			if ( '' !== $url ) {
+				$inner = '<img class="ds-heading-rule-img" src="' . esc_url( $url ) . '" alt="" loading="lazy" decoding="async" />';
+			}
+		}
+
+		return '<span class="ds-heading-rule' . $mod . '" aria-hidden="true">' . $inner . '</span>';
 	}
 
 	/**
@@ -300,7 +318,37 @@ FLBuilder::register_module( 'DS_Heading_Module', array(
 						'label'   => __( 'Show Divider', 'ds-toolkit' ),
 						'default' => 'yes',
 						'options' => array( 'yes' => __( 'Yes', 'ds-toolkit' ), 'no' => __( 'No', 'ds-toolkit' ) ),
-						'toggle'  => array( 'yes' => array( 'fields' => array( 'divider_position', 'divider_style', 'divider_width', 'divider_width_unit', 'divider_thickness', 'divider_radius', 'divider_gap', 'divider_color' ) ) ),
+						'toggle'  => array( 'yes' => array( 'fields' => array( 'divider_type', 'divider_position', 'divider_style', 'divider_width', 'divider_width_unit', 'divider_thickness', 'divider_radius', 'divider_gap', 'divider_color', 'divider_image', 'divider_img_h' ) ) ),
+					),
+					'divider_type'      => array(
+						'type'    => 'select',
+						'label'   => __( 'Eyebrow Divider Type', 'ds-toolkit' ),
+						'default' => 'line',
+						'options' => array(
+							'line'  => __( 'Line', 'ds-toolkit' ),
+							'image' => __( 'Image', 'ds-toolkit' ),
+						),
+						'help'    => __( 'Swap the divider line for a decorative image or icon. It sits in the same place with the same spacing, and a centred sub-heading shows it on both sides.', 'ds-toolkit' ),
+						'toggle'  => array(
+							'line'  => array( 'fields' => array( 'divider_style', 'divider_width', 'divider_width_unit', 'divider_thickness', 'divider_radius', 'divider_color' ) ),
+							'image' => array( 'fields' => array( 'divider_image', 'divider_img_h' ) ),
+						),
+					),
+					'divider_image'     => array(
+						'type'        => 'photo',
+						'label'       => __( 'Divider Image', 'ds-toolkit' ),
+						'show_remove' => true,
+						'connections' => array( 'photo' ),
+						'help'        => __( 'Blank keeps the line, so the heading never renders an empty gap.', 'ds-toolkit' ),
+					),
+					'divider_img_h'     => array(
+						'type'        => 'unit',
+						'label'       => __( 'Image Size', 'ds-toolkit' ),
+						'default'     => '',
+						'description' => 'px',
+						'responsive'  => true,
+						'slider'      => array( 'min' => 8, 'max' => 160, 'step' => 1 ),
+						'help'        => __( 'Height of the divider image; the width follows so the aspect ratio never changes. Use the responsive icon for tablet and mobile sizes — leaving those blank keeps the desktop size. Blank everywhere tracks the sub-heading size.', 'ds-toolkit' ),
 					),
 					'divider_position'  => array(
 						'type'    => 'select',

--- a/modules/ds-heading/includes/frontend.css.php
+++ b/modules/ds-heading/includes/frontend.css.php
@@ -88,6 +88,17 @@ if ( ( $settings->divider_show ?? 'yes' ) === 'yes' ) {
 		echo "$node .ds-heading-rule-line { height: {$dth}px; background: {$dcol}; border: 0; }\n";
 	}
 
+	// Image divider (GH #169): authored HEIGHT, width follows, per breakpoint. Same
+	// max-height approach as the Style 2 end mark so the aspect ratio is preserved.
+	if ( 'image' === ( $settings->divider_type ?? 'line' ) ) {
+		foreach ( array( '' => '', '_medium' => $bpm, '_responsive' => $bpr ) as $sfx => $bp ) {
+			$v = $settings->{ 'divider_img_h' . $sfx } ?? '';
+			if ( '' === $v || null === $v ) { continue; }
+			$rule = "$node .ds-heading-rule-img { max-height: " . (int) $v . "px; }";
+			echo ( '' === $sfx ) ? "$rule\n" : "@media (max-width:{$bp}px){ $rule }\n";
+		}
+	}
+
 	// Gap between an inline (eyebrow) rule and the sub-heading text.
 	$dgap = $u( $settings->divider_gap ?? '', 14 );
 	echo "$node .ds-heading-sub--withrule { gap: {$dgap}px; }\n";


### PR DESCRIPTION
Closes #169.

New **Eyebrow Divider Type** control — Line (default) or Image — plus **Divider Image** and a responsive **Image Size**. The image drops into the same slot as the line, so alignment, the divider gap and the centred both-sides behaviour all keep working untouched.

Sizing reuses the Style 2 end-mark recipe: authored **height**, with `height:auto` / `width:auto` / `max-height` / `max-width:100%`, so the image scales against whichever limit binds first and never loses its aspect ratio or overflows.

### Two judgement calls worth your eye
1. **The trailing copy on a centred sub-heading is mirrored.** The issue asks for the image to be "visually balanced on both sides", and an asymmetric ornament is only balanced as a *matched pair*. Unmirrored, an arrow divider renders as two arrows both pointing the same way. A symmetric divider is unaffected by the flip. Easy to drop if you'd rather it not flip.
2. **Type = Image with no image chosen falls back to the line** rather than rendering an empty gap, so a half-configured module never looks broken.

Decoration either way: the wrapper already carries `aria-hidden` and the `img` adds an empty `alt`.

### Verified in a browser
Using a deliberately **asymmetric** 120×40 arrow ornament, so mirroring and aspect ratio are both measurable.

| Case | Result |
|---|---|
| line, centred (baseline) | 48×3 both sides, gaps 62/62 — unchanged |
| image, centred @ 1440/768/390 | **84×28** both sides, ratio **exactly 3**, trailing **mirrored**, gaps 98/98, no overflow |
| image, left | trailing `display:none`, single image |
| responsive size | desktop 84×28, mobile **42×14**, ratio still exactly 3 |
| oversized 120px @ 1440/768/390/320 | shrinks 120×40 → 107×36 → 51×17 → 40×13, ratio held, **never overlaps the text**, stays inside the container, no page overflow |

### Acceptance criteria
- [x] `Line` remains the default and preserves the current appearance
- [x] Selecting `Image` displays the Media Library and responsive size controls
- [x] The image replaces the eyebrow line in the preview and on the frontend
- [x] Center-aligned eyebrows display the image on both sides
- [x] Image proportions preserved at every breakpoint (measured ratio exactly 3 at every size tested)
- [x] Images do not overlap the text or cause horizontal overflow
- [x] Existing Heading modules unchanged — a line divider, a plain heading and a Style 2 heading render byte-for-byte identically to `main`
- [x] Existing controls, responsive patterns and module architecture reused (end-mark sizing recipe, existing rule slot, existing alignment CSS)