### PR TITLE
fix: Style 6 can reach the Content Width control it always honoured (GH #178)

### DIFF
--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.114
+ * Version:           1.9.115
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.114' );
+define( 'DS_TOOLKIT_VERSION', '1.9.115' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-cta/ds-cta.php
+++ b/modules/ds-cta/ds-cta.php
@@ -788,11 +788,6 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 				'title'  => __( 'Section', 'ds-toolkit' ),
 				'fields' => array(
 					'section_bg' => array( 'type' => 'color', 'connections' => array( 'color' ), 'label' => __( 'Section Background', 'ds-toolkit' ), 'default' => 'var(--fl-global-light-background)', 'show_reset' => true ),
-				),
-			),
-			'grid' => array(
-				'title'  => __( 'Grid', 'ds-toolkit' ),
-				'fields' => array(
 					'content_width'     => array(
 						'type'    => 'select',
 						'label'   => __( 'Content Width', 'ds-toolkit' ),
@@ -806,6 +801,11 @@ FLBuilder::register_module( 'DS_CTA_Module', array(
 						'help'    => __( 'Full width lets the CTA fill a full-width row/column. Use the row/column padding for side spacing.', 'ds-toolkit' ),
 					),
 					'content_max_width' => array( 'type' => 'unit', 'label' => __( 'Max Width', 'ds-toolkit' ), 'default' => '1280', 'description' => 'px', 'slider' => array( 'min' => 480, 'max' => 1920, 'step' => 10 ) ),
+				),
+			),
+			'grid' => array(
+				'title'  => __( 'Grid', 'ds-toolkit' ),
+				'fields' => array(
 					'columns'    => array( 'type' => 'unit', 'label' => __( 'Columns', 'ds-toolkit' ), 'default' => '4', 'responsive' => true, 'slider' => array( 'min' => 1, 'max' => 6, 'step' => 1 ) ),
 					'gap'        => array( 'type' => 'unit', 'label' => __( 'Gap', 'ds-toolkit' ), 'default' => '20', 'description' => 'px', 'responsive' => true, 'slider' => array( 'min' => 0, 'max' => 60, 'step' => 1 ) ),
 				),


### PR DESCRIPTION
Closes #178.

### The bug is visibility, not width logic
The capability requested already existed end to end. The CSS emitter has always read `content_width` for **every** style — `.ds-cta-wrap` for Styles 1–5, and `.ds-news-wrap` for Style 6, where `full` emits `max-width:none; margin:0`. But the control sat in the **Grid** panel, and Grid is not in Style 6's section list (nor Style 5's). A fully wired setting nobody could set — the same class of bug as #154, where `section_bg` sat in a panel two styles never showed.

### Fix
`content_width` + `content_max_width` move from the Grid panel into the **Section** panel, which Styles 1, 2, 3, 5 and 6 all show. One field definition, same name — the key is load-bearing: migrated Post Loop program nodes carry `content_width` values, and the Style 6 emitter mirrors Post Loop on purpose. Default stays **Boxed**.

| Style | Effect |
|---|---|
| 1–3 | same control, one panel over (it is a section-level setting, not a grid one) |
| 5 | sees the control for the first time — already wired underneath |
| 6 | **the fix** — Full width now reachable |
| 4 | own hero layout, untouched |

### Measured (one program, 1600px and 700px columns)
| Case | wide column | narrow column |
|---|---|---|
| rows, boxed (the report) | card **1280** of 1600 | 700 of 700 |
| rows, **full** | card **1600 of 1600** | **700 of 700** |
| grid, full | wrap expands to 1600 | 700 |

"Parent column width = CTA Style 6 width" — exactly the acceptance line in the issue.

### Regression
Defaults for Styles 1, 2, 3, 5, and Style 6 in both layouts render **byte-identical HTML and CSS to `main`** — no existing page changes, no redesign, fonts/colours/buttons untouched, mobile stacking from #174 unaffected.

### Diagnosis note for the reported symptom
A card "narrow on the **left**" is the *Horizontal (grid)* layout doing its job: one program in a three-column grid occupies the first 1/3-width cell (measured: 411px card at the left of a 1280px wrap). The full-width row treatment is the **Vertical — full-width rows** layout from 1.9.113 — and a page saved before that update serves stale bundled CSS until its BB layout cache regenerates.