### PR TITLE
feat: Hero Banner Style 1 gets an optional Eyebrow Image (GH #192) (1.9.127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to DS Toolkit are documented here.
 
 ---
 
+## [1.9.127] - 2026-09-08
+### Added
+- **Hero Banner Style 1 gets an optional Eyebrow Image (GH #192).** A new photo field at the top of the Text section renders a crest, badge or logo directly above the Eyebrow text. Set nothing and nothing is output, not even a gap. The image keeps its aspect ratio, never stretches to the hero width, follows the hero's alignment at every breakpoint, and shrinks on narrow screens. An **Eyebrow Image Size** control authors the height (width follows), responsive per device; blank is 72px. The library alt text rides along when the attachment has one. Style 2 and Style 3 are untouched, and a hero saved before this release renders byte-for-byte as before.
+
 ## [1.9.126] - 2026-09-08
 ### Added
 - **Origin Guard blocks the WDG doorway (payload 1.1.0).** The Sep 2026 botnet re-installs its kit by requesting doorway query strings (`ITMCODE=`, `ARRAY=`, `sale/search/detail`, `juejiang`) and shell paths (`/images/images`, `/fonts/fonts`, hex web-root folders, `cache.php`, `filefuns.php`, `plugins/starter-*`). The generated mu-plugin now answers 403 to those before WordPress loads. Signature-only: no IP rules, because PHP sees the host's edge address. Every site rewrites its Origin Guard file on this update.

--- a/ds-toolkit.php
+++ b/ds-toolkit.php
@@ -3,7 +3,7 @@
  * Plugin Name:       DS Toolkit
  * Plugin URI:        https://github.com/agabriel1590/ds-toolkit
  * Description:       Design Shop custom features and build toolkit.
- * Version:           1.9.126
+ * Version:           1.9.127
  * Author:            Alipio Gabriel
  * Author URI:        https://github.com/agabriel1590
  * Text Domain:       ds-toolkit
@@ -17,7 +17,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'DS_TOOLKIT_VERSION', '1.9.126' );
+define( 'DS_TOOLKIT_VERSION', '1.9.127' );
 define( 'DS_TOOLKIT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'DS_TOOLKIT_URL', plugin_dir_url( __FILE__ ) );
 

--- a/modules/ds-hero/css/frontend.css
+++ b/modules/ds-hero/css/frontend.css
@@ -39,6 +39,14 @@
 .ds-hero-eyebrow::before,.ds-hero-eyebrow::after{content:"";width:34px;height:2px;background:currentColor;display:inline-block;flex:0 1 auto;min-width:0;}
 .ds-hero-eyebrow::after{display:none;}
 .ds-hero--center .ds-hero-eyebrow::after{display:inline-block;}
+/* ---- Eyebrow image (GH #192) --------------------------------------------------
+   Optional mark above the eyebrow. The wrapper is a block so the hero's text-align
+   (responsive, re-declared per breakpoint by the dynamic CSS) positions it; the img
+   is inline-block with auto width/height so it keeps its ratio, never stretches to
+   the hero width, and shrinks on narrow screens. Height is authored via the dynamic
+   sheet (max-height per breakpoint); 72px is the untouched default. */
+.ds-hero-eyebrow-img{display:block;margin:0 0 16px;line-height:0;}
+.ds-hero-eyebrow-img img{display:inline-block;width:auto;height:auto;max-width:100%;max-height:72px;vertical-align:bottom;}
 
 .ds-hero-title{font-size:clamp(3.4rem,10vw,8rem);line-height:.92;text-transform:uppercase;letter-spacing:.01em;font-weight:700;color:var(--fl-global-white,#fff);margin:20px 0 0;overflow-wrap:normal;word-break:keep-all;hyphens:none;}
 .ds-hero-accent{color:var(--fl-global-primary,#7ee29a);}

--- a/modules/ds-hero/ds-hero.php
+++ b/modules/ds-hero/ds-hero.php
@@ -283,6 +283,16 @@ class DS_Hero_Module extends FLBuilderModule {
 		$this->render_bg();
 		echo '<div class="ds-hero-wrap"><div class="ds-hero-inner">';
 
+		// Eyebrow image (GH #192). Emitted only when a photo resolves, so an unset
+		// field leaves no empty markup or spacing. The block wrapper lets the hero's
+		// responsive text-align place it; the <img> inside is inline-block so it never
+		// stretches to the hero width. Above the fold, so it loads eagerly. The
+		// library alt text rides along when the attachment has one.
+		$eb_img = ! empty( $s->eyebrow_image ) ? $this->photo_url( $s->eyebrow_image, 'large' ) : '';
+		if ( '' !== $eb_img ) {
+			$eb_alt = is_numeric( $s->eyebrow_image ) ? (string) get_post_meta( (int) $s->eyebrow_image, '_wp_attachment_image_alt', true ) : '';
+			echo '<div class="ds-hero-eyebrow-img"><img src="' . esc_url( $eb_img ) . '" alt="' . esc_attr( $eb_alt ) . '" loading="eager" decoding="async" /></div>';
+		}
 		if ( ! empty( $s->eyebrow ) ) {
 			echo '<span class="ds-hero-eyebrow">' . esc_html( $s->eyebrow ) . '</span>';
 		}
@@ -947,6 +957,25 @@ FLBuilder::register_module( 'DS_Hero_Module', array(
 			'text' => array(
 				'title'  => __( 'Text', 'ds-toolkit' ),
 				'fields' => array(
+					// Optional mark above the eyebrow (GH #192): a crest, badge or logo. Same
+					// shape as the Heading module's divider image — the editor authors a
+					// HEIGHT and the width follows, so the aspect ratio is never touched.
+					'eyebrow_image' => array(
+						'type'        => 'photo',
+						'label'       => __( 'Eyebrow Image', 'ds-toolkit' ),
+						'show_remove' => true,
+						'connections' => array( 'photo' ),
+						'help'        => __( 'Optional image shown directly above the Eyebrow text (a crest, badge or logo). Blank renders nothing, not even a gap.', 'ds-toolkit' ),
+					),
+					'eyebrow_img_h' => array(
+						'type'        => 'unit',
+						'label'       => __( 'Eyebrow Image Size', 'ds-toolkit' ),
+						'default'     => '',
+						'description' => 'px',
+						'responsive'  => true,
+						'slider'      => array( 'min' => 16, 'max' => 320, 'step' => 1 ),
+						'help'        => __( 'Height of the eyebrow image; the width follows so the aspect ratio never changes. Blank = 72px. Use the responsive icon for tablet and mobile sizes.', 'ds-toolkit' ),
+					),
 					'eyebrow' => array(
 						'type'    => 'text',
 						'label'   => __( 'Eyebrow', 'ds-toolkit' ),

--- a/modules/ds-hero/includes/frontend.css.php
+++ b/modules/ds-hero/includes/frontend.css.php
@@ -111,6 +111,18 @@ if ( 'style2' !== $style ) {
 	}
 }
 
+// ---- Eyebrow image height (GH #192): authored HEIGHT, width follows, per breakpoint.
+// Same max-height approach as the Heading module's divider image so the aspect
+// ratio is preserved. Dynamic (0,3,1) so it beats the static 72px default.
+if ( 'style1' === $style ) {
+	foreach ( array( '' => '', '_medium' => $bpm, '_responsive' => $bpr ) as $sfx => $bp ) {
+		$v = $settings->{ 'eyebrow_img_h' . $sfx } ?? '';
+		if ( '' === $v || null === $v ) { continue; }
+		$rule = "$node .ds-hero .ds-hero-eyebrow-img img { max-height: " . (int) $v . "px; }";
+		echo ( '' === $sfx ) ? "$rule\n" : "@media (max-width:{$bp}px){ $rule }\n";
+	}
+}
+
 // ---- Style 2 (Page Banner): adaptive heights, no-image background, banner colours ----
 if ( 'style2' === $style ) {
 	$hbg = $u( $settings->banner_h_bg ?? '', 52 );


### PR DESCRIPTION
Closes #192.

## What

Hero Banner **Style 1 (Classic)** gains an optional **Eyebrow Image** photo field at the top of the Text section, exactly where KD asked for it: Eyebrow Image, (Eyebrow Image Size), Eyebrow, Headline, Subtext. The `text` section is registered only for Style 1, so the field appears only there.

## How it renders

- Emitted only when a photo resolves, so an unset field produces no markup and no spacing.
- A block wrapper `.ds-hero-eyebrow-img` holds an inline-block `<img>`: the hero's existing responsive `text-align` (re-declared per breakpoint by the dynamic CSS) positions it, so it follows Alignment at every device without new alignment rules; `width:auto; height:auto; max-width:100%` keeps the aspect ratio, never stretches to the hero width, and shrinks on narrow screens.
- 16px gap to the eyebrow text; `loading="eager"` because it sits above the fold.
- **Eyebrow Image Size** (responsive unit) authors a `max-height` so the width follows, mirroring the Heading module's divider image (#169). Blank keeps the static 72px default. Emitted at (0,3,1) so it beats the static rule whatever the stylesheet load order.
- Library alt text is used when the attachment has one.

## Verification

Stub harness rendering the module + dynamic CSS from a pristine `main` worktree and from this branch, 13 checks, all passing:

| Check | Result |
|---|---|
| Existing hero (field unset): HTML and CSS byte-identical to `main` | pass |
| Image set: wrapper+img (large size, library alt, eager) directly above the eyebrow | pass |
| Image set: removing the inserted block restores the baseline exactly (nothing else changed) | pass |
| No size set: no dynamic rule (static 72px applies) | pass |
| Size 96 / tablet 64 / mobile blank: desktop + medium rules emitted, no responsive rule | pass |
| Style 3 with the field set: ignored in markup and CSS | pass |
| URL value (connected photo): renders URL, empty alt | pass |
| Image without eyebrow text: image shown, no empty eyebrow span | pass |
| Form order and Style-1-only section | pass |

`php -l` clean on both PHP files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
