### PR TITLE
Info List plain-row hover fix + Media > University Logo Finder for partners (1.9.116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.116] - 2026-09-03
+### Fixed
+- **Info List: rows with no link no longer underline on hover.** The hover rule targeted every `.ds-info-item`, so a plain row (link type "No link", or a text field like a school name) underlined exactly like a real link and read as clickable. Reported on an athlete profile where Position and School looked like links that went nowhere. The underline is now scoped to `a.ds-info-item`, so linked rows keep their hover and plain rows stay static. Markup and settings are unchanged.
+
+### Added
+- **Media -> University Logo Finder for partners.** The finder lived only as a tab on the DS Toolkit settings page, which is registered for LeagueApps accounts alone, so a Partner could never reach it no matter which role toggles were set. It now also registers as its own page under Media for any user with `upload_files`, using the same view and import handler. Settings, Plugins and Tools stay hidden for partners as before; the DS Toolkit tab is unchanged for LeagueApps users. The import handler's capability check moved from `manage_options` to `upload_files` to match the page (importing into the library is an upload).
+
 ## [1.9.112] - 2026-08-28
 ### Fixed
 - **Origin Guard blocked visitors submitting a page password.** WordPress's password-protected page form posts to `wp-login.php?action=postpass` from the protected page itself and never sets the login test cookie, so the guard's cold-login-POST rule refused it and every visitor who typed the correct password got "Forbidden" (seen on mvvc's "Coach Portal"). The rule now exempts `action=postpass`; credential stuffing targets the login action and stays blocked. Payload bumped to **1.0.1**, which is what makes existing sites rewrite their guard file — the installer only touches the filesystem when the state fingerprint changes, so without the payload bump sites already carrying the broken file would have kept it indefinitely (and any hand-patched site would have been silently reverted on the next payload change).

--- a/admin/class-ds-logo-finder.php
+++ b/admin/class-ds-logo-finder.php
@@ -63,7 +63,7 @@ class DS_Logo_Finder {
     public function ajax_import_logo() {
         check_ajax_referer( 'ds_import_logo', 'nonce' );
 
-        if ( ! current_user_can( 'manage_options' ) ) {
+        if ( ! current_user_can( 'upload_files' ) ) {
             wp_send_json_error( array( 'message' => 'Permission denied.' ) );
         }
 

--- a/admin/class-ds-toolkit-admin.php
+++ b/admin/class-ds-toolkit-admin.php
@@ -33,10 +33,45 @@ class DS_Toolkit_Admin {
     }
 
     public function add_menu() {
+        // The University Logo Finder is a partner-facing tool (school crests for
+        // athlete commitment pages), so it gets its own entry under Media for
+        // anyone who can add to the library. Settings stays hidden from partners,
+        // and the DS Toolkit page below stays LeagueApps-only; this is the same
+        // finder reached from a menu they can actually see.
+        add_media_page(
+            'University Logo Finder',
+            'University Logo Finder',
+            'upload_files',
+            'ds-logo-finder',
+            array( $this, 'render_logo_finder_page' )
+        );
+
         if ( ! $this->is_leagueapps_user() ) {
             return;
         }
         add_options_page( 'DS Toolkit', 'DS Toolkit', 'manage_options', 'ds-toolkit', array( $this, 'render_page' ) );
+    }
+
+    /**
+     * Media -> University Logo Finder. Same view and import handler as the
+     * DS Toolkit tab, without the settings chrome around it.
+     */
+    public function render_logo_finder_page() {
+        if ( ! current_user_can( 'upload_files' ) ) {
+            return;
+        }
+        ?>
+        <div class="wrap dst-wrap">
+            <div class="dst-header">
+                <div class="dst-header-icon"><span class="dashicons dashicons-format-image"></span></div>
+                <div class="dst-header-text">
+                    <h1>University Logo Finder</h1>
+                    <p>Search a college or university and import its logo into the Media Library.</p>
+                </div>
+            </div>
+            <?php require DS_TOOLKIT_PATH . 'admin/views/page-logo-finder.php'; ?>
+        </div>
+        <?php
     }
 
     public function register_settings() {
@@ -69,6 +104,11 @@ class DS_Toolkit_Admin {
     }
 
     public function enqueue_scripts( $hook ) {
+        if ( $hook === 'media_page_ds-logo-finder' ) {
+            wp_enqueue_style( 'ds-toolkit-admin', DS_TOOLKIT_URL . 'assets/css/admin.css', array(), DS_TOOLKIT_VERSION );
+            $this->logo_finder->enqueue_assets();
+            return;
+        }
         if ( $hook !== 'settings_page_ds-toolkit' ) {
             return;
         }

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.115
+ * Version:           1.9.116
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.115' );
+define( 'DS_TOOLKIT_VERSION', '1.9.116' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-info-list/css/frontend.css
+++ b/modules/ds-info-list/css/frontend.css
@@ -5,5 +5,5 @@
 .ds-info-ico i{font-size:16px;line-height:1;display:block;}
 /* explicit colour so the text isn't tinted by the theme's content-link rule */
 .ds-info-item .ds-info-text{color:var(--fl-global-body);line-height:1.3;word-break:break-word;}
-.ds-info-item:hover .ds-info-text{text-decoration:underline;}
+a.ds-info-item:hover .ds-info-text{text-decoration:underline;}
 .ds-info-item--plain{cursor:default;}


### PR DESCRIPTION
## Fixed
- **Info List: rows with no link no longer underline on hover.** The hover rule hit every `.ds-info-item`, so plain rows (link type "No link", or a plain text field such as a school name) underlined like a link and read as clickable. Scoped to `a.ds-info-item`. Reported on an athlete profile (Position / School).

## Added
- **Media -> University Logo Finder for partners.** The finder was only a tab on the DS Toolkit settings page, which is registered for LeagueApps accounts alone, so a Partner could never reach it regardless of role toggles. It now also registers under Media for any user with `upload_files`, reusing the same view and import handler. Settings/Plugins/Tools stay hidden for partners; the DS Toolkit tab is unchanged. Import handler capability moved `manage_options` -> `upload_files` to match the page.

Version bumped in both header and define. CHANGELOG entry added.