### PR TITLE
fix: origin guard blocks the WDG doorway; tripwire trusts managed mu files only when small and clean (1.9.126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.126] - 2026-09-08
+### Added
+- **Origin Guard blocks the WDG doorway (payload 1.1.0).** The Sep 2026 botnet re-installs its kit by requesting doorway query strings (`ITMCODE=`, `ARRAY=`, `sale/search/detail`, `juejiang`) and shell paths (`/images/images`, `/fonts/fonts`, hex web-root folders, `cache.php`, `filefuns.php`, `plugins/starter-*`). The generated mu-plugin now answers 403 to those before WordPress loads. Signature-only: no IP rules, because PHP sees the host's edge address. Every site rewrites its Origin Guard file on this update.
+### Fixed
+- **Tripwire no longer pages the team about the toolkit's own files.** `ds-antibot-off.php` and `ds-doorway-block.php` (incident-response helpers) join `ds-origin-guard.php` as managed names, but a managed name is trusted only when the file is under 4 KB and carries no eval/base64/goto obfuscation; an attacker's loader wearing one of those names still alerts (they overwrote `ds-origin-guard.php` once). 43 false alarms on 2026-09-08.
+- **Tripwire's nightly admin roster ignores Design Shop staff** (`@leagueapps.com`), matching the instant check's trust rule since 1.9.125.
+
 ## [1.9.125] - 2026-09-05
 ### Fixed
 - **Tripwire stops crying wolf when the team adds an administrator.** Every new admin triggered a "you may be compromised" email regardless of who created it, so routine provisioning paged the whole team (found on accessplus1: a real partner user added by a Design Shop admin). Worse, the same event was reported **twice**, because the instant alert never wrote the account into the baseline the nightly roster check diffs against, so it came back that night as "appeared since yesterday". The instant alert now records the account either way (killing the duplicate) and only emails when the creation is **not** attributable to an established administrator. Unattributable self-registrations, throwaway/placeholder addresses (`example.*`, `*.invalid`, `tripledown.org`), grants made by an admin account less than a day old, and grants by a non-administrator all still email immediately, which is precisely the campaign's own signature. Routine additions are kept in a 20-entry `admin_log` audit trail in plugin state instead.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.125
+ * Version:           1.9.126
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.125' );
+define( 'DS_TOOLKIT_VERSION', '1.9.126' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/features/class-ds-tripwire.php
+++ b/features/class-ds-tripwire.php
@@ -41,6 +41,10 @@ class DS_Tripwire {
 
     /** A legit mu-plugins/index.php is an empty guard file; loaders are 20KB+. */
     const MU_INDEX_MAX_BYTES = 4096;
+    /** mu-plugins files ds-toolkit itself writes; trusted only when small and clean (see check_mu_plugins). */
+    const MU_MANAGED = array( 'ds-origin-guard.php', 'ds-antibot-off.php', 'ds-doorway-block.php' );
+    const MU_MANAGED_MAX_BYTES = 4096;
+
 
     /** Self-heal markers; any hit in a scanned tail is a confirmed infection. */
     const MARKERS = array( 'WDG-CORE-' . 'START', '$wdg' . '_k', '$co' . 'ki' );
@@ -126,7 +130,14 @@ class DS_Tripwire {
         $baseline = isset( $state['mu_baseline'] ) ? (array) $state['mu_baseline'] : array();
         if ( $seeded ) {
             foreach ( array_diff_key( $current, $baseline ) as $base => $size ) {
-                if ( 'ds-origin-guard.php' === $base ) continue; // toolkit-managed
+                // Toolkit-managed helpers (Origin Guard, the incident-response AntiBot
+                // and doorway files) are exempt ONLY when they look like ours: tiny and
+                // free of obfuscation. The Sep 2026 attacker overwrote ds-origin-guard.php
+                // with an 8 KB loader, so a bare name is not trust.
+                if ( in_array( $base, self::MU_MANAGED, true ) && $size <= self::MU_MANAGED_MAX_BYTES
+                    && ! preg_match( '/eval\s*\(|base64_decode|gzinflate|gzuncompress|str_rot13|goto [A-Za-z_]/', (string) @file_get_contents( $dir . '/' . $base, false, null, 0, 8192 ) ) ) {
+                    continue;
+                }
                 $out[] = "A new PHP file appeared in mu-plugins since yesterday: {$base} ({$size} bytes). Nobody should be adding files there.";
             }
         }
@@ -204,6 +215,8 @@ class DS_Tripwire {
         $baseline = isset( $state['admin_baseline'] ) ? (array) $state['admin_baseline'] : array();
         if ( $seeded ) {
             foreach ( array_diff_key( $admins, $baseline ) as $id => $label ) {
+                // Design Shop staff adding their own access is routine, not a break-in.
+                if ( preg_match( '/<[^>]+@leagueapps\.com>$/i', $label ) ) continue;
                 $out[] = "A new administrator account appeared since yesterday: {$label}. If nobody on the team created it, treat this as a break-in.";
             }
         }

--- a/includes/class-ds-origin-guard-installer.php
+++ b/includes/class-ds-origin-guard-installer.php
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class DS_Origin_Guard_Installer {
 
 	/** Bump when the generated mu-plugin payload changes. Drives auto-refresh. */
-	const PAYLOAD_VERSION = '1.0.1';
+	const PAYLOAD_VERSION = '1.1.0';
 
 	const MU_FILENAME = 'ds-origin-guard.php';
 	const STATE_OPT   = 'ds_origin_guard_state';
@@ -227,6 +227,17 @@ if ( ! \$dsog_logged_in
 	\$dsog_deny( 'users-enum' );
 }
 {$login_rule}{$xmlrpc_rule}
+
+// 4) WDG doorway spam + kit shell paths (Sep 2026 fleet campaign). The botnet
+// re-installs its kit by requesting these; nothing legitimate ever does.
+// Signature-only on purpose: PHP sees the host's edge address, not the visitor,
+// so an IP rule here would lock out everyone.
+if ( preg_match( '#(^|[?&/])(sale/search/detail|sale%2Fsearch|ITMCODE=|ARRAY=|juejiang)#i', \$dsog_uri )
+	|| preg_match( '#^/(images/images|fonts/fonts|[0-9a-f]{5}/[0-9a-f]{5})(/|\?|\$)#i', \$dsog_uri )
+	|| preg_match( '#/(cache\\.php|filefuns\\.php)(\?|\$)#i', \$dsog_uri )
+	|| preg_match( '#/wp-content/plugins/starter-[a-z0-9-]+/#i', \$dsog_uri ) ) {
+	\$dsog_deny( 'doorway' );
+}
 
 unset( \$dsog_uri, \$dsog_method, \$dsog_logged_in, \$dsog_k, \$dsog_deny, \$dsog_postpass );
 


### PR DESCRIPTION
The Sep 2026 botnet re-installs its kit by requesting doorway query strings
(ITMCODE=, ARRAY=, sale/search/detail, juejiang) and shell paths (/images/images,
/fonts/fonts, hex web-root folders, cache.php, filefuns.php, plugins/starter-*).
Origin Guard's generated mu-plugin now answers 403 to those before WordPress
loads (payload 1.1.0, so every site rewrites the file on update). Signature-only:
PHP sees the host's edge address, so an IP rule would lock out everyone.

Tripwire paged the team 43 times on 2026-09-08 about ds-antibot-off.php, a file
the incident-response chain had deployed the day before. Managed names
(ds-origin-guard.php, ds-antibot-off.php, ds-doorway-block.php) are now exempt,
but only when the file is under 4 KB and free of eval/base64/goto: the attacker
overwrote ds-origin-guard.php with an 8 KB loader once, so a name is not trust.
The nightly admin roster also skips @leagueapps.com accounts, matching the
instant check's rule from 1.9.125.