### PR TITLE
chore: tripwire alerts to design@ inbox, address the point person (1.9.120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.120] - 2026-09-03
+### Changed
+- **Tripwire alerts route to the shared design@leagueapps.com inbox and address "the Design Shop point person for security" instead of a named individual.** Recipients stay overridable per site via `tripwire_alert_email` (comma-separated list) and the `ds_tripwire_alert_email` filter.
+
 ## [1.9.119] - 2026-09-03
 ### Changed
 - **Tripwire alerts rewritten in plain language.** Every finding now says what was found and why it matters in words a non-technical reader can act on, and the email walks through what to do (do not delete anything — the malware self-repairs; forward to Ali). The default recipient is agabriel@leagueapps.com for now; it moves to the shared design@ inbox once the team is briefed on the response playbook. Comma-separated recipient lists still supported via `tripwire_alert_email`.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.119
+ * Version:           1.9.120
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.119' );
+define( 'DS_TOOLKIT_VERSION', '1.9.120' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-tripwire.php
+++ b/features/class-ds-tripwire.php
@@ -238,7 +238,7 @@ class DS_Tripwire {
             array(
                 "A new administrator just appeared on this site: {$user->user_login} <{$user->user_email}> ({$how}).",
                 "Created by: {$actor}.",
-                'If nobody on the team did this, the site may be compromised — in the recent attack a rogue admin account appeared two hours before the malware. Tell Ali right away.',
+                'If nobody on the team did this, the site may be compromised — in the recent attack a rogue admin account appeared two hours before the malware. Flag it to the Design Shop point person for security right away.',
             )
         );
     }
@@ -247,12 +247,12 @@ class DS_Tripwire {
 
     private function alert( $subject, array $lines ) {
         // Comma-separated list supported; invalid entries are dropped. The
-        // fallback is Ali for now — switch to design@leagueapps.com once the
-        // wider team has been briefed on the response playbook.
+        // fallback is the shared Design Shop inbox so alerts always reach a
+        // person who can route them.
         $raw = (string) ( $this->settings['tripwire_alert_email'] ?? '' );
         $to  = array_filter( array_map( 'trim', explode( ',', $raw ) ), 'is_email' );
         if ( ! $to ) {
-            $to = array( 'agabriel@leagueapps.com' );
+            $to = array( 'design@leagueapps.com' );
         }
         $to   = apply_filters( 'ds_tripwire_alert_email', $to );
         $site = home_url();
@@ -268,7 +268,7 @@ class DS_Tripwire {
               . "should be looked at today.\n\n"
               . "What to do:\n"
               . "1. Do not delete anything yourself — this malware repairs itself if only one copy is removed.\n"
-              . "2. Send this email to Ali (agabriel@leagueapps.com), who has the removal playbook.\n"
+              . "2. Forward this email to the Design Shop point person for security, who has the removal playbook, so it can be actioned right away.\n"
               . "3. If the site looks fine to visitors, that is normal — this malware hides from people "
               . "and only shows itself to search engines.\n\n"
               . "— DS Tripwire (part of the DS Toolkit plugin)\n";

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -340,7 +340,7 @@ class DS_Toolkit {
             // Tripwire: on fleet-wide. First run seeds baselines silently
             // (clone-safe); it only ever emails on later drift or hard IOCs.
             'tripwire_enabled'                   => 1,
-            'tripwire_alert_email'               => 'agabriel@leagueapps.com',
+            'tripwire_alert_email'               => 'design@leagueapps.com',
             // Ships in monitor mode: staged rollout. Every rule is safe on
             // its own — the pagination rule only refuses pages WordPress
             // confirms are empty, and reverse-DNS-verified search engines are


### PR DESCRIPTION
Alerts route to design@leagueapps.com by default and the copy says to forward to the Design Shop point person for security instead of naming an individual. Per-site override + filter unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)