### PR TITLE
fix: tripwire dedupes new-admin alerts; daily check at true site-local 03:10 (1.9.121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.121] - 2026-09-03
+### Fixed
+- **Tripwire: one alert per new administrator, not two.** Creating an admin fires both `set_user_role` and `user_register`, so a single rogue account emailed twice; a per-request guard now dedupes.
+- **Tripwire: the daily check really runs at 03:10 site time.** The first-run scheduling used the timezone-shifted clock as if it were UTC, so the cron landed at 03:10 UTC instead of site-local; the offset is now converted back.
+
 ## [1.9.120] - 2026-09-03
 ### Changed
 - **Tripwire alerts route to the shared design@leagueapps.com inbox and address "the Design Shop point person for security" instead of a named individual.** Recipients stay overridable per site via `tripwire_alert_email` (comma-separated list) and the `ds_tripwire_alert_email` filter.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.120
+ * Version:           1.9.121
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.120' );
+define( 'DS_TOOLKIT_VERSION', '1.9.121' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-tripwire.php
+++ b/features/class-ds-tripwire.php
@@ -65,8 +65,11 @@ class DS_Tripwire {
 
         if ( is_admin() || wp_doing_cron() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
             if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
-                // 03:10 site time: off-peak, and offset from the :00 herd.
-                $first = strtotime( 'tomorrow 03:10', current_time( 'timestamp' ) );
+                // 03:10 site-local time: off-peak, and offset from the :00 herd.
+                // strtotime against the tz-shifted clock gives a "local reading";
+                // subtract the offset to get the real UTC timestamp cron expects.
+                $local  = strtotime( 'tomorrow 03:10', current_time( 'timestamp' ) );
+                $first  = $local ? $local - (int) round( (float) get_option( 'gmt_offset', 0 ) * HOUR_IN_SECONDS ) : 0;
                 wp_schedule_event( $first ? $first : time() + DAY_IN_SECONDS, 'daily', self::CRON_HOOK );
             }
         }
@@ -224,6 +227,12 @@ class DS_Tripwire {
     }
 
     private function alert_new_admin( $user, $how ) {
+        static $alerted = array();
+        if ( isset( $alerted[ $user->ID ] ) ) {
+            return;
+        }
+        $alerted[ $user->ID ] = true;
+
         $actor = 'unknown actor';
         if ( function_exists( 'wp_get_current_user' ) ) {
             $current = wp_get_current_user();


### PR DESCRIPTION
Two audit findings: (1) creating an admin fires set_user_role + user_register, double-emailing one event - per-request guard added; (2) first-run scheduling treated the tz-shifted clock as UTC, landing at 03:10 UTC instead of site time - offset now converted back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)