### PR TITLE
chore: tripwire alerts default to design@leagueapps.com, accept a comma list (1.9.118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.118] - 2026-09-03
+### Changed
+- **Tripwire alert address: defaults to the shared design@leagueapps.com inbox and accepts a comma-separated list.** `tripwire_alert_email` may now hold several recipients (invalid entries are dropped); if nothing valid remains the shared inbox is the fallback. The `ds_tripwire_alert_email` filter now receives (and should return) an array.
+
 ## [1.9.117] - 2026-09-03
 ### Added
 - **DS Tripwire: daily indicator-of-compromise check + instant new-administrator alerts.** Born from the Aug/Sep 2026 "WDG" fleet campaign (98 sites across both hosts; Defender was installed on nearly every victim and never alerted). A daily cron (03:10 site time) checks exactly the places the campaign lives: unexpected PHP files in mu-plugins (baseline drift plus a hard blocklist of the campaign's camouflage names and the `wdg-<8 hex>.php` loader pattern), fake `wdg-*`/`starter-*` plugin folders, the WDG-CORE self-heal marker in the tails of both theme functions.php, webroot index.php and wp-config.php, a rogue webroot error.php, an oversized mu-plugins/index.php, and administrator-roster drift. Independently of the cron, creating or promoting any administrator emails an alert immediately — on the campaign's patient zero the attacker's admin account existed two hours before the first malware file, so this alone collapses the response window from days to minutes. Cheap by design (two directory listings and four file tails once a day, zero frontend cost), clone-safe (first run seeds baselines silently, so a fresh blueprint clone never emails), and dependency-free (wp_mail, one option row of state; findings persist to the option even if mail fails). On fleet-wide by default; alert address defaults to agabriel@leagueapps.com and is overridable per site via `tripwire_alert_email` or the `ds_tripwire_alert_email` filter.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.117
+ * Version:           1.9.118
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.117' );
+define( 'DS_TOOLKIT_VERSION', '1.9.118' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-tripwire.php
+++ b/features/class-ds-tripwire.php
@@ -246,9 +246,12 @@ class DS_Tripwire {
     /* -------------------------------------------------------------- output */
 
     private function alert( $subject, array $lines ) {
-        $to = $this->settings['tripwire_alert_email'] ?? '';
-        if ( ! is_email( $to ) ) {
-            $to = 'agabriel@leagueapps.com';
+        // Comma-separated list supported; invalid entries dropped, and the
+        // shared Design Shop inbox is the fallback if nothing valid remains.
+        $raw = (string) ( $this->settings['tripwire_alert_email'] ?? '' );
+        $to  = array_filter( array_map( 'trim', explode( ',', $raw ) ), 'is_email' );
+        if ( ! $to ) {
+            $to = array( 'design@leagueapps.com' );
         }
         $to   = apply_filters( 'ds_tripwire_alert_email', $to );
         $site = home_url();

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -340,7 +340,7 @@ class DS_Toolkit {
             // Tripwire: on fleet-wide. First run seeds baselines silently
             // (clone-safe); it only ever emails on later drift or hard IOCs.
             'tripwire_enabled'                   => 1,
-            'tripwire_alert_email'               => 'agabriel@leagueapps.com',
+            'tripwire_alert_email'               => 'design@leagueapps.com',
             // Ships in monitor mode: staged rollout. Every rule is safe on
             // its own — the pagination rule only refuses pages WordPress
             // confirms are empty, and reverse-DNS-verified search engines are


### PR DESCRIPTION
tripwire_alert_email now defaults to the shared design@leagueapps.com inbox and accepts a comma-separated recipient list (invalid entries dropped, shared inbox as fallback). The ds_tripwire_alert_email filter now works with an array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)