### PR TITLE
fix: tournament cards parse slash-date ranges so events sort first-to-last (1.9.122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.122] - 2026-09-03
+### Fixed
+- **Post Loop, Tournament Cards: events with slash-date ranges now sort first-to-last and drop when past.** An Event Date like `09/19 - 09/20/2026` (or `Oct 31 - Nov 1, 2026`) failed to parse, so every event shared one "unknown date" key and the cards kept the query's newest-first order; past events also never dropped. The parser now keeps the start of a range and borrows the year from the end when the start has none. ISO `YYYY-MM-DD` values parse too. Reported on sportsatthebeach.com (Zendesk #456359).
+
 ## [1.9.121] - 2026-09-03
 ### Fixed
 - **Tripwire: one alert per new administrator, not two.** Creating an admin fires both `set_user_role` and `user_register`, so a single rogue account emailed twice; a per-request guard now dedupes.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.121
+ * Version:           1.9.122
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.121' );
+define( 'DS_TOOLKIT_VERSION', '1.9.122' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-post-loop/ds-post-loop.php
+++ b/modules/ds-post-loop/ds-post-loop.php
@@ -1092,10 +1092,30 @@ class DS_Post_Loop_Module extends FLBuilderModule {
 	private function parse_event_date( $str ) {
 		$str = trim( (string) $str );
 		if ( '' === $str ) { return 0; }
+		// ISO "2026-09-19" (or an ISO range): those dashes are separators, not a day range.
+		if ( preg_match( '/^(\d{4}-\d{2}-\d{2})/', $str, $iso ) ) {
+			$ts = strtotime( $iso[1] );
+			return $ts ? (int) $ts : 0;
+		}
+		$dash = '[\x{2013}\x{2014}-]';
+		// Range whose END carries its own month or a slash date: "09/19 - 09/20/2026",
+		// "09/19/2026 - 09/20/2026", "Oct 31 - Nov 1, 2026". Keep the START and borrow
+		// the year from the end when the start has none. Before this, "09/19 - 09/20/2026"
+		// normalised to "09/19/20/2026", strtotime returned false, every event fell into
+		// the same "unknown date" bucket and the Tournament Cards kept the query's
+		// date-DESC order (sportsatthebeach, Zendesk #456359).
+		if ( preg_match( '/^(.*?)\s*' . $dash . '\s*((?:[A-Za-z]{3,9}\.?\s+\d{1,2}|\d{1,2}\/\d{1,2})(?:\/\d{2,4})?.*)$/u', $str, $m ) && '' !== trim( $m[1] ) ) {
+			$start = trim( $m[1] );
+			$end   = trim( $m[2] );
+			if ( ! preg_match( '/\b\d{4}\b/', $start ) && preg_match( '/\b(\d{4})\b/', $end, $y ) ) {
+				$start .= ( false !== strpos( $start, '/' ) ) ? '/' . $y[1] : ' ' . $y[1];
+			}
+			$str = $start;
+		}
 		// "18-20" / "18th-20th" -> "18". Ordinal suffixes must be part of the match:
 		// strtotime mis-parses an unnormalised "March 20th-21st, 2027" into MARCH 2026,
 		// which silently dropped future events as "past" (seen on the fleet blueprint).
-		$norm = preg_replace( '/(\d{1,2})(?:st|nd|rd|th)?\s*[\x{2013}\x{2014}-]\s*\d{1,2}(?:st|nd|rd|th)?/iu', '$1', $str );
+		$norm = preg_replace( '/(\d{1,2})(?:st|nd|rd|th)?\s*' . $dash . '\s*\d{1,2}(?:st|nd|rd|th)?/iu', '$1', $str );
 		$ts = strtotime( $norm );
 		return $ts ? (int) $ts : 0;
 	}


### PR DESCRIPTION
Event Dates like `09/19 - 09/20/2026` or `Oct 31 - Nov 1, 2026` failed to parse in the Post Loop Tournament Cards layout, so every event got the same unknown-date key, the cards kept the query's newest-first order, and past events never dropped. The parser now keeps the start of the range and borrows the year from the end when the start has none; ISO dates parse too. Tested against 23 real formats (all pass; the previous code failed 8). Reported on sportsatthebeach.com, Zendesk #456359.