### PR TITLE
feat: Page Banner gets a Title Alignment control — top, center, bottom (GH #176)

### DIFF
--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.113
+ * Version:           1.9.114
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.113' );
+define( 'DS_TOOLKIT_VERSION', '1.9.114' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-hero/css/frontend.css
+++ b/modules/ds-hero/css/frontend.css
@@ -124,6 +124,16 @@
 .ds-banner--has-bg .ds-hero-title{color:var(--fl-global-white,#fff);}
 .ds-banner--has-bg .ds-hero-sub{color:#e9eef0;}
 .ds-banner--no-bg{background:var(--fl-global-light-background,#f2f4f6);}
+/* ---- Style 2 vertical title placement (GH #176) --------------------------------
+   The banner is a flex box that centres its content, so Top/Bottom are one
+   cross-axis change on the section. Center adds no class and no rule — an
+   existing banner renders untouched. The 28px inset only exists on the two new
+   variants, so the title never sits hard against the banner edge; the Spacing
+   padding control still adds on top of it as it always has. */
+.ds-hero--banner.ds-banner--v-top{align-items:flex-start;}
+.ds-hero--banner.ds-banner--v-bottom{align-items:flex-end;}
+.ds-banner--v-top .ds-hero-wrap{padding-top:28px;}
+.ds-banner--v-bottom .ds-hero-wrap{padding-bottom:28px;}
 .ds-banner--no-bg .ds-hero-title{color:var(--fl-global-headings,#15171b);}
 .ds-banner--no-bg .ds-hero-sub{color:var(--fl-global-body,#5b6671);}
 

--- a/modules/ds-hero/ds-hero.php
+++ b/modules/ds-hero/ds-hero.php
@@ -380,7 +380,13 @@ class DS_Hero_Module extends FLBuilderModule {
 		// Parallax: only for a photo banner (a fixed video can't parallax cleanly).
 		$parallax = ( ( $s->banner_parallax ?? 'no' ) === 'yes' ) && ( '' !== $img ) && ( '' === $video );
 
-		$mods = 'ds-hero ds-hero--style2 ds-hero--banner ds-banner--' . $align . ( $has_bg ? ' ds-banner--has-bg' : ' ds-banner--no-bg' ) . ( $parallax ? ' ds-banner--parallax' : '' );
+		// Vertical title placement (GH #176). Center is the default and adds no
+		// class, so an existing banner's markup does not change by a byte.
+		$valign = (string) ( $s->banner_valign ?? 'center' );
+		if ( ! in_array( $valign, array( 'top', 'center', 'bottom' ), true ) ) { $valign = 'center'; }
+		$vmod = ( 'center' === $valign ) ? '' : ' ds-banner--v-' . $valign;
+
+		$mods = 'ds-hero ds-hero--style2 ds-hero--banner ds-banner--' . $align . ( $has_bg ? ' ds-banner--has-bg' : ' ds-banner--no-bg' ) . ( $parallax ? ' ds-banner--parallax' : '' ) . $vmod;
 		echo '<section class="' . esc_attr( $mods ) . '"' . ( $parallax ? ' data-parallax="1"' : '' ) . '>';
 		if ( '' !== $video ) {
 			echo '<div class="ds-hero-bg"><video class="ds-hero-video" autoplay muted loop playsinline src="' . esc_url( $video ) . '"></video></div>';
@@ -1074,6 +1080,17 @@ FLBuilder::register_module( 'DS_Hero_Module', array(
 				'title'  => __( 'Banner', 'ds-toolkit' ),
 				'fields' => array(
 					'banner_align'       => array( 'type' => 'select', 'label' => __( 'Alignment', 'ds-toolkit' ), 'default' => 'center', 'responsive' => true, 'options' => array( 'left' => __( 'Left', 'ds-toolkit' ), 'center' => __( 'Center', 'ds-toolkit' ), 'right' => __( 'Right', 'ds-toolkit' ) ) ),
+					'banner_valign'      => array(
+						'type'    => 'select',
+						'label'   => __( 'Title Alignment', 'ds-toolkit' ),
+						'default' => 'center',
+						'options' => array(
+							'top'    => __( 'Top', 'ds-toolkit' ),
+							'center' => __( 'Center (default)', 'ds-toolkit' ),
+							'bottom' => __( 'Bottom', 'ds-toolkit' ),
+						),
+						'help'    => __( 'Where the title block sits vertically inside the banner. Bottom keeps a photo\'s subject clear — faces in a team photo stay uncovered. Only the title placement moves; the photo, overlay and typography are untouched.', 'ds-toolkit' ),
+					),
 					'banner_parallax' => array(
 						'type'    => 'select',
 						'label'   => __( 'Parallax', 'ds-toolkit' ),


### PR DESCRIPTION
Closes #176.

Style 2 centres its title because the banner section is a flex box with `align-items:center` — so the whole feature is one cross-axis change:

- **Title Alignment** select (Top / Center / Bottom) in the Banner style panel, shown only for Style 2 (the panel already sits behind the `hero_style` toggle)
- a `ds-banner--v-top` / `ds-banner--v-bottom` modifier on the section
- two static rules, plus a 28px inset so a moved title never touches the banner edge

**Center is the default and adds no class and no rule** — an existing banner's markup and CSS do not change by a byte. The reference case from the issue's screenshot is a team-photo banner: centred, the title sits across the players' faces; Bottom drops it clear of them.

Only the title block moves. Photo, scrim, overlay, typography, horizontal alignment and banner heights are untouched, and the no-photo compact banner honours the same setting. No JavaScript.

### Verified in a browser
| Viewport | title offset from banner top (Top / Center / Bottom) | contained | overflow |
|---|---|---|---|
| 1440 | 28 / 204 / 380 (banner 468px) | yes | 0 |
| 768 | 28 / 215 / 403 | yes | 0 |
| 390 | 28 / 186 / 344 (banner 439px) | yes | 0 |

### Acceptance criteria
- [x] Setting appears only when Style 2 is selected (lives in the Style-2-only Banner panel)
- [x] Exactly three options: Top / Center / Bottom
- [x] Center is the default; a default Style 2 renders **byte-identical HTML and CSS** to `main`
- [x] Only vertical title placement changes — image, overlay, typography, horizontal alignment and dimensions untouched
- [x] Existing design system reused: modifier-class pattern, static-sheet rules, no new JS or components
- [x] Works at desktop / tablet / mobile with no clipping or overflow (measured above)
- [x] Styles 1 and 3 byte-identical to `main`