### PR TITLE
fix: Defender Mask Login password-reset links on Flywheel (1.9.124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.124] - 2026-09-04
+### Fixed
+- **Password reset links work again on Flywheel sites running Defender's Mask Login Area.** Flywheel strips the reset cookie on the masked login path, so Defender (Flywheel only) appends a `wd-ml-token` to the emailed link instead. Defender 6.2.x searches for the WordPress 6 link order (`action=rp&key=…&login=…`) and misses the WordPress 7 order (`login=…&key=…&action=rp`), so the token never landed and every link read "Your password reset link appears to be invalid." New compat feature `defender_flywheel_reset_fix_enabled` (default on, Features tab) re-appends the token after Defender runs. Inert on WP Engine and on sites without Defender or without Mask Login. Found on Lower Alabama Volleyball after the 2026-09-03 fleet admin password reset.
+
 ## [1.9.123] - 2026-09-03
 ### Changed
 - **Tripwire no longer carries the malware marker strings as literals.** Third-party scanners (Sucuri, Flywheel) matched the tripwire source file itself on the campaign signature; the markers are now assembled at runtime so the plugin file never contains them.

--- a/admin/class-ds-toolkit-admin.php
+++ b/admin/class-ds-toolkit-admin.php
@@ -262,6 +262,7 @@ class DS_Toolkit_Admin {
                 $child_pages_columns_tablet  = ! empty( $opts['child_pages_columns_tablet'] ) ? (int) $opts['child_pages_columns_tablet'] : 2;
                 $child_pages_columns_mobile  = ! empty( $opts['child_pages_columns_mobile'] ) ? (int) $opts['child_pages_columns_mobile'] : 1;
                 $uabb_post_loop_fix_enabled  = ! empty( $opts['uabb_post_loop_fix_enabled'] );
+                $defender_flywheel_reset_fix_enabled = ! empty( $opts['defender_flywheel_reset_fix_enabled'] );
                 // Blueprint-gated feature toggles — only surfaced on qualifying installs.
                 $blueprint_version        = DS_Toolkit::blueprint_version();
                 $disable_comments_enabled = ! empty( $opts['disable_comments_enabled'] );

--- a/admin/views/page-settings.php
+++ b/admin/views/page-settings.php
@@ -25,7 +25,7 @@ if ( $dst_bp6 ) {
 $dst_grp_partner = array( $enabled, $design_academy_enabled );
 $dst_grp_site    = $dst_bp6 ? array( $theme_setting_enabled, $image_optimization_enabled ) : array();
 $dst_grp_site[]  = $nested_order_enabled;
-$dst_grp_dev     = array( $uabb_post_loop_fix_enabled, $acf_css_vars_enabled, $getsubmenu_enabled, $current_year_enabled, $overlay_nav_enabled, $forminator_email_partner_enabled, $child_pages_enabled );
+$dst_grp_dev     = array( $uabb_post_loop_fix_enabled, $defender_flywheel_reset_fix_enabled, $acf_css_vars_enabled, $getsubmenu_enabled, $current_year_enabled, $overlay_nav_enabled, $forminator_email_partner_enabled, $child_pages_enabled );
 
 $dst_count = function ( $arr ) {
 	return count( array_filter( $arr ) ) . ' of ' . count( $arr ) . ' on';
@@ -435,6 +435,22 @@ $dst_mod_all = count( DS_Toolkit::module_features() );
                 <input type="hidden" name="ds_toolkit_settings[uabb_post_loop_fix_enabled]" value="0">
                 <input type="checkbox" id="uabb_post_loop_fix_enabled" name="ds_toolkit_settings[uabb_post_loop_fix_enabled]" value="1" <?php checked( $uabb_post_loop_fix_enabled ); ?>>
                 <label for="uabb_post_loop_fix_enabled"></label>
+            </div>
+        </div>
+    </div>
+
+    <!-- Defender Mask Login + Flywheel: password-reset link token -->
+    <div class="dst-card">
+        <div class="dst-card-row">
+            <div class="dst-card-icon"><span class="dashicons dashicons-shield-alt"></span></div>
+            <div class="dst-card-info">
+                <strong>Defender Mask Login on Flywheel — Password Reset Link Fix</strong>
+                <span>Flywheel strips the password-reset cookie on a masked login URL, so Defender swaps in a <code>wd-ml-token</code> parameter on the emailed link. Defender 6.2.x looks for the WordPress 6 link order and misses the WordPress 7 one, so the token is never added and every reset link says "appears to be invalid". This re-appends the token after Defender runs. Inert unless Defender's Mask Login is enabled AND the host is Flywheel.</span>
+            </div>
+            <div class="dst-toggle">
+                <input type="hidden" name="ds_toolkit_settings[defender_flywheel_reset_fix_enabled]" value="0">
+                <input type="checkbox" id="defender_flywheel_reset_fix_enabled" name="ds_toolkit_settings[defender_flywheel_reset_fix_enabled]" value="1" <?php checked( $defender_flywheel_reset_fix_enabled ); ?>>
+                <label for="defender_flywheel_reset_fix_enabled"></label>
             </div>
         </div>
     </div>

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.123
+ * Version:           1.9.124
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.123' );
+define( 'DS_TOOLKIT_VERSION', '1.9.124' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-defender-flywheel-reset-fix.php
+++ b/features/class-ds-defender-flywheel-reset-fix.php
@@ -1,0 +1,91 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+/**
+ * Repairs WordPress password-reset links on Flywheel sites that run Defender's
+ * Mask Login Area.
+ *
+ * Flywheel strips the wp-resetpass cookie on the masked login path, so Defender
+ * (on Flywheel only) replaces that cookie with a short-lived transient keyed off a
+ * `wd-ml-token` parameter it appends to the emailed link. Defender 6.2.x appends the
+ * token with a str_replace() that looks for the link in the form
+ * `wp-login.php?action=rp&key=…&login=…`, but WordPress 7 builds the link as
+ * `?login=…&key=…&action=rp`. The search never matches, the token is never added,
+ * the flow falls back to the (stripped) cookie, and every reset link reads
+ * "Your password reset link appears to be invalid." Seen fleet-wide after the
+ * 2026-09-03 admin password reset (Lower Alabama Volleyball, Zendesk thread).
+ *
+ * Fix: after Defender has rewritten the message, append `wd-ml-token=<login>` to
+ * any reset link that carries `action=rp` and `key=` but no token. Runs only when
+ * Defender's Mask Login is enabled AND the host is Flywheel, so it is inert on
+ * WP Engine and on sites without Defender. Safe to remove once Defender matches
+ * the WordPress 7 link order.
+ */
+class DS_Defender_Flywheel_Reset_Fix {
+
+    public function __construct( $settings = array() ) {}
+
+    public function init() {
+        // Defender hooks retrieve_password_message at 10; run after it.
+        add_filter( 'retrieve_password_message', array( $this, 'append_token' ), 20, 4 );
+    }
+
+    /**
+     * @param string  $message    Email body.
+     * @param string  $key        Reset key.
+     * @param string  $user_login User login.
+     * @param WP_User $user_data  User object.
+     * @return string
+     */
+    public function append_token( $message, $key = '', $user_login = '', $user_data = null ) {
+        if ( ! is_string( $message ) || '' === $message || '' === (string) $user_login ) {
+            return $message;
+        }
+        if ( false !== strpos( $message, 'wd-ml-token=' ) ) {
+            return $message; // Defender already did its job.
+        }
+        if ( ! self::mask_login_enabled() || ! self::is_flywheel() ) {
+            return $message;
+        }
+        $token = '&wd-ml-token=' . rawurlencode( $user_login );
+        return preg_replace_callback(
+            '~https?://[^\s<>"\']+~i',
+            function ( $m ) use ( $token ) {
+                $url = $m[0];
+                if ( false === stripos( $url, 'action=rp' ) || false === stripos( $url, 'key=' ) ) {
+                    return $url;
+                }
+                return $url . $token;
+            },
+            $message
+        );
+    }
+
+    /** Defender stores the mask settings as a JSON string (sometimes an array). */
+    public static function mask_login_enabled() {
+        if ( ! class_exists( 'WP_Defender\Controller\Mask_Login' ) ) {
+            return false;
+        }
+        $raw = get_option( 'wd_masking_login_settings' );
+        if ( is_string( $raw ) ) {
+            $raw = json_decode( $raw, true );
+        }
+        return is_array( $raw ) && ! empty( $raw['enabled'] ) && ! empty( $raw['mask_url'] );
+    }
+
+    /** Mirror Defender's own host detection when available; fall back to the server header. */
+    public static function is_flywheel() {
+        if ( class_exists( 'WP_Defender\Component\Security_Tweaks\Servers\Server' ) ) {
+            try {
+                $server = \WP_Defender\Component\Security_Tweaks\Servers\Server::get_current_server();
+                if ( is_string( $server ) && '' !== $server ) {
+                    return 'flywheel' === strtolower( $server );
+                }
+            } catch ( \Throwable $e ) {
+                // fall through to the header check
+            }
+        }
+        $software = isset( $_SERVER['SERVER_SOFTWARE'] ) ? (string) $_SERVER['SERVER_SOFTWARE'] : '';
+        return false !== stripos( $software, 'flywheel' );
+    }
+}

--- a/includes/class-ds-toolkit.php
+++ b/includes/class-ds-toolkit.php
@@ -51,6 +51,12 @@ class DS_Toolkit {
             'file'  => 'features/class-ds-uabb-post-loop-fix.php',
             'class' => 'DS_UABB_Post_Loop_Fix',
         ),
+        // Flywheel + Defender Mask Login: re-append Defender's wd-ml-token to the
+        // password-reset link that WordPress 7 formats in an order Defender misses.
+        'defender_flywheel_reset_fix_enabled' => array(
+            'file'  => 'features/class-ds-defender-flywheel-reset-fix.php',
+            'class' => 'DS_Defender_Flywheel_Reset_Fix',
+        ),
         'overlay_nav_enabled' => array(
             'file'  => 'features/class-ds-overlay-nav.php',
             'class' => 'DS_Overlay_Nav',
@@ -330,6 +336,9 @@ class DS_Toolkit {
             // Compat patch — only does anything when UABB Advanced Posts fires its
             // hooks, so it's safe to default on. Sites without UABB are unaffected.
             'uabb_post_loop_fix_enabled'         => 1,
+            // Compat patch — inert unless Defender Mask Login is on AND the host is
+            // Flywheel, so it's safe to default on across the fleet.
+            'defender_flywheel_reset_fix_enabled' => 1,
             // Partner-safe access control + the Design Academy dashboard panel:
             // on for the whole fleet regardless of blueprint generation.
             'user_roles_enabled'                 => 1,


### PR DESCRIPTION
Flywheel strips the wp-resetpass cookie on the masked login path, so Defender (Flywheel only) appends a wd-ml-token to the emailed reset link instead. Defender 6.2.x str_replaces the WordPress 6 link order (action=rp&key=...&login=...) and misses the WordPress 7 order (login=...&key=...&action=rp), so the token never lands, the flow falls back to the stripped cookie, and every link reads 'appears to be invalid'. Reproduced on Lower Alabama Volleyball: the emailed link fails as-is and renders the reset form with the token appended.

New compat feature defender_flywheel_reset_fix_enabled (default on, Features tab toggle) runs after Defender on retrieve_password_message and appends the token to any reset link that has action=rp and key= but no token. Inert unless Defender's Mask Login is enabled AND the host is Flywheel (mirrors Defender's own Server::get_current_server, falls back to SERVER_SOFTWARE).