### PR TITLE
fix: tripwire only alerts on administrators nobody trusted created (1.9.125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.125] - 2026-09-05
+### Fixed
+- **Tripwire stops crying wolf when the team adds an administrator.** Every new admin triggered a "you may be compromised" email regardless of who created it, so routine provisioning paged the whole team (found on accessplus1: a real partner user added by a Design Shop admin). Worse, the same event was reported **twice**, because the instant alert never wrote the account into the baseline the nightly roster check diffs against, so it came back that night as "appeared since yesterday". The instant alert now records the account either way (killing the duplicate) and only emails when the creation is **not** attributable to an established administrator. Unattributable self-registrations, throwaway/placeholder addresses (`example.*`, `*.invalid`, `tripledown.org`), grants made by an admin account less than a day old, and grants by a non-administrator all still email immediately, which is precisely the campaign's own signature. Routine additions are kept in a 20-entry `admin_log` audit trail in plugin state instead.
+- The nightly roster check now only fires for administrators that appeared **without** going through WordPress's roles API (a direct database write or a plugin bypassing it), which is a stronger signal than before, so its wording stays blunt.
+
 ## [1.9.124] - 2026-09-04
 ### Fixed
 - **Password reset links work again on Flywheel sites running Defender's Mask Login Area.** Flywheel strips the reset cookie on the masked login path, so Defender (Flywheel only) appends a `wd-ml-token` to the emailed link instead. Defender 6.2.x searches for the WordPress 6 link order (`action=rp&key=…&login=…`) and misses the WordPress 7 order (`login=…&key=…&action=rp`), so the token never landed and every link read "Your password reset link appears to be invalid." New compat feature `defender_flywheel_reset_fix_enabled` (default on, Features tab) re-appends the token after Defender runs. Inert on WP Engine and on sites without Defender or without Mask Login. Found on Lower Alabama Volleyball after the 2026-09-03 fleet admin password reset.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.124
+ * Version:           1.9.125
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.124' );
+define( 'DS_TOOLKIT_VERSION', '1.9.125' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-tripwire.php
+++ b/features/class-ds-tripwire.php
@@ -186,7 +186,15 @@ class DS_Tripwire {
         return array();
     }
 
-    /** Administrator roster drift since the previous run. */
+    /**
+     * Administrator roster drift since the previous run.
+     *
+     * Since alert_new_admin() folds every hook-caught account into the baseline,
+     * anything this still catches got its role WITHOUT going through
+     * user_register / set_user_role / add_user_role: a direct database write, or
+     * a plugin bypassing the roles API. That is a stronger signal than it used to
+     * be, not a weaker one, so the wording below stays blunt.
+     */
     private function check_admins( &$state, $seeded ) {
         $out    = array();
         $admins = array();
@@ -226,6 +234,28 @@ class DS_Tripwire {
         }
     }
 
+    /**
+     * Alert on a new administrator, but only when the account cannot be explained
+     * by someone already trusted on this site.
+     *
+     * Two things were wrong with alerting on every new administrator (found
+     * 2026-09-04 on accessplus1, where a real partner user created by a Design
+     * Shop admin produced a "you may be compromised" email):
+     *
+     * 1. Routine provisioning paged the whole team. An alert that fires on our own
+     *    normal work teaches people to skim past it, and then the genuine one gets
+     *    skimmed past too, which is the exact failure this feature exists to avoid.
+     * 2. The same event was reported TWICE. check_admins() diffs against
+     *    admin_baseline, which this path never updated, so the account came back
+     *    that night as "appeared since yesterday".
+     *
+     * The campaign's signature is the opposite of routine provisioning: its admins
+     * (adminxix, the TDN####Cz@tripledown.org set, admin_xxxxxx@example.com) arrived
+     * with no logged-in creator at all. So attribution is the filter. An established
+     * administrator, or our own WP-CLI tooling, is recorded silently; anything
+     * unattributable, freshly escalated, or carrying a throwaway address still
+     * emails immediately.
+     */
     private function alert_new_admin( $user, $how ) {
         static $alerted = array();
         if ( isset( $alerted[ $user->ID ] ) ) {
@@ -233,23 +263,112 @@ class DS_Tripwire {
         }
         $alerted[ $user->ID ] = true;
 
-        $actor = 'unknown actor';
-        if ( function_exists( 'wp_get_current_user' ) ) {
-            $current = wp_get_current_user();
-            if ( $current && $current->exists() ) {
-                $actor = $current->user_login;
-            } elseif ( defined( 'WP_CLI' ) && WP_CLI ) {
-                $actor = 'WP-CLI';
-            }
+        $actor = $this->current_actor();
+
+        // Recorded either way, so the nightly roster check never reports the same
+        // account a second time.
+        $this->remember_admin( $user, $actor );
+
+        if ( $this->actor_is_established() && ! self::email_is_throwaway( $user->user_email ) ) {
+            return;
         }
+
         $this->alert(
             'New administrator: ' . $user->user_login,
             array(
                 "A new administrator just appeared on this site: {$user->user_login} <{$user->user_email}> ({$how}).",
                 "Created by: {$actor}.",
-                'If nobody on the team did this, the site may be compromised — in the recent attack a rogue admin account appeared two hours before the malware. Flag it to the Design Shop point person for security right away.',
+                'If nobody on the team did this, the site may be compromised. In the recent attack a rogue admin account appeared two hours before the malware. Flag it to the Design Shop point person for security right away.',
             )
         );
+    }
+
+    /** Who is performing the change, for the alert body and the state log. */
+    private function current_actor() {
+        if ( function_exists( 'wp_get_current_user' ) ) {
+            $current = wp_get_current_user();
+            if ( $current && $current->exists() ) {
+                return $current->user_login;
+            }
+        }
+        if ( defined( 'WP_CLI' ) && WP_CLI ) {
+            return 'WP-CLI';
+        }
+        return 'unknown actor';
+    }
+
+    /**
+     * True when the change is attributable to someone already trusted here: our own
+     * WP-CLI tooling, or a logged-in administrator whose account is more than a day
+     * old. A brand-new administrator immediately creating another one is precisely
+     * the escalation chain we DO want to hear about, so the age floor matters.
+     */
+    private function actor_is_established() {
+        if ( defined( 'WP_CLI' ) && WP_CLI ) {
+            return true;
+        }
+        if ( ! function_exists( 'wp_get_current_user' ) ) {
+            return false;
+        }
+        $current = wp_get_current_user();
+        // No session at all: self-registration, which is how the campaign's
+        // accounts appeared. Always worth an email.
+        if ( ! $current || ! $current->exists() ) {
+            return false;
+        }
+        if ( ! in_array( 'administrator', (array) $current->roles, true ) ) {
+            return false;
+        }
+        $registered = strtotime( (string) $current->user_registered );
+        return $registered && ( time() - $registered ) > DAY_IN_SECONDS;
+    }
+
+    /** Disposable / placeholder domains seen on the campaign's rogue accounts. */
+    private static function email_is_throwaway( $email ) {
+        $at = strrpos( (string) $email, '@' );
+        if ( false === $at ) {
+            return true;
+        }
+        $domain = strtolower( substr( (string) $email, $at + 1 ) );
+        $bad    = array(
+            'example.com',
+            'example.org',
+            'example.net',
+            'example.invalid',
+            'test.com',
+            'mailinator.com',
+            'tripledown.org',
+        );
+        if ( in_array( $domain, $bad, true ) ) {
+            return true;
+        }
+        return '.invalid' === substr( $domain, -8 );
+    }
+
+    /**
+     * Fold a just-seen administrator into the nightly baseline so check_admins()
+     * does not re-report it, and keep a short local audit trail of who added whom.
+     * The label format must match check_admins() exactly or the diff misses.
+     */
+    private function remember_admin( $user, $actor ) {
+        $state = get_option( self::STATE_OPT, array() );
+        if ( ! is_array( $state ) ) {
+            $state = array();
+        }
+
+        $baseline                          = isset( $state['admin_baseline'] ) ? (array) $state['admin_baseline'] : array();
+        $baseline[ (int) $user->ID ]       = $user->user_login . ' <' . $user->user_email . '>';
+        $state['admin_baseline']           = $baseline;
+
+        $log   = isset( $state['admin_log'] ) ? (array) $state['admin_log'] : array();
+        $log[] = array(
+            'at'  => gmdate( 'Y-m-d H:i' ),
+            'who' => $user->user_login . ' <' . $user->user_email . '>',
+            'by'  => $actor,
+        );
+        $state['admin_log'] = array_slice( $log, -20 );
+
+        update_option( self::STATE_OPT, $state, false );
     }
 
     /* -------------------------------------------------------------- output */


### PR DESCRIPTION
## Problem

DS Tripwire emailed a full "you may be compromised" alert for **every** new administrator, whoever created it. Found on `accessplus1` on 2026-09-04: KD added a real partner user (`kabaker8@dons.usfca.edu`) and the team got a break-in warning. The site is clean, verified against the full campaign IOC list.

Two separate faults:

1. **Routine provisioning paged the team.** An alert that fires on our own normal work teaches people to skim past it, and then the genuine one gets skimmed past too, which is the exact failure this feature exists to prevent.
2. **The same event alerted twice.** `alert_new_admin()` never wrote the account into `admin_baseline`, which `check_admins()` diffs against, so the nightly run reported it again as "appeared since yesterday". Confirmed live on accessplus1: baseline held 3 admins, the new account was absent, next cron 8h out.

## Change

The instant alert now records the account either way (killing the duplicate) and only emails when the creation is **not** attributable to someone already trusted. The campaign's signature is the opposite of routine provisioning: `adminxix`, the `TDN####Cz@tripledown.org` set and `admin_xxxxxx@example.com` all arrived with no logged-in creator, so attribution is the filter.

Still emails immediately:

- self-registration with no session
- throwaway or placeholder addresses (`example.*`, `*.invalid`, `tripledown.org`, mailinator)
- a grant made by an administrator account less than a day old (the escalation chain)
- a grant made by a non-administrator

Routine additions go to a 20-entry `admin_log` audit trail in plugin state instead.

`check_admins()` now only fires for administrators that appeared **without** going through the roles API (a direct database write, or a plugin bypassing it), which is a stronger signal than before, so its wording stays blunt.

## Verification

Stub harness over 7 scenarios, all passing, including the exact accessplus1 case and each campaign pattern:

| Scenario | Email | Recorded |
|---|---|---|
| established admin creates real user | no | yes |
| self-registration, no actor | **yes** | yes |
| established admin + `example.invalid` | **yes** | yes |
| day-old admin creates another admin | **yes** | yes |
| editor-level actor grants admin | **yes** | yes |
| established admin + `tripledown.org` | **yes** | yes |
| subscriber registers (not an admin) | no | not tracked |

Baseline label format confirmed byte-identical to `check_admins()`, so the dedupe actually matches. `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
