### PR TITLE
fix: tripwire assembles IOC markers at runtime (1.9.123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.123] - 2026-09-03
+### Changed
+- **Tripwire no longer carries the malware marker strings as literals.** Third-party scanners (Sucuri, Flywheel) matched the tripwire source file itself on the campaign signature; the markers are now assembled at runtime so the plugin file never contains them.
+
 ## [1.9.122] - 2026-09-03
 ### Fixed
 - **Post Loop, Tournament Cards: events with slash-date ranges now sort first-to-last and drop when past.** An Event Date like `09/19 - 09/20/2026` (or `Oct 31 - Nov 1, 2026`) failed to parse, so every event shared one "unknown date" key and the cards kept the query's newest-first order; past events also never dropped. The parser now keeps the start of a range and borrows the year from the end when the start has none. ISO `YYYY-MM-DD` values parse too. Reported on sportsatthebeach.com (Zendesk #456359).

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.122
+ * Version:           1.9.123
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.122' );
+define( 'DS_TOOLKIT_VERSION', '1.9.123' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-tripwire.php
+++ b/features/class-ds-tripwire.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  * Defender sat on nearly every compromised site and never alerted; the kit's
  * tells were nonetheless trivially checkable: rogue files in mu-plugins, fake
  * wdg-<hex>/starter-* plugin folders, and a self-replicating
- * WDG-CORE-START comment block appended to functions.php / index.php /
+ * self-healing comment block (the campaign's marker) appended to functions.php / index.php /
  * wp-config.php. On the campaign's patient zero the attacker's admin account
  * appeared TWO HOURS before the first file drop — an instant new-admin email
  * would have turned a 98-site campaign into a one-site incident.
@@ -43,7 +43,7 @@ class DS_Tripwire {
     const MU_INDEX_MAX_BYTES = 4096;
 
     /** Self-heal markers; any hit in a scanned tail is a confirmed infection. */
-    const MARKERS = array( 'WDG-CORE-START', '$wdg_k', '$coki' );
+    const MARKERS = array( 'WDG-CORE-' . 'START', '$wdg' . '_k', '$co' . 'ki' );
 
     private $settings;
 


### PR DESCRIPTION
Scanners flagged features/class-ds-tripwire.php because it contained the campaign's marker strings verbatim. The markers are now built by concatenation at runtime; detection unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)