### PR TITLE
feat: CTA Style 6 gets a Layout control — cards grid or full-width rows (GH #174)

### DIFF
--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.112
+ * Version:           1.9.113
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.112' );
+define( 'DS_TOOLKIT_VERSION', '1.9.113' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/includes/class-ds-program-cards.php
+++ b/includes/class-ds-program-cards.php
@@ -181,6 +181,11 @@ class DS_Program_Cards {
 		// radius shows; blank keeps the theme shape (button follows the theme by default).
 		$btn_cls = 'ds-program-btn' . ( ( $s->pg_btn_style ?? 'theme' ) === 'custom' ? ' ds-no-clip' : '' );
 
+		// Layout (GH #174): 'columns' is the original card grid, verbatim. 'rows'
+		// renders one full-width row per program with the content flowing across.
+		// Carousel display keeps the grid form — its track must stay a flex row.
+		$rows = ( ( $s->pg_layout ?? 'columns' ) === 'rows' ) && ( ( $s->display ?? 'grid' ) !== 'carousel' );
+
 		echo '<section class="ds-news ds-programs"><div class="ds-news-wrap">';
 		self::head( $s );
 
@@ -195,7 +200,7 @@ class DS_Program_Cards {
 			return;
 		}
 
-		self::open( $s, 'ds-program-grid' );
+		self::open( $s, 'ds-program-grid' . ( $rows ? ' ds-program-grid--rows' : '' ) );
 
 		foreach ( $items as $it ) {
 			$it    = (object) $it;
@@ -394,40 +399,53 @@ class DS_Program_Cards {
 		$col = array( 'DS_Module_UI', 'color' );
 		$u   = array( 'DS_Module_UI', 'u' );
 
-		$pgc = max( 1, min( 6, (int) ( $settings->pg_cols ?? 3 ) ) );
+		// Rows layout (GH #174): the column counts, equal-height stretch, card
+		// alignment and image height are grid-shape settings — emitting them would
+		// fight the rows CSS at equal specificity and win on order (the node rules
+		// come after the stylesheet). Rows keeps gap, padding, colours, typography
+		// and the button styling below.
+		$rows = ( ( $settings->pg_layout ?? 'columns' ) === 'rows' ) && ( ( $settings->display ?? 'grid' ) !== 'carousel' );
+
 		$pgg = $u( $settings->pg_gap ?? '', 24 );
-		echo "$node .ds-program-grid{grid-template-columns:repeat({$pgc},1fr);gap:{$pgg}px;}\n";
-
-		// Tablet and mobile counts were hardcoded to 2 and 1, so the Columns control
-		// only ever changed the desktop row (GH #148). They are configurable now, and
-		// an unset value keeps the number that was hardcoded before — so every
-		// existing layout renders exactly as it did. The 1024/600 breakpoints are the
-		// ones this grid has always used; no new ones are introduced.
-		$cols_at = static function ( $val, $fallback ) {
-			if ( '' === $val || null === $val ) { return $fallback; }
-			return max( 1, min( 6, (int) $val ) );
-		};
-		$pgm = $cols_at( $settings->pg_cols_medium ?? '', 2 );
-		$pgr = $cols_at( $settings->pg_cols_responsive ?? '', 1 );
-		echo "@media(max-width:1024px){ $node .ds-program-grid{grid-template-columns:repeat({$pgm},1fr);} }\n";
-		echo "@media(max-width:600px){ $node .ds-program-grid{grid-template-columns:repeat({$pgr},1fr);} }\n";
-
-		if ( ( $settings->pg_same_height ?? 'yes' ) === 'yes' ) {
-			echo "$node .ds-program-grid{align-items:stretch;} $node .ds-program-card{height:100%;}\n";
+		if ( $rows ) {
+			echo "$node .ds-program-grid{gap:{$pgg}px;}\n";
 		} else {
-			echo "$node .ds-program-grid{align-items:start;} $node .ds-program-card{height:auto;}\n";
+			$pgc = max( 1, min( 6, (int) ( $settings->pg_cols ?? 3 ) ) );
+			echo "$node .ds-program-grid{grid-template-columns:repeat({$pgc},1fr);gap:{$pgg}px;}\n";
+
+			// Tablet and mobile counts were hardcoded to 2 and 1, so the Columns control
+			// only ever changed the desktop row (GH #148). They are configurable now, and
+			// an unset value keeps the number that was hardcoded before — so every
+			// existing layout renders exactly as it did. The 1024/600 breakpoints are the
+			// ones this grid has always used; no new ones are introduced.
+			$cols_at = static function ( $val, $fallback ) {
+				if ( '' === $val || null === $val ) { return $fallback; }
+				return max( 1, min( 6, (int) $val ) );
+			};
+			$pgm = $cols_at( $settings->pg_cols_medium ?? '', 2 );
+			$pgr = $cols_at( $settings->pg_cols_responsive ?? '', 1 );
+			echo "@media(max-width:1024px){ $node .ds-program-grid{grid-template-columns:repeat({$pgm},1fr);} }\n";
+			echo "@media(max-width:600px){ $node .ds-program-grid{grid-template-columns:repeat({$pgr},1fr);} }\n";
+
+			if ( ( $settings->pg_same_height ?? 'yes' ) === 'yes' ) {
+				echo "$node .ds-program-grid{align-items:stretch;} $node .ds-program-card{height:100%;}\n";
+			} else {
+				echo "$node .ds-program-grid{align-items:start;} $node .ds-program-card{height:auto;}\n";
+			}
 		}
 
 		$pgpad = $u( $settings->pg_pad ?? '', 28 );
 		$pgbg  = $col( $settings->pg_card_bg ?? '' );
 		echo "$node .ds-program-card{padding:{$pgpad}px;" . ( $pgbg ? "background:{$pgbg};" : '' ) . "}\n";
 
-		$pal = ( ( $settings->pg_align ?? 'left' ) === 'center' ) ? 'center' : 'left';
-		$pai = ( 'center' === $pal ) ? 'center' : 'flex-start';
-		echo "$node .ds-program-card{text-align:{$pal};align-items:{$pai};}\n";
+		if ( ! $rows ) {
+			$pal = ( ( $settings->pg_align ?? 'left' ) === 'center' ) ? 'center' : 'left';
+			$pai = ( 'center' === $pal ) ? 'center' : 'flex-start';
+			echo "$node .ds-program-card{text-align:{$pal};align-items:{$pai};}\n";
 
-		$pih = $u( $settings->pg_img_h ?? '', 180 );
-		echo "$node .ds-program-media{height:{$pih}px;}\n";
+			$pih = $u( $settings->pg_img_h ?? '', 180 );
+			echo "$node .ds-program-media{height:{$pih}px;}\n";
+		}
 
 		$pis = $u( $settings->pg_icon_size ?? '', 40 );
 		echo "$node .ds-program-ico{font-size:{$pis}px;line-height:1;}\n";

--- a/modules/ds-cta/css/frontend.css
+++ b/modules/ds-cta/css/frontend.css
@@ -284,3 +284,40 @@
 .ds-program-desc{margin:0;color:var(--fl-global-body);font-size:.95rem;line-height:1.5;}
 .fl-builder-content .ds-program-card .ds-program-btn{align-self:flex-start;flex-shrink:0;margin-top:auto;display:inline-block;background:var(--fl-global-button);color:var(--fl-global-white);padding:10px 22px;border-radius:6px;font-weight:700;font-size:.82rem;letter-spacing:1px;text-transform:uppercase;text-decoration:none;transition:background .2s ease;position:relative;z-index:2;}
 .fl-builder-content .ds-program-card .ds-program-btn:hover,.fl-builder-content .ds-program-card:hover .ds-program-btn{background:var(--fl-global-accent);color:var(--fl-global-white);}
+
+/* ---- Style 6 Vertical rows layout (GH #174) --------------------------------------
+   One full-width row per program: date on the left, title over sub-heading, the
+   description beside them, button on the right. Layout only — every font, colour,
+   border and button rule above applies unchanged, so switching layouts never
+   restyles a card. The flat card markup is shared with the columns layout (and with
+   legacy Post Loop program instances), so the row shape is drawn with grid areas
+   rather than new wrappers. 1024/600 are the breakpoints this grid has always used. */
+.ds-program-grid--rows{display:flex;flex-direction:column;}
+.ds-program-grid--rows .ds-program-card{flex-direction:row;align-items:center;gap:24px;width:100%;height:auto;}
+.ds-program-grid--rows .ds-program-ico{flex:0 0 auto;}
+.ds-program-grid--rows .ds-program-media{flex:0 0 150px;width:150px;height:100px;}
+.ds-program-grid--rows .ds-program-body{display:grid;grid-template-columns:auto minmax(0,1.1fr) minmax(0,1fr) auto;grid-template-areas:"date title desc btn" "date sub desc btn";align-items:center;column-gap:28px;row-gap:2px;}
+.ds-program-grid--rows .ds-program-date{grid-area:date;align-self:center;}
+.ds-program-grid--rows .ds-program-title{grid-area:title;align-self:end;}
+.ds-program-grid--rows .ds-program-sub{grid-area:sub;align-self:start;}
+.ds-program-grid--rows .ds-program-desc{grid-area:desc;}
+/* four classes: the stock button rule is .fl-builder-content .ds-program-card
+   .ds-program-btn at (0,3,1) and carries margin-top:auto for the columns layout —
+   in a row that auto margin would pin the button to the bottom edge. */
+.fl-builder-content .ds-program-grid--rows .ds-program-card .ds-program-btn{grid-area:btn;margin-top:0;align-self:center;justify-self:end;}
+@media(max-width:1024px){
+  .ds-program-grid--rows .ds-program-body{grid-template-columns:auto minmax(0,1fr) auto;grid-template-areas:"date title btn" "date sub btn" "desc desc desc";}
+}
+@media(max-width:600px){
+  .ds-program-grid--rows .ds-program-card{flex-direction:column;align-items:flex-start;}
+  .ds-program-grid--rows .ds-program-media{width:100%;flex-basis:auto;height:140px;}
+  .ds-program-grid--rows .ds-program-body{display:flex;flex-direction:column;gap:6px;}
+  /* The grid-area align-self values above survive into this flex column, where
+     align-self means HORIZONTAL alignment — the date centred itself and the title
+     right-aligned. Pin every child back to the left edge for the stacked card. */
+  .ds-program-grid--rows .ds-program-date,
+  .ds-program-grid--rows .ds-program-sub,
+  .ds-program-grid--rows .ds-program-title,
+  .ds-program-grid--rows .ds-program-desc{align-self:flex-start;}
+  .fl-builder-content .ds-program-grid--rows .ds-program-card .ds-program-btn{align-self:flex-start;}
+}

--- a/modules/ds-cta/ds-cta.php
+++ b/modules/ds-cta/ds-cta.php
@@ -1209,6 +1209,19 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 			'program_opts' => array(
 				'title'  => __( 'Program Cards', 'ds-toolkit' ),
 				'fields' => array(
+					'pg_layout'      => array(
+						'type'    => 'select',
+						'label'   => __( 'Layout', 'ds-toolkit' ),
+						'default' => 'columns',
+						'options' => array(
+							'columns' => __( 'Horizontal — cards side by side (default)', 'ds-toolkit' ),
+							'rows'    => __( 'Vertical — full-width rows', 'ds-toolkit' ),
+						),
+						'help'    => __( 'Horizontal flows the cards left to right into the Columns count below. Vertical stacks one full-width row per program, with the date, text and button laid across the row; rows collapse back to stacked cards on phones. Fonts, colours and buttons stay exactly as styled below in both.', 'ds-toolkit' ),
+						'toggle'  => array(
+							'columns' => array( 'fields' => array( 'pg_cols', 'pg_same_height', 'pg_align', 'pg_img_h' ) ),
+						),
+					),
 					'pg_cols'        => array(
 						'type'       => 'unit',
 						'label'      => __( 'Columns', 'ds-toolkit' ),


### PR DESCRIPTION
Closes #174.

### A premise correction first
The issue asks for Horizontal = "programs across multiple columns... use the container width evenly... responsive". **That already exists**: the Columns control has driven the grid at `repeat(N,1fr)` with responsive tablet/mobile counts since #148 (default 3 / 2 / 1). What Style 6 could **not** do is the look in the issue's own reference screenshot — one full-width row per program with the date, title over sub-heading, description and button laid *across* the row. That row treatment is what this adds.

### The control
New **Layout** select on the Program Cards panel, named in the issue's vocabulary:

| Option | What it is |
|---|---|
| **Horizontal — cards side by side** (default) | the existing grid, verbatim; Columns / Equal Height / Alignment / Image Height stay with it |
| **Vertical — full-width rows** | the reference-screenshot row: date \| title over sub \| description \| button |

Layout only — every font, colour, border, hover and button rule applies unchanged in both, per the issue's "preserve the existing Style 6 fonts, colors, spacing, borders, and button styling".

### Implementation notes
- The row is drawn with **grid areas over the existing flat markup**, no new wrappers — the markup is shared with legacy Post Loop program instances, which can never set `pg_layout` and stay byte-identical on the default path. Post Loop's own CSS block is untouched.
- **Carousel display keeps the grid form** regardless of the setting: its track must stay a flex row.
- Grid-shape settings (columns, equal height, alignment, image height) are **not emitted in rows mode** — per-node rules land after the stylesheet and would win the specificity tie against the rows CSS.
- Breakpoints are the **1024/600** this grid has always used: at 1024 the description drops to its own line; at 600 the row collapses into the same stacked card the grid produces.
- One bug caught by screenshot during verification: grid-area `align-self` values survive into the mobile flex column, where `align-self` means *horizontal* alignment — the date centred itself and the title right-aligned. The 600px block pins every child back to the left edge.

### Verified in a browser
- Rows are full width (1280px card in a 1280px grid), button inset exactly the card padding from the right, at 1440 and 900
- 390px: stacked card, every element left-pinned, matching the grid's own mobile look
- No horizontal page overflow at any width
- Carousel + rows: the guard holds, track stays a plain `ds-program-grid`
- **Default Style 6 renders byte-identical HTML and CSS to `main`** — requirement 5/6/7 (no redesign, Styles 1–5 untouched) holds by construction, since nothing outside Style 6's program panel changed

Screenshots of desktop rows / tablet / mobile / default grid attached to the issue comment.